### PR TITLE
Fix CODE ultra-rapid download endpoint

### DIFF
--- a/crates/sidereon-core/src/data.rs
+++ b/crates/sidereon-core/src/data.rs
@@ -612,9 +612,12 @@ const CATALOG: [CenterCatalogEntry; 11] = [
     CenterCatalogEntry {
         center: AnalysisCenter::CodUlt,
         code: "cod_ult",
-        protocol: ArchiveProtocol::Http,
-        host: "ftp.aiub.unibe.ch",
-        root_url: "http://ftp.aiub.unibe.ch",
+        protocol: ArchiveProtocol::Https,
+        host: "www.aiub.unibe.ch",
+        // AIUB retired the old ftp.aiub.unibe.ch HTTP tree. Its public file
+        // browser links products through this stable HTTPS download surface,
+        // which redirects to the current object store.
+        root_url: "https://www.aiub.unibe.ch/download",
         products: &COD_ULT_PRODUCTS,
         issues: &COD_ULT_ISSUES,
     },
@@ -652,8 +655,9 @@ const CELESTRAK_SPACE_WEATHER_SOURCE: SpaceWeatherSourceEntry = SpaceWeatherSour
     root_url: "https://celestrak.org/SpaceData",
 };
 
-const ALLOWED_HOSTS: [&str; 6] = [
+const ALLOWED_HOSTS: [&str; 7] = [
     "ftp.aiub.unibe.ch",
+    "www.aiub.unibe.ch",
     "navigation-office.esa.int",
     "isdc-data.gfz.de",
     "igs.bkg.bund.de",

--- a/crates/sidereon-core/tests/data_catalog.rs
+++ b/crates/sidereon-core/tests/data_catalog.rs
@@ -175,7 +175,7 @@ fn ultra_rapid_sp3_urls_match_binding_catalog_examples() {
     );
     assert_eq!(
         cod.archive_url().expect("url"),
-        "http://ftp.aiub.unibe.ch/CODE/COD0OPSULT_20261620000_01D_05M_ORB.SP3"
+        "https://www.aiub.unibe.ch/download/CODE/COD0OPSULT_20261620000_01D_05M_ORB.SP3"
     );
 }
 
@@ -189,10 +189,16 @@ fn ultra_rapid_sp3_locations_include_current_patterns_and_fallbacks() {
 
     let code = ultra_sp3_locations(AnalysisCenter::CodUlt, date(2026, 6, 3), "0000")
         .expect("CODE candidates");
+    assert!(code.iter().all(|location| location
+        .url
+        .starts_with("https://www.aiub.unibe.ch/download/CODE/")));
     let alias = code.last().expect("latest alias");
     assert_eq!(alias.pattern, "alias_latest");
     assert_eq!(alias.filename, "COD0OPSULT.SP3");
-    assert_eq!(alias.url, "http://ftp.aiub.unibe.ch/CODE/COD0OPSULT.SP3");
+    assert_eq!(
+        alias.url,
+        "https://www.aiub.unibe.ch/download/CODE/COD0OPSULT.SP3"
+    );
 
     let gfz_target = ProductDateTime::new(date(2026, 7, 12), 10, 0, 0).expect("target");
     let gfz_issues =


### PR DESCRIPTION
## Summary
- move `cod_ult` from the retired `ftp.aiub.unibe.ch` HTTP tree to AIUB's official HTTPS download endpoint
- preserve CODE's `0000` issue and exact product names
- cover every CODE ultra candidate URL, including the current alias

## Live evidence
- old day-195 URL: HTTP 404
- official day-195 URL: HTTP 200, 1,473,962 bytes, valid SP3, 289 epochs at 300 s through midnight
- official live alias: HTTP 200, 577 epochs

## Validation
- `cargo fmt --check`
- `cargo test -p sidereon-core --test data_catalog`

No alternate-center substitution is added.