### PR TITLE
Release 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "flate2",
  "sidereon-core",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "approx",
  "cc",

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -16,8 +16,8 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm_0
 tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon = { path = "../sidereon", version = "0.27.0" }
-sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
+sidereon = { path = "../sidereon", version = "0.27.1" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.1" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `sidereon-core` are documented here.
 
+## [0.27.1] - 2026-07-13
+
+### Fixed
+
+- `lambda_ils_search` now rejects ambiguity values outside the `i64` lattice
+  domain before reduction and checks back-transformed candidates before integer
+  conversion. Previously, an extreme finite input could saturate to
+  `i64::MAX`, overflow canonical rescoring, and return `Ok` with non-finite
+  scores and ratio.
+
+### Evaluation-bit stability
+
+- Calls whose ambiguity inputs and back-transformed candidates remain within
+  the `i64` lattice domain retain the same LAMBDA arithmetic, candidate
+  ordering, scores, and fix decisions. Inputs or internally produced candidates
+  outside that domain now return the existing typed `InvalidInput` error.
+
 ## [0.27.0] - 2026-07-12
 
 ### Added

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "0.27.0"
+version = "0.27.1"
 authors = []
 edition = "2021"
 description = "Numerical astrodynamics propagation core plus the GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP) behind a default-on gnss feature"

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -9,5 +9,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.1" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "0.27.0"
+version = "0.27.1"
 authors = []
 edition = "2021"
 description = "Thin ergonomic API over sidereon-core: SP3 loading and SPP/RTK/PPP positioning solves with rich result structs and one error enum"
@@ -16,5 +16,5 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "0.27.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.27.1" }
 flate2 = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "cc",
  "libm",


### PR DESCRIPTION
## What changed

- bump `sidereon-core` and the `sidereon` facade to 0.27.1
- update all workspace dependency pins and lockfiles
- document the LAMBDA integer-domain correctness fix and its evaluation-bit boundary

## Why

The 0.27.0 LAMBDA ILS API could accept an extreme finite ambiguity outside its `i64` result domain, saturate during conversion, and return `Ok` with non-finite scores and ratio. Main now rejects such inputs and invalid back-transformed candidates with the existing typed `InvalidInput` error.

## Validation

- independent release review approved all version, dependency, lock, and changelog locations
- `cargo publish -p sidereon-core --dry-run --allow-dirty`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- exact CI crash replay and committed fuzz corpus passed on the fix commit
