### PR TITLE
Release Sidereon 0.28.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "flate2",
  "sidereon-core",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "approx",
  "cc",

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -16,8 +16,8 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm_0
 tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon = { path = "../sidereon", version = "0.28.0" }
-sidereon-core = { path = "../sidereon-core", version = "0.28.0" }
+sidereon = { path = "../sidereon", version = "0.28.1" }
+sidereon-core = { path = "../sidereon-core", version = "0.28.1" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "0.28.0"
+version = "0.28.1"
 authors = []
 edition = "2021"
 description = "Numerical astrodynamics propagation core plus the GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP) behind a default-on gnss feature"

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -9,5 +9,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "0.28.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.28.1" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "0.28.0"
+version = "0.28.1"
 authors = []
 edition = "2021"
 description = "Thin ergonomic API over sidereon-core: SP3 loading and SPP/RTK/PPP positioning solves with rich result structs and one error enum"
@@ -16,5 +16,5 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "0.28.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.28.1" }
 flate2 = "1"


### PR DESCRIPTION
Patch release for the CODE ultra-rapid endpoint repair merged in #7.

- bumps `sidereon-core` and `sidereon` to 0.28.1
- updates internal workspace pins and lockfile
- contains no numerical or solver changes

Validated with formatting, focused catalog tests, core/facade checks, and core package verification.