### PR TITLE
Release 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "flate2",
  "sidereon-core",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "approx",
  "cc",

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -16,8 +16,8 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm_0
 tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon = { path = "../sidereon", version = "0.26.1" }
-sidereon-core = { path = "../sidereon-core", version = "0.26.1" }
+sidereon = { path = "../sidereon", version = "0.27.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `sidereon-core` are documented here.
 
-## [Unreleased]
+## [0.27.0] - 2026-07-12
 
 ### Added
 
@@ -12,6 +12,12 @@ All notable changes to `sidereon-core` are documented here.
   `ProjVgridshiftArithmetic` selection for contracted or separately rounded
   multiply-add evaluation. The new path is pinned against 13,051 public-grid
   reference points; invalid coordinates return typed errors.
+
+### Evaluation-bit stability
+
+- Existing geoid loaders and `GeoidGrid::undulation_rad` retain their previous
+  evaluation bits. The new PROJ path has no implicit platform-dependent
+  default: callers select fused or separately rounded arithmetic explicitly.
 
 ## [0.26.1]
 

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "0.26.1"
+version = "0.27.0"
 authors = []
 edition = "2021"
 description = "Numerical astrodynamics propagation core plus the GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP) behind a default-on gnss feature"

--- a/crates/sidereon-core/README.md
+++ b/crates/sidereon-core/README.md
@@ -27,6 +27,8 @@ and never compile the SP3/RINEX/IONEX/solver code.
 - Single-point positioning, double-differenced RTK with LAMBDA ambiguity resolution, and
   static precise point positioning.
 - Broadcast Klobuchar ionosphere and Saastamoinen plus Niell troposphere.
+- EGM96/EGM2008 geoid grids, including the public PROJ EGM96 GTX loader with
+  explicit fused or separately rounded PROJ 9.3 interpolation.
 
 ## Parity bar
 

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -9,5 +9,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "0.26.1" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "0.26.1"
+version = "0.27.0"
 authors = []
 edition = "2021"
 description = "Thin ergonomic API over sidereon-core: SP3 loading and SPP/RTK/PPP positioning solves with rich result structs and one error enum"
@@ -16,5 +16,5 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "0.26.1" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
 flate2 = "1"

--- a/crates/sidereon/README.md
+++ b/crates/sidereon/README.md
@@ -118,7 +118,7 @@ of epochs across a rayon pool, bit-identical to the serial path.
 ## What's in the box
 
 - **Orbits:** SGP4/TLE and OMM, numerical propagation with atmospheric drag and decay/reentry prediction, Kepler and anomaly conversions, classical and equinoctial elements, passes, look angles, ground tracks
-- **Frames, time & geodesy:** TEME ↔ GCRS ↔ ITRS, GMST/GAST, geodetic ↔ ECEF, topocentric coordinates, UTC/TT/TDB/UT1, EGM96 geoid, DTED terrain elevation
+- **Frames, time & geodesy:** TEME ↔ GCRS ↔ ITRS, GMST/GAST, geodetic ↔ ECEF, topocentric coordinates, UTC/TT/TDB/UT1, EGM96/EGM2008 geoid grids, PROJ EGM96 GTX loading with explicit fused or separately rounded interpolation, DTED terrain elevation
 - **Bodies & almanac:** Sun/Moon/planet apparent places (geocentric or topocentric RA/Dec and az/el), Sun and Moon rise/set, Moon illumination, seasons, moon phases, eclipses, planetary transits, plus JPL SPK (DAF/.bsp) kernels
 - **Observation geometry:** angular separation and position angle, phase/beta/parallactic angles, sub-solar and sub-observer points, terminator, satellite visual magnitude
 - **Positioning:** SPP, RINEX observation to SPP assembly and solve helpers, RTK (float/fixed), PPP (float/fixed), DOP, velocity, robust fault detection and exclusion

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "cc",
  "libm",


### PR DESCRIPTION
## What changed

- release `sidereon-core` and `sidereon` 0.27.0
- add the public PROJ EGM96 GTX loader and fallible radian interpolation API
- make fused versus separately rounded PROJ arithmetic explicit
- add typed coordinate errors, public provenance fixtures, and a permanent x86_64 gate
- update core and facade registry READMEs

## Numerical behavior

Existing geoid loaders and `GeoidGrid::undulation_rad` retain their prior evaluation bits. The new PROJ path has no implicit platform-dependent arithmetic default.

## Validation

- full workspace tests and doc tests
- strict all-target workspace Clippy and formatting
- 13,051 contracted oracle points at zero ULP
- Ubuntu x86_64 arithmetic gate
- core and facade minor-release semver checks: 196/196 each
- RustSec audit with only the existing allowed `paste` maintenance warning
- locked core package dry-run
