### PR TITLE
Enforce symmetry in RTK process-noise update

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `sidereon-core` are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Sequential RTK solves with baseline process noise now enforce the exact
+  symmetry of the information-form time update. The rank-3 correction is
+  symmetric mathematically, but independently evaluated matrix triangles could
+  accumulate phase-precision roundoff and destabilize long held-ambiguity arcs.
+
+### Evaluation-bit stability
+
+- Process-noise-enabled sequential RTK updates can move in their last bits when
+  the two information-matrix triangles are averaged. The zero-process-noise
+  path and public interfaces are unchanged.
+
 ## [0.28.0] - 2026-07-13
 
 ### Added

--- a/crates/sidereon-core/src/rtk_filter/tests.rs
+++ b/crates/sidereon-core/src/rtk_filter/tests.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::astro::math::vec3::sub3;
 
 use super::antenna::ReceiverAntennaScratch;
+use super::update::time_update_information;
 use super::*;
 use crate::ambiguity::AmbiguityId;
 use crate::constants::{C_M_S, F_L1_HZ};
@@ -2968,6 +2969,30 @@ fn velocity_prediction_moves_prior_after_first_epoch_only_when_enabled() {
     default_path.epoch_count = 1;
     propagate_baseline_mean(&mut default_path, &epoch, &opts);
     assert_eq!(default_path.baseline_m, [1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn process_noise_time_update_preserves_exact_information_symmetry() {
+    let n = 6;
+    let information = vec![
+        1.1e12, 2.3e8, -4.7e8, 7.1e9, -9.2e9, 1.3e10, //
+        2.3e8, 9.7e11, 5.9e8, -6.4e9, 8.6e9, -1.1e10, //
+        -4.7e8, 5.9e8, 1.3e12, 4.2e9, -7.3e9, 9.4e9, //
+        7.1e9, -6.4e9, 4.2e9, 2.0e11, 3.1e8, -2.2e8, //
+        -9.2e9, 8.6e9, -7.3e9, 3.1e8, 2.5e11, 4.3e8, //
+        1.3e10, -1.1e10, 9.4e9, -2.2e8, 4.3e8, 3.0e11,
+    ];
+    let updated = time_update_information(&information, n, 8.0).expect("non-singular time update");
+
+    for row in 0..n {
+        for column in (row + 1)..n {
+            assert_eq!(
+                updated[row * n + column].to_bits(),
+                updated[column * n + row].to_bits(),
+                "information entries ({row}, {column}) and ({column}, {row}) differ"
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------

--- a/crates/sidereon-core/src/rtk_filter/update.rs
+++ b/crates/sidereon-core/src/rtk_filter/update.rs
@@ -1440,7 +1440,11 @@ fn fixed_maps_from_holds(
 /// ambiguity block exactly. Returns `None` on a singular 3×3 system (caller keeps
 /// the un-inflated prior). Same operation order as the Elixir
 /// `inflate_baseline_information` for bit-for-bit trace parity.
-fn time_update_information(information: &[f64], n: usize, sigma: f64) -> Option<Vec<f64>> {
+pub(super) fn time_update_information(
+    information: &[f64],
+    n: usize,
+    sigma: f64,
+) -> Option<Vec<f64>> {
     let inv_q = 1.0 / (sigma * sigma);
     // M = Q⁻¹ + Λ₀₀ (3×3 top-left block of the information matrix).
     let mut m = [[0.0f64; 3]; 3];
@@ -1470,6 +1474,17 @@ fn time_update_information(information: &[f64], n: usize, sigma: f64) -> Option<
                 corr += wia * information[j * n + a];
             }
             out[i * n + j] -= corr;
+        }
+    }
+    // The correction is symmetric in exact arithmetic, but the two triangles
+    // are evaluated through different expression orders; with phase-precision
+    // information magnitudes the round-off difference can exceed the state
+    // validator's symmetry tolerance. Enforce the symmetry the math promises.
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let mean = 0.5 * (out[i * n + j] + out[j * n + i]);
+            out[i * n + j] = mean;
+            out[j * n + i] = mean;
         }
     }
     Some(out)

--- a/crates/sidereon-core/tests/rtk_real_arc.rs
+++ b/crates/sidereon-core/tests/rtk_real_arc.rs
@@ -2037,9 +2037,12 @@ fn wettzell_kinematic_rtk_filter_tracks_rtklib_truth_class() {
     assert_eq!(
         kinematic_baseline_m.map(f64::to_bits),
         [
-            0xbfef_8873_53a6_52a3,
-            0xbfe4_e3eb_2e47_f1d6,
-            0x3ff0_fd89_2e64_d93d,
+            // Re-frozen after enforcing the information time update's exact
+            // symmetry. The truth-class quality assertions above remain the
+            // primary gate for this process-noise-enabled solve.
+            0xbfef_7247_4db4_6e89,
+            0xbfe4_e9cf_5eaa_c5dd,
+            0x3ff1_1093_a8be_62c9,
         ]
     );
 


### PR DESCRIPTION
## What changed

- Enforce exact symmetry after the information-form RTK process-noise update by averaging each off-diagonal pair.
- Add a high-dynamic-range regression that pins bit-identical upper/lower information entries.
- Re-freeze the existing process-noise-enabled Wettzell real-arc golden while retaining its physical truth gates.
- Document the evaluation-bit impact; the zero-process-noise path and public interfaces are unchanged.

## Why

The rank-3 process-noise correction is symmetric mathematically, but the two matrix triangles were evaluated independently. On long held-ambiguity arcs, phase-precision magnitudes made the floating-point disagreement large enough for the next state validation to reject the filter's own posterior. A downstream causal PPC reproducer first returned an impossible receiver position and later rejected the carried matrix as non-symmetric.

This restores the numerical repair that had existed on the historical PPC branch without bringing any benchmark runner or experimental policy into `main`.

## Validation

- `cargo test -p sidereon-core --no-fail-fast`
  - 2,194 unit tests passed; one regeneration helper ignored.
  - All integration and doc tests passed, including the updated RTK real-arc test.
- `cargo clippy -p sidereon-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Downstream PPC reproducer: repaired 140/140-epoch run completed without the prior Earth-shell or symmetry rejection; the longer prefix crossed the former epoch-1,202 failure boundary.

## Scope

No public API changes. No PPC CLI, scorer, runner, threshold, hold policy, or estimator tuning is included.
