### PR TITLE
feat(data): add atomic exact-product cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +460,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -511,6 +549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +580,27 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1308,6 +1377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,7 +1411,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "0.29.2"
+version = "0.30.0"
 dependencies = [
  "flate2",
  "sidereon-core",
@@ -1356,17 +1436,20 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "0.29.2"
+version = "0.30.0"
 dependencies = [
  "approx",
  "cc",
  "criterion",
+ "fs2",
+ "getrandom",
  "libm",
  "nalgebra",
  "rayon",
  "roxmltree",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "trust-region-least-squares",
 ]
@@ -1632,6 +1715,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vt100"

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -16,8 +16,8 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm_0
 tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon = { path = "../sidereon", version = "0.29.2" }
-sidereon-core = { path = "../sidereon-core", version = "0.29.2" }
+sidereon = { path = "../sidereon", version = "0.30.0" }
+sidereon-core = { path = "../sidereon-core", version = "0.30.0" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 All notable changes to `sidereon-core` are documented here.
 
-## [Unreleased]
+## [0.30.0] - 2026-07-16
+
+### Added
+
+- Added the schema-v3 exact-product cache protocol. Commit records bind the
+  complete product identity, explicit distribution source, and SHA-256 digest
+  and length of validated product, distributor archive, and provenance bytes.
+- Added native Linux/macOS `ExactProductCache` transactions with bounded
+  cross-process locking, cryptorandom immutable entries, synchronized files and
+  directories, one atomic commit marker, unlocked-reader refresh retry, and
+  lock-scoped abandoned-entry cleanup. The ergonomic `sidereon` crate re-exports
+  the same API.
+- Added `analysis_center` and `format_version` to `ProductIdentity`. Canonical
+  identity bytes and portable keys now include every exact identity field.
+
+### Compatibility
+
+- This is a source-breaking identity-model correction: Rust struct literals
+  must provide the two new fields. The minor version advances because
+  `ProductIdentity` is externally constructible; `cargo-semver-checks` confirms
+  a patch release would be incorrect.
 
 ### Fixed
 

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "0.29.2"
+version = "0.30.0"
 authors = []
 edition = "2021"
 description = "Numerical astrodynamics propagation core plus the GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP) behind a default-on gnss feature"
@@ -35,11 +35,16 @@ libm = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 roxmltree = "0.21"
+sha2 = "0.10"
 # Data-parallel batch propagation: the multi-satellite walkers in `astro::passes`
 # fan independent per-satellite arcs across a rayon work-stealing pool. Each arc
 # is the same serial kernel, so results stay bit-identical to the serial path.
 rayon = "1"
 trust-region-least-squares = { path = "../trust-region-least-squares", version = "0.9" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+fs2 = "0.4"
+getrandom = "0.2"
 
 [build-dependencies]
 cc = "1"
@@ -59,3 +64,7 @@ harness = false
 # the test suite for field-level diffing against the pure-Rust SGP4 port. Not
 # part of the public API. Off by default.
 sgp4-debug-oracle = []
+# Test-only exact-cache crash/barrier instrumentation. Off by default so an
+# installed library never reacts to the integration suite's environment
+# variables.
+exact-cache-test-failpoints = []

--- a/crates/sidereon-core/README.md
+++ b/crates/sidereon-core/README.md
@@ -30,6 +30,21 @@ and never compile the SP3/RINEX/IONEX/solver code.
 - EGM96/EGM2008 geoid grids, including the public PROJ EGM96 GTX loader with
   explicit fused or separately rounded PROJ 9.3 interpolation.
 
+## Exact-product cache transactions
+
+`sidereon_core::exact_cache` provides one schema-v3 commit format for every
+interface. It binds the complete product identity, explicit distribution
+source, and SHA-256 digest and length of validated product, original archive,
+and provenance bytes.
+
+On Linux and macOS, `ExactProductCache` adds a bounded cross-process advisory
+lock, immutable synchronized entry directories, atomic marker replacement,
+verified locked or unlocked reads, and lock-scoped cleanup. Callers retain
+transport and parsing responsibility: validate product semantics before
+publication and parse the authenticated bytes again on a cache hit. The full
+audit and filesystem assumptions are documented in
+[`docs/exact-product-cache-atomicity.md`](../../docs/exact-product-cache-atomicity.md).
+
 ## Parity bar
 
 Every independently reproducible, libm-bound component (propagation, frames, time, SGP4,

--- a/crates/sidereon-core/src/data.rs
+++ b/crates/sidereon-core/src/data.rs
@@ -1400,6 +1400,8 @@ const GFZ_ULT_SP3_PATTERNS: [UltraSp3Pattern; 3] = [
 pub struct ProductIdentity {
     /// Product family.
     pub family: ProductType,
+    /// Catalog analysis-center product line.
+    pub analysis_center: AnalysisCenter,
     /// Producing or combining organization.
     pub publisher: ProductPublisher,
     /// Solution class or tier.
@@ -1420,6 +1422,12 @@ pub struct ProductIdentity {
     pub official_filename: String,
     /// Public serialization format.
     pub format: ProductFormat,
+    /// Parsed serialization revision when the request constrains one.
+    ///
+    /// Catalog identities leave this unset because the revision is carried by
+    /// product content rather than the official filename. A resolved identity
+    /// may set it after parsing the product.
+    pub format_version: Option<String>,
     /// Prediction horizon when the product line encodes one.
     pub prediction_horizon_days: Option<u8>,
 }
@@ -1442,6 +1450,16 @@ impl ProductIdentity {
             return Err(DataCatalogError::InconsistentProductIdentity { field: "format" });
         }
 
+        if self
+            .format_version
+            .as_deref()
+            .is_some_and(|value| value.is_empty() || value.as_bytes().contains(&0))
+        {
+            return Err(DataCatalogError::InconsistentProductIdentity {
+                field: "format_version",
+            });
+        }
+
         let horizon_valid = match (self.publisher, self.solution, self.prediction_horizon_days) {
             (ProductPublisher::Code, SolutionClass::Predicted, Some(1 | 2)) => true,
             (_, SolutionClass::Predicted, _) => false,
@@ -1453,7 +1471,6 @@ impl ProductIdentity {
                 field: "prediction_horizon_days",
             });
         }
-
         let descriptor = product_type_convention(self.family);
         let expected = match descriptor.kind {
             ProductFilenameKind::Sampled => {
@@ -1501,25 +1518,72 @@ impl ProductIdentity {
                 field: "official_filename",
             });
         }
+        if self.publisher != self.analysis_center.publisher()
+            || self.solution != self.analysis_center.solution_class()
+            || self.prediction_horizon_days != self.analysis_center.prediction_horizon_days()
+        {
+            return Err(DataCatalogError::InconsistentProductIdentity {
+                field: "analysis_center",
+            });
+        }
         Ok(())
     }
 
     /// Deterministic identity key suitable for a portable cache layout.
     pub fn key(&self) -> Result<String, DataCatalogError> {
-        self.validate()?;
-        let prediction = self.prediction_horizon_days.map_or_else(
-            || "observed".to_string(),
-            |days| format!("prediction_{days}d"),
-        );
+        use sha2::{Digest, Sha256};
+
+        let canonical = self.canonical_bytes()?;
+        let digest = Sha256::digest(canonical);
         Ok(format!(
-            "{}/{}/{}/{}/{}/{}",
-            self.family.code(),
+            "{}-{}-{}",
             self.publisher.code().to_ascii_lowercase(),
             self.solution.code(),
-            self.campaign.code().to_ascii_lowercase(),
-            prediction,
-            self.official_filename
+            digest[..10]
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
         ))
+    }
+
+    /// Canonical, unambiguous bytes containing every exact identity field.
+    ///
+    /// The encoding is ASCII/UTF-8 field text separated by NUL bytes. It is a
+    /// stable cross-interface input to cache identity hashing, not a display
+    /// or interchange document.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, DataCatalogError> {
+        self.validate()?;
+        let date = format!(
+            "{:04}-{:02}-{:02}",
+            self.date.year, self.date.month, self.date.day
+        );
+        let version = self.version.to_string();
+        let prediction = self
+            .prediction_horizon_days
+            .map(|days| days.to_string())
+            .unwrap_or_default();
+        let fields = [
+            self.family.code(),
+            self.analysis_center.code(),
+            self.publisher.code(),
+            self.solution.code(),
+            self.campaign.code(),
+            version.as_str(),
+            date.as_str(),
+            self.issue.as_deref().unwrap_or_default(),
+            self.span.as_str(),
+            self.sample.as_str(),
+            self.official_filename.as_str(),
+            self.format.code(),
+            self.format_version.as_deref().unwrap_or_default(),
+            prediction.as_str(),
+        ];
+        if fields.iter().any(|field| field.as_bytes().contains(&0)) {
+            return Err(DataCatalogError::InconsistentProductIdentity {
+                field: "canonical_encoding",
+            });
+        }
+        Ok(fields.join("\0").into_bytes())
     }
 
     /// Deterministic cache path for this identity and distributor.
@@ -1839,16 +1903,23 @@ impl ProductSpec {
         };
         let identity = ProductIdentity {
             family: self.product_type,
+            analysis_center: self.center,
             publisher: self.center.publisher(),
             solution: self.center.solution_class(),
             campaign,
             version: 0,
             date: self.date,
-            issue: self.issue.clone(),
+            issue: match descriptor.kind {
+                ProductFilenameKind::Sampled => {
+                    Some(self.issue.clone().unwrap_or_else(|| "0000".to_string()))
+                }
+                ProductFilenameKind::Nav => None,
+            },
             span: convention.span.to_string(),
             sample: self.sample.clone(),
             official_filename: self.canonical_filename()?,
             format: product_format(self.product_type),
+            format_version: None,
             prediction_horizon_days: self.center.prediction_horizon_days(),
         };
         identity.validate()?;

--- a/crates/sidereon-core/src/exact_cache.rs
+++ b/crates/sidereon-core/src/exact_cache.rs
@@ -1,0 +1,754 @@
+//! Exact-product cache identity binding and atomic publication.
+//!
+//! The pure functions in this module define one commit record for every
+//! Sidereon interface, including WebAssembly hosts. On native targets,
+//! [`ExactProductCache`] adds bounded cross-process locking, immutable entry
+//! staging, durable writes, and an atomic reader-visible commit.
+//!
+//! Network transport and product parsing remain outside this module. Callers
+//! must validate product semantics before publication and repeat that semantic
+//! validation on bytes returned from a cache hit.
+
+use crate::data::{DataCatalogError, DistributionSource, ProductIdentity};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+
+/// Commit-record version shared by all Sidereon interfaces.
+pub const EXACT_CACHE_SCHEMA_VERSION: u8 = 3;
+
+/// Directory below one exact identity/source cache directory.
+pub const EXACT_CACHE_CONTROL_DIRECTORY: &str = ".sidereon-cache-v3";
+
+/// Name of the single reader-visible commit record.
+pub const EXACT_CACHE_MARKER_FILENAME: &str = "current.json";
+
+/// Error produced by the shared exact-product cache protocol.
+#[derive(Debug, thiserror::Error)]
+pub enum ExactCacheError {
+    /// The product identity is internally inconsistent.
+    #[error("invalid exact product identity: {0}")]
+    Identity(#[from] DataCatalogError),
+    /// An immutable transaction identifier is not 32 lower-case hexadecimal characters.
+    #[error("invalid exact-cache entry identifier")]
+    InvalidEntryId,
+    /// A commit record is malformed or does not bind the supplied entry.
+    #[error("invalid or mismatched exact-cache commit: {0}")]
+    InvalidCommit(&'static str),
+    /// A native filesystem operation failed.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("exact-cache {operation} failed: {source}")]
+    Io {
+        /// Operation that failed.
+        operation: &'static str,
+        /// Underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The per-entry cross-process lock was not acquired in time.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("timed out waiting for the exact-cache lock")]
+    LockTimeout,
+    /// Cross-process durable cache publication is unsupported on this platform.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("durable exact-cache publication is unsupported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// Digests and lengths bound by one exact-cache commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExactCacheDigests {
+    /// SHA-256 of canonical full [`ProductIdentity`] bytes.
+    pub identity_sha256: String,
+    /// Explicit distribution source.
+    pub distribution_source: String,
+    /// SHA-256 of decompressed, validated product bytes.
+    pub product_sha256: String,
+    /// Product byte length.
+    pub product_byte_length: u64,
+    /// SHA-256 of distributor archive bytes.
+    pub archive_sha256: String,
+    /// Archive byte length.
+    pub archive_byte_length: u64,
+    /// SHA-256 of the exact provenance bytes.
+    pub provenance_sha256: String,
+    /// Provenance byte length.
+    pub provenance_byte_length: u64,
+}
+
+/// Parsed, verified commit record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedExactCacheCommit {
+    /// Immutable transaction identifier referenced by the marker.
+    pub entry_id: String,
+    /// Verified identity, source, and byte bindings.
+    pub digests: ExactCacheDigests,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CommitRecord {
+    schema_version: u8,
+    entry: String,
+    identity_sha256: String,
+    distribution_source: String,
+    product_sha256: String,
+    product_byte_length: u64,
+    archive_sha256: String,
+    archive_byte_length: u64,
+    provenance_sha256: String,
+    provenance_byte_length: u64,
+}
+
+/// Return the SHA-256 binding for every field of an exact product identity.
+pub fn identity_sha256(identity: &ProductIdentity) -> Result<String, ExactCacheError> {
+    Ok(sha256_hex(&identity.canonical_bytes()?))
+}
+
+/// Build a canonical commit record for an immutable cache transaction.
+///
+/// `entry_id` must be a freshly allocated, immutable transaction directory.
+/// Native callers normally use [`ExactProductCache::publish`], which allocates
+/// it. WebAssembly hosts can generate 16 random bytes, encode them as lower-case
+/// hexadecimal, store the three byte objects under that identifier, and then
+/// atomically replace their commit marker with the returned bytes.
+pub fn build_commit_record(
+    identity: &ProductIdentity,
+    source: DistributionSource,
+    entry_id: &str,
+    product: &[u8],
+    archive: &[u8],
+    provenance: &[u8],
+) -> Result<Vec<u8>, ExactCacheError> {
+    validate_entry_id(entry_id)?;
+    let record = CommitRecord {
+        schema_version: EXACT_CACHE_SCHEMA_VERSION,
+        entry: entry_id.to_owned(),
+        identity_sha256: identity_sha256(identity)?,
+        distribution_source: source.code().to_owned(),
+        product_sha256: sha256_hex(product),
+        product_byte_length: byte_length(product)?,
+        archive_sha256: sha256_hex(archive),
+        archive_byte_length: byte_length(archive)?,
+        provenance_sha256: sha256_hex(provenance),
+        provenance_byte_length: byte_length(provenance)?,
+    };
+    serde_json::to_vec(&record).map_err(|_| ExactCacheError::InvalidCommit("serialization"))
+}
+
+/// Verify that one marker and immutable byte triple belong to the requested
+/// full identity and explicit distribution source.
+///
+/// The returned provenance bytes are authenticated by the marker but remain
+/// application data. The acquisition interface must parse them and confirm
+/// requested/resolved identities and product semantics before accepting a hit.
+pub fn verify_commit_record(
+    identity: &ProductIdentity,
+    source: DistributionSource,
+    marker: &[u8],
+    product: &[u8],
+    archive: &[u8],
+    provenance: &[u8],
+) -> Result<VerifiedExactCacheCommit, ExactCacheError> {
+    let record: CommitRecord = serde_json::from_slice(marker)
+        .map_err(|_| ExactCacheError::InvalidCommit("malformed JSON"))?;
+    if record.schema_version != EXACT_CACHE_SCHEMA_VERSION {
+        return Err(ExactCacheError::InvalidCommit("schema version"));
+    }
+    validate_entry_id(&record.entry)?;
+    let expected_identity = identity_sha256(identity)?;
+    let expected = ExactCacheDigests {
+        identity_sha256: expected_identity,
+        distribution_source: source.code().to_owned(),
+        product_sha256: sha256_hex(product),
+        product_byte_length: byte_length(product)?,
+        archive_sha256: sha256_hex(archive),
+        archive_byte_length: byte_length(archive)?,
+        provenance_sha256: sha256_hex(provenance),
+        provenance_byte_length: byte_length(provenance)?,
+    };
+    let actual = ExactCacheDigests {
+        identity_sha256: record.identity_sha256,
+        distribution_source: record.distribution_source,
+        product_sha256: record.product_sha256,
+        product_byte_length: record.product_byte_length,
+        archive_sha256: record.archive_sha256,
+        archive_byte_length: record.archive_byte_length,
+        provenance_sha256: record.provenance_sha256,
+        provenance_byte_length: record.provenance_byte_length,
+    };
+    if actual != expected {
+        return Err(ExactCacheError::InvalidCommit("identity, source, or bytes"));
+    }
+    Ok(VerifiedExactCacheCommit {
+        entry_id: record.entry,
+        digests: actual,
+    })
+}
+
+fn validate_entry_id(entry_id: &str) -> Result<(), ExactCacheError> {
+    if entry_id.len() == 32
+        && entry_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(ExactCacheError::InvalidEntryId)
+    }
+}
+
+fn byte_length(bytes: &[u8]) -> Result<u64, ExactCacheError> {
+    u64::try_from(bytes.len()).map_err(|_| ExactCacheError::InvalidCommit("byte length overflow"))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::*;
+    use fs2::FileExt;
+    use std::fs::{self, File, OpenOptions};
+    use std::io::{ErrorKind, Write};
+    use std::path::{Path, PathBuf};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const LOCK_FILENAME: &str = ".sidereon-cache.lock";
+
+    /// Paths and exact bytes from one verified immutable cache entry.
+    #[derive(Debug, Clone)]
+    pub struct CommittedExactCacheEntry {
+        /// Immutable transaction identifier.
+        pub entry_id: String,
+        /// Validated product path.
+        pub product_path: PathBuf,
+        /// Distributor archive path.
+        pub archive_path: PathBuf,
+        /// Provenance path.
+        pub provenance_path: PathBuf,
+        /// Exact product bytes authenticated by the commit record.
+        pub product: Vec<u8>,
+        /// Exact archive bytes authenticated by the commit record.
+        pub archive: Vec<u8>,
+        /// Exact provenance bytes authenticated by the commit record.
+        pub provenance: Vec<u8>,
+    }
+
+    /// One exact identity/source cache rooted at the caller's stable product path.
+    #[derive(Debug, Clone)]
+    pub struct ExactProductCache {
+        stable_path: PathBuf,
+        identity: ProductIdentity,
+        source: DistributionSource,
+    }
+
+    /// Held cross-process lock for one [`ExactProductCache`].
+    pub struct ExactCacheGuard {
+        lock_file: File,
+        stable_path: PathBuf,
+    }
+
+    impl Drop for ExactCacheGuard {
+        fn drop(&mut self) {
+            let _ = FileExt::unlock(&self.lock_file);
+        }
+    }
+
+    impl ExactProductCache {
+        /// Create a cache handle after validating the complete identity.
+        pub fn new(
+            stable_path: impl Into<PathBuf>,
+            identity: ProductIdentity,
+            source: DistributionSource,
+        ) -> Result<Self, ExactCacheError> {
+            identity.validate()?;
+            let stable_path = stable_path.into();
+            if stable_path.file_name().is_none() || stable_path.parent().is_none() {
+                return Err(ExactCacheError::InvalidCommit("stable product path"));
+            }
+            Ok(Self {
+                stable_path,
+                identity,
+                source,
+            })
+        }
+
+        /// Stable caller-facing path used to locate this cache entry.
+        #[must_use]
+        pub fn stable_path(&self) -> &Path {
+            &self.stable_path
+        }
+
+        /// Acquire the per-entry cross-process lock with bounded waiting.
+        pub fn lock(&self, timeout: Duration) -> Result<ExactCacheGuard, ExactCacheError> {
+            ensure_supported_platform()?;
+            let parent = self
+                .stable_path
+                .parent()
+                .ok_or(ExactCacheError::InvalidCommit("stable product parent"))?;
+            durable_create_dir_all(parent)?;
+            let lock_path = parent.join(LOCK_FILENAME);
+            let lock_file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(lock_path)
+                .map_err(|source| io("open lock", source))?;
+            lock_file
+                .sync_all()
+                .map_err(|source| io("sync lock", source))?;
+            sync_directory(parent)?;
+            let deadline = Instant::now()
+                .checked_add(timeout)
+                .ok_or(ExactCacheError::LockTimeout)?;
+            loop {
+                match lock_file.try_lock_exclusive() {
+                    Ok(()) => {
+                        return Ok(ExactCacheGuard {
+                            lock_file,
+                            stable_path: self.stable_path.clone(),
+                        });
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Err(ExactCacheError::LockTimeout);
+                        }
+                        thread::sleep((deadline - now).min(Duration::from_millis(10)));
+                    }
+                    Err(source) => return Err(io("lock", source)),
+                }
+            }
+        }
+
+        /// Read and digest-verify the currently committed immutable entry.
+        ///
+        /// Returns `Ok(None)` only when no commit marker exists. A malformed,
+        /// incomplete, or mismatched entry is an error, never a cache miss.
+        pub fn read(&self) -> Result<Option<CommittedExactCacheEntry>, ExactCacheError> {
+            let marker_path = self.marker_path();
+            for _ in 0..16 {
+                let marker = match fs::read(&marker_path) {
+                    Ok(bytes) => bytes,
+                    Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+                    Err(source) => return Err(io("read marker", source)),
+                };
+                test_read_barrier();
+                match self.read_committed_entry(&marker) {
+                    Ok(entry) => return Ok(Some(entry)),
+                    Err(error) => match fs::read(&marker_path) {
+                        Ok(current) if current != marker => continue,
+                        Err(current_error) if current_error.kind() == ErrorKind::NotFound => {
+                            continue;
+                        }
+                        _ => return Err(error),
+                    },
+                }
+            }
+            Err(ExactCacheError::InvalidCommit(
+                "commit changed repeatedly during read",
+            ))
+        }
+
+        fn read_committed_entry(
+            &self,
+            marker: &[u8],
+        ) -> Result<CommittedExactCacheEntry, ExactCacheError> {
+            let record: CommitRecord = serde_json::from_slice(marker)
+                .map_err(|_| ExactCacheError::InvalidCommit("malformed JSON"))?;
+            validate_entry_id(&record.entry)?;
+            let paths = self.entry_paths(&record.entry)?;
+            let product = fs::read(&paths.product).map_err(|source| io("read product", source))?;
+            let archive = fs::read(&paths.archive).map_err(|source| io("read archive", source))?;
+            let provenance =
+                fs::read(&paths.provenance).map_err(|source| io("read provenance", source))?;
+            let verified = verify_commit_record(
+                &self.identity,
+                self.source,
+                marker,
+                &product,
+                &archive,
+                &provenance,
+            )?;
+            Ok(CommittedExactCacheEntry {
+                entry_id: verified.entry_id,
+                product_path: paths.product,
+                archive_path: paths.archive,
+                provenance_path: paths.provenance,
+                product,
+                archive,
+                provenance,
+            })
+        }
+
+        /// Publish a complete validated candidate under the held entry lock.
+        pub fn publish(
+            &self,
+            guard: &ExactCacheGuard,
+            product: &[u8],
+            archive: &[u8],
+            provenance: &[u8],
+        ) -> Result<CommittedExactCacheEntry, ExactCacheError> {
+            self.require_guard(guard)?;
+            ensure_supported_platform()?;
+            let control = self.control_directory();
+            let entries = control.join("entries");
+            durable_create_dir_all(&entries)?;
+            let entry_id = self.allocate_entry_id(&entries)?;
+            let paths = self.entry_paths(&entry_id)?;
+            let entry_directory = paths
+                .product
+                .parent()
+                .ok_or(ExactCacheError::InvalidCommit("entry parent"))?;
+            sync_directory(&entries)?;
+            let marker_temp =
+                control.join(format!(".{EXACT_CACHE_MARKER_FILENAME}.{entry_id}.tmp"));
+            let marker = build_commit_record(
+                &self.identity,
+                self.source,
+                &entry_id,
+                product,
+                archive,
+                provenance,
+            )?;
+            let result: Result<(), ExactCacheError> = (|| {
+                write_exclusive(&paths.product, product)?;
+                test_failpoint("after_payload");
+                write_exclusive(&paths.archive, archive)?;
+                test_failpoint("after_archive");
+                write_exclusive(&paths.provenance, provenance)?;
+                test_failpoint("after_metadata");
+                sync_directory(entry_directory)?;
+                sync_directory(&entries)?;
+                test_failpoint("after_entry_sync");
+                write_exclusive(&marker_temp, &marker)?;
+                test_failpoint("after_marker_write");
+                fs::rename(&marker_temp, self.marker_path())
+                    .map_err(|source| io("rename marker", source))?;
+                test_failpoint("after_marker_rename");
+                sync_directory(&control)?;
+                test_failpoint("after_commit_sync");
+                Ok(())
+            })();
+            if result.is_err() {
+                let _ = fs::remove_file(&marker_temp);
+                if self.current_entry_id().as_deref() != Some(entry_id.as_str()) {
+                    let _ = fs::remove_dir_all(entry_directory);
+                }
+            }
+            result?;
+            Ok(CommittedExactCacheEntry {
+                entry_id,
+                product_path: paths.product,
+                archive_path: paths.archive,
+                provenance_path: paths.provenance,
+                product: product.to_vec(),
+                archive: archive.to_vec(),
+                provenance: provenance.to_vec(),
+            })
+        }
+
+        /// Remove unreferenced transactions while holding the entry lock.
+        pub fn cleanup_abandoned(&self, guard: &ExactCacheGuard) -> Result<(), ExactCacheError> {
+            self.require_guard(guard)?;
+            let control = self.control_directory();
+            let entries = control.join("entries");
+            let current = match fs::read(self.marker_path()) {
+                Ok(marker) => {
+                    let record: CommitRecord = match serde_json::from_slice(&marker) {
+                        Ok(record) => record,
+                        Err(_) => return Ok(()),
+                    };
+                    if validate_entry_id(&record.entry).is_err() {
+                        return Ok(());
+                    }
+                    Some(record.entry)
+                }
+                Err(error) if error.kind() == ErrorKind::NotFound => None,
+                Err(_) => return Ok(()),
+            };
+            if let Ok(children) = fs::read_dir(&entries) {
+                for child in children.flatten() {
+                    let name = child.file_name();
+                    if current.as_deref() != name.to_str() {
+                        let _ = fs::remove_dir_all(child.path());
+                    }
+                }
+            }
+            if let Ok(children) = fs::read_dir(&control) {
+                let prefix = format!(".{EXACT_CACHE_MARKER_FILENAME}.");
+                for child in children.flatten() {
+                    let name = child.file_name();
+                    let Some(name) = name.to_str() else {
+                        continue;
+                    };
+                    if name.starts_with(&prefix) && name.ends_with(".tmp") {
+                        let _ = fs::remove_file(child.path());
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        fn require_guard(&self, guard: &ExactCacheGuard) -> Result<(), ExactCacheError> {
+            if guard.stable_path == self.stable_path {
+                Ok(())
+            } else {
+                Err(ExactCacheError::InvalidCommit("cache lock scope"))
+            }
+        }
+
+        fn control_directory(&self) -> PathBuf {
+            self.stable_path
+                .parent()
+                .expect("validated cache path has parent")
+                .join(EXACT_CACHE_CONTROL_DIRECTORY)
+        }
+
+        fn marker_path(&self) -> PathBuf {
+            self.control_directory().join(EXACT_CACHE_MARKER_FILENAME)
+        }
+
+        fn entry_paths(&self, entry_id: &str) -> Result<EntryPaths, ExactCacheError> {
+            validate_entry_id(entry_id)?;
+            let filename = self
+                .stable_path
+                .file_name()
+                .ok_or(ExactCacheError::InvalidCommit("stable product filename"))?;
+            let entry = self.control_directory().join("entries").join(entry_id);
+            let product = entry.join(filename);
+            let archive = entry.join(format!("{}.archive", filename.to_string_lossy()));
+            let provenance = entry.join(format!("{}.provenance.json", filename.to_string_lossy()));
+            Ok(EntryPaths {
+                product,
+                archive,
+                provenance,
+            })
+        }
+
+        fn allocate_entry_id(&self, entries: &Path) -> Result<String, ExactCacheError> {
+            for _ in 0..128 {
+                let mut random = [0_u8; 16];
+                getrandom::getrandom(&mut random).map_err(|error| {
+                    io("random entry id", std::io::Error::other(error.to_string()))
+                })?;
+                let mut entry_id = String::with_capacity(32);
+                for byte in random {
+                    write!(&mut entry_id, "{byte:02x}").expect("writing to String cannot fail");
+                }
+                match fs::create_dir(entries.join(&entry_id)) {
+                    Ok(()) => return Ok(entry_id),
+                    Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+                    Err(source) => return Err(io("create entry", source)),
+                }
+            }
+            Err(ExactCacheError::InvalidCommit("entry identifier collision"))
+        }
+
+        fn current_entry_id(&self) -> Option<String> {
+            let marker = fs::read(self.marker_path()).ok()?;
+            let record: CommitRecord = serde_json::from_slice(&marker).ok()?;
+            validate_entry_id(&record.entry).ok()?;
+            Some(record.entry)
+        }
+    }
+
+    struct EntryPaths {
+        product: PathBuf,
+        archive: PathBuf,
+        provenance: PathBuf,
+    }
+
+    fn io(operation: &'static str, source: std::io::Error) -> ExactCacheError {
+        ExactCacheError::Io { operation, source }
+    }
+
+    fn ensure_supported_platform() -> Result<(), ExactCacheError> {
+        if cfg!(any(target_os = "linux", target_os = "macos")) {
+            Ok(())
+        } else {
+            Err(ExactCacheError::UnsupportedPlatform)
+        }
+    }
+
+    fn durable_create_dir_all(path: &Path) -> Result<(), ExactCacheError> {
+        if path.is_dir() {
+            return Ok(());
+        }
+        let mut missing = Vec::new();
+        let mut cursor = path;
+        while !cursor.exists() {
+            missing.push(cursor.to_path_buf());
+            cursor = cursor
+                .parent()
+                .ok_or(ExactCacheError::InvalidCommit("cache directory parent"))?;
+        }
+        for directory in missing.iter().rev() {
+            match fs::create_dir(directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::AlreadyExists && directory.is_dir() => {}
+                Err(source) => return Err(io("create directory", source)),
+            }
+            let parent = directory
+                .parent()
+                .ok_or(ExactCacheError::InvalidCommit("cache directory parent"))?;
+            sync_directory(parent)?;
+        }
+        Ok(())
+    }
+
+    fn write_exclusive(path: &Path, bytes: &[u8]) -> Result<(), ExactCacheError> {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .map_err(|source| io("create immutable file", source))?;
+        file.write_all(bytes)
+            .map_err(|source| io("write immutable file", source))?;
+        file.sync_all()
+            .map_err(|source| io("sync immutable file", source))
+    }
+
+    fn sync_directory(path: &Path) -> Result<(), ExactCacheError> {
+        File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|source| io("sync directory", source))
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    fn test_failpoint(name: &str) {
+        if std::env::var_os("SIDEREON_TEST_EXACT_CACHE_FAILPOINT").as_deref()
+            == Some(std::ffi::OsStr::new(name))
+        {
+            std::process::exit(86);
+        }
+    }
+
+    #[cfg(not(feature = "exact-cache-test-failpoints"))]
+    fn test_failpoint(_name: &str) {}
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    fn test_read_barrier() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            let Some(barrier) = std::env::var_os("SIDEREON_TEST_EXACT_CACHE_READ_BARRIER") else {
+                return;
+            };
+            let barrier = PathBuf::from(barrier);
+            fs::write(barrier.with_extension("ready"), b"ready")
+                .expect("write exact-cache read barrier");
+            let release = barrier.with_extension("release");
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !release.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for exact-cache read barrier"
+                );
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+    }
+
+    #[cfg(not(feature = "exact-cache-test-failpoints"))]
+    fn test_read_barrier() {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::{CommittedExactCacheEntry, ExactCacheGuard, ExactProductCache};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{product, AnalysisCenter, ProductDate, ProductType};
+
+    fn identity() -> ProductIdentity {
+        product(
+            AnalysisCenter::CodUlt,
+            ProductType::Sp3,
+            ProductDate::new(2026, 7, 16).expect("date"),
+            Some("05M"),
+            Some("0000"),
+        )
+        .expect("product")
+        .identity()
+        .expect("identity")
+    }
+
+    #[test]
+    fn commit_binds_every_byte_group_identity_and_source() {
+        let identity = identity();
+        let marker = build_commit_record(
+            &identity,
+            DistributionSource::Direct,
+            "0123456789abcdef0123456789abcdef",
+            b"product",
+            b"archive",
+            b"provenance",
+        )
+        .expect("commit");
+        let verified = verify_commit_record(
+            &identity,
+            DistributionSource::Direct,
+            &marker,
+            b"product",
+            b"archive",
+            b"provenance",
+        )
+        .expect("verify");
+        assert_eq!(verified.entry_id, "0123456789abcdef0123456789abcdef");
+
+        for (product, archive, provenance) in [
+            (&b"changed"[..], &b"archive"[..], &b"provenance"[..]),
+            (&b"product"[..], &b"changed"[..], &b"provenance"[..]),
+            (&b"product"[..], &b"archive"[..], &b"changed"[..]),
+        ] {
+            assert!(verify_commit_record(
+                &identity,
+                DistributionSource::Direct,
+                &marker,
+                product,
+                archive,
+                provenance,
+            )
+            .is_err());
+        }
+        assert!(verify_commit_record(
+            &identity,
+            DistributionSource::NasaCddis,
+            &marker,
+            b"product",
+            b"archive",
+            b"provenance",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn malformed_entry_ids_are_rejected() {
+        for entry in [
+            "",
+            "ABCDEF0123456789ABCDEF0123456789",
+            "0123456789abcdef0123456789abcdeg",
+            "0123456789abcdef",
+        ] {
+            assert!(build_commit_record(
+                &identity(),
+                DistributionSource::Direct,
+                entry,
+                b"product",
+                b"archive",
+                b"provenance",
+            )
+            .is_err());
+        }
+    }
+}

--- a/crates/sidereon-core/src/lib.rs
+++ b/crates/sidereon-core/src/lib.rs
@@ -89,6 +89,7 @@ mod crinex; // Hatanaka (CRINEX) observation-file decoder
 pub mod data; // sans-IO GNSS product filename and archive URL catalog
 pub mod dop; // dilution-of-precision geometry (GDOP/PDOP/HDOP/VDOP/TDOP)
 pub mod error_metrics; // covariance-derived CEP, radial, and ellipse metrics
+pub mod exact_cache; // exact-product cache identity binding and atomic publication
 pub mod frequencies; // canonical GNSS carrier-frequency table
 mod glonass; // GLONASS PZ-90.11 state-vector RK4 propagation
 pub mod has; // Galileo HAS MT1 correction payload decode/encode

--- a/crates/sidereon-core/tests/data_catalog.rs
+++ b/crates/sidereon-core/tests/data_catalog.rs
@@ -150,6 +150,20 @@ fn exact_request_and_cache_key_keep_source_selection_explicit() {
 }
 
 #[test]
+fn exact_identity_key_is_stable_across_interfaces() {
+    let identity = mgex_sp3(AnalysisCenter::Cod, date(2026, 7, 12), None)
+        .expect("CODE product")
+        .identity()
+        .expect("identity");
+    assert_eq!(identity.analysis_center, AnalysisCenter::Cod);
+    assert_eq!(identity.format_version, None);
+    assert_eq!(
+        identity.key().expect("cache key"),
+        "cod-final-a91258c21fa4860c34ce"
+    );
+}
+
+#[test]
 fn exact_product_set_requires_every_declared_identity_before_processing() {
     let first = mgex_sp3(AnalysisCenter::Cod, date(2026, 7, 12), None)
         .expect("first product")

--- a/crates/sidereon-core/tests/exact_cache_atomicity.rs
+++ b/crates/sidereon-core/tests/exact_cache_atomicity.rs
@@ -1,0 +1,292 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use sidereon_core::data::{
+    product, AnalysisCenter, DistributionSource, ProductDate, ProductIdentity, ProductType,
+};
+use sidereon_core::exact_cache::{ExactCacheError, ExactProductCache};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const OLD_PRODUCT: &[u8] = b"old validated product";
+const OLD_ARCHIVE: &[u8] = b"old archive";
+const OLD_PROVENANCE: &[u8] = b"{\"acquisition\":\"old\"}";
+const NEW_PRODUCT: &[u8] = b"new validated product";
+const NEW_ARCHIVE: &[u8] = b"new archive";
+const NEW_PROVENANCE: &[u8] = b"{\"acquisition\":\"new\"}";
+
+fn identity() -> ProductIdentity {
+    product(
+        AnalysisCenter::CodUlt,
+        ProductType::Sp3,
+        ProductDate::new(2026, 7, 16).expect("date"),
+        Some("05M"),
+        Some("0000"),
+    )
+    .expect("product")
+    .identity()
+    .expect("identity")
+}
+
+fn cache(path: impl Into<PathBuf>) -> ExactProductCache {
+    ExactProductCache::new(path, identity(), DistributionSource::Direct).expect("cache")
+}
+
+fn temp_directory(label: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let directory = std::env::temp_dir().join(format!(
+        "sidereon-exact-cache-{label}-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&directory).expect("create temporary directory");
+    directory
+}
+
+fn wait_for(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !path.exists() {
+        assert!(Instant::now() < deadline, "timed out waiting for {path:?}");
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn child(mode: &str, stable: &Path, root: &Path) -> std::process::Child {
+    let mut command = Command::new(std::env::current_exe().expect("test executable"));
+    command
+        .arg("--exact")
+        .arg("exact_cache_subprocess")
+        .arg("--nocapture")
+        .env("SIDEREON_EXACT_CACHE_CHILD_MODE", mode)
+        .env("SIDEREON_EXACT_CACHE_CHILD_STABLE", stable)
+        .env("SIDEREON_EXACT_CACHE_CHILD_ROOT", root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if mode == "read_barrier" {
+        command.env(
+            "SIDEREON_TEST_EXACT_CACHE_READ_BARRIER",
+            root.join("read-barrier"),
+        );
+    }
+    command.spawn().expect("spawn cache helper")
+}
+
+#[test]
+fn exact_cache_subprocess() {
+    let Some(mode) = std::env::var_os("SIDEREON_EXACT_CACHE_CHILD_MODE") else {
+        return;
+    };
+    let stable =
+        PathBuf::from(std::env::var_os("SIDEREON_EXACT_CACHE_CHILD_STABLE").expect("stable path"));
+    let root =
+        PathBuf::from(std::env::var_os("SIDEREON_EXACT_CACHE_CHILD_ROOT").expect("root path"));
+    let cache = cache(stable);
+    match mode.to_str().expect("UTF-8 mode") {
+        "hold" => {
+            let guard = cache.lock(Duration::from_secs(5)).expect("lock");
+            let orphan = root
+                .join("cache")
+                .join(".sidereon-cache-v3")
+                .join("entries")
+                .join("ffffffffffffffffffffffffffffffff");
+            fs::create_dir_all(&orphan).expect("orphan");
+            fs::write(root.join("ready"), b"ready").expect("ready");
+            wait_for(&root.join("release"));
+            drop(guard);
+        }
+        "publish" => {
+            let guard = cache.lock(Duration::from_secs(5)).expect("lock");
+            cache
+                .publish(&guard, NEW_PRODUCT, NEW_ARCHIVE, NEW_PROVENANCE)
+                .expect("publish");
+        }
+        "publish_if_miss" => {
+            wait_for(&root.join("start"));
+            let guard = cache.lock(Duration::from_secs(5)).expect("lock");
+            if cache.read().expect("read").is_none() {
+                let mut counter = OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(root.join("downloads"))
+                    .expect("download counter");
+                counter.write_all(b"download\n").expect("count download");
+                counter.sync_all().expect("sync download counter");
+                cache
+                    .publish(&guard, OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
+                    .expect("publish");
+            }
+        }
+        "read_barrier" => {
+            let entry = cache.read().expect("coherent read").expect("cache hit");
+            fs::write(root.join("read-product"), entry.product).expect("write read result");
+        }
+        other => panic!("unknown child mode {other}"),
+    }
+}
+
+#[test]
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn unlocked_reader_retries_when_cleanup_removes_its_previous_entry() {
+    let root = temp_directory("reader-cleanup-race");
+    let stable = root.join("cache").join("product.SP3");
+    let cache = cache(&stable);
+    let guard = cache.lock(Duration::from_secs(1)).expect("initial lock");
+    cache
+        .publish(&guard, OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
+        .expect("initial publish");
+    drop(guard);
+
+    let mut reader = child("read_barrier", &stable, &root);
+    wait_for(&root.join("read-barrier.ready"));
+
+    let guard = cache.lock(Duration::from_secs(1)).expect("refresh lock");
+    cache
+        .publish(&guard, NEW_PRODUCT, NEW_ARCHIVE, NEW_PROVENANCE)
+        .expect("refresh publish");
+    cache
+        .cleanup_abandoned(&guard)
+        .expect("cleanup previous entry");
+    drop(guard);
+    fs::write(root.join("read-barrier.release"), b"release").expect("release reader");
+
+    assert!(reader.wait().expect("reader status").success());
+    assert_eq!(
+        fs::read(root.join("read-product")).expect("read result"),
+        NEW_PRODUCT
+    );
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn two_processes_publish_one_download_for_the_same_identity() {
+    let root = temp_directory("race");
+    let stable = root.join("cache").join("product.SP3");
+    let mut first = child("publish_if_miss", &stable, &root);
+    let mut second = child("publish_if_miss", &stable, &root);
+    fs::write(root.join("start"), b"start").expect("release start barrier");
+    assert!(first.wait().expect("first status").success());
+    assert!(second.wait().expect("second status").success());
+    let downloads = fs::read_to_string(root.join("downloads")).expect("download counter");
+    assert_eq!(downloads.lines().count(), 1);
+    let entry = cache(&stable).read().expect("read").expect("entry");
+    assert_eq!(entry.product, OLD_PRODUCT);
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn live_writer_lock_cannot_be_stolen_or_cleaned() {
+    let root = temp_directory("live-lock");
+    let stable = root.join("cache").join("product.SP3");
+    let mut holder = child("hold", &stable, &root);
+    wait_for(&root.join("ready"));
+    let cache = cache(&stable);
+    assert!(matches!(
+        cache.lock(Duration::from_millis(50)),
+        Err(ExactCacheError::LockTimeout)
+    ));
+    let orphan = root
+        .join("cache")
+        .join(".sidereon-cache-v3")
+        .join("entries")
+        .join("ffffffffffffffffffffffffffffffff");
+    assert!(orphan.is_dir());
+    fs::write(root.join("release"), b"release").expect("release holder");
+    assert!(holder.wait().expect("holder status").success());
+    let guard = cache
+        .lock(Duration::from_secs(1))
+        .expect("lock after release");
+    cache.cleanup_abandoned(&guard).expect("cleanup abandoned");
+    assert!(!orphan.exists());
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn process_death_at_each_publication_boundary_leaves_old_or_complete_new_entry() {
+    for step in [
+        "after_payload",
+        "after_archive",
+        "after_metadata",
+        "after_entry_sync",
+        "after_marker_write",
+        "after_marker_rename",
+        "after_commit_sync",
+    ] {
+        let root = temp_directory(step);
+        let stable = root.join("cache").join("product.SP3");
+        let cache = cache(&stable);
+        let guard = cache.lock(Duration::from_secs(1)).expect("initial lock");
+        cache
+            .publish(&guard, OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
+            .expect("initial publish");
+        drop(guard);
+
+        let mut publisher = Command::new(std::env::current_exe().expect("test executable"))
+            .arg("--exact")
+            .arg("exact_cache_subprocess")
+            .arg("--nocapture")
+            .env("SIDEREON_EXACT_CACHE_CHILD_MODE", "publish")
+            .env("SIDEREON_EXACT_CACHE_CHILD_STABLE", &stable)
+            .env("SIDEREON_EXACT_CACHE_CHILD_ROOT", &root)
+            .env("SIDEREON_TEST_EXACT_CACHE_FAILPOINT", step)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn crashing publisher");
+        assert_eq!(publisher.wait().expect("publisher status").code(), Some(86));
+
+        let entry = cache
+            .read()
+            .expect("coherent read")
+            .expect("old or new entry");
+        let accepted = (entry.product == OLD_PRODUCT
+            && entry.archive == OLD_ARCHIVE
+            && entry.provenance == OLD_PROVENANCE)
+            || (entry.product == NEW_PRODUCT
+                && entry.archive == NEW_ARCHIVE
+                && entry.provenance == NEW_PROVENANCE);
+        assert!(accepted, "mixed entry accepted after {step}");
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+}
+
+#[test]
+fn reader_rejects_corruption_and_identity_or_source_substitution() {
+    let root = temp_directory("corruption");
+    let stable = root.join("cache").join("product.SP3");
+    let cache = cache(&stable);
+    let guard = cache.lock(Duration::from_secs(1)).expect("lock");
+    let published = cache
+        .publish(&guard, OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
+        .expect("publish");
+    drop(guard);
+
+    fs::write(&published.product_path, b"corrupt").expect("corrupt payload");
+    assert!(matches!(
+        cache.read(),
+        Err(ExactCacheError::InvalidCommit(_))
+    ));
+    fs::write(&published.product_path, OLD_PRODUCT).expect("restore payload");
+
+    let other_source = ExactProductCache::new(&stable, identity(), DistributionSource::NasaCddis)
+        .expect("other source cache");
+    assert!(matches!(
+        other_source.read(),
+        Err(ExactCacheError::InvalidCommit(_))
+    ));
+
+    let mut other_identity = identity();
+    other_identity.format_version = Some("SP3-d".to_owned());
+    let other_identity =
+        ExactProductCache::new(&stable, other_identity, DistributionSource::Direct)
+            .expect("other identity cache");
+    assert!(matches!(
+        other_identity.read(),
+        Err(ExactCacheError::InvalidCommit(_))
+    ));
+    fs::remove_dir_all(root).expect("cleanup");
+}

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -9,5 +9,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "0.29.2" }
+sidereon-core = { path = "../sidereon-core", version = "0.30.0" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "0.29.2"
+version = "0.30.0"
 authors = []
 edition = "2021"
 description = "Thin ergonomic API over sidereon-core: SP3 loading and SPP/RTK/PPP positioning solves with rich result structs and one error enum"
@@ -16,5 +16,5 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "0.29.2" }
+sidereon-core = { path = "../sidereon-core", version = "0.30.0" }
 flate2 = "1"

--- a/crates/sidereon/src/lib.rs
+++ b/crates/sidereon/src/lib.rs
@@ -34,7 +34,8 @@
 //! - GNSS utility modules such as [`frequencies`], [`combinations`],
 //!   [`quality`], [`carrier_phase`], [`signal`], [`velocity`],
 //!   [`broadcast_comparison`], [`constants`], [`navigation`], [`geometry`],
-//!   [`data`], [`dgnss`], [`constellation`], [`ppp_corrections`], [`rtk`],
+//!   [`data`], [`exact_cache`], [`dgnss`], [`constellation`],
+//!   [`ppp_corrections`], [`rtk`],
 //!   [`staleness`], [`tides`], [`ils`], and [`terrain`] expose the core helper
 //!   surface,
 //! - [`astro`] exposes time/frame conversions, Sun/Moon positions, RF link
@@ -196,6 +197,7 @@ pub use sidereon_core::astro::frames::{
     EarthOrientation, EarthOrientationProvider, TdbEarthOrientationProvider,
 };
 pub use sidereon_core::astro::propagator::{ForceModelComponents, ForceModelKind};
+pub use sidereon_core::exact_cache;
 pub use sidereon_core::geometry_quality::{
     classify, GeometryQuality, GeometryQualityThresholds, ObservabilityTier,
 };

--- a/docs/exact-product-cache-atomicity.md
+++ b/docs/exact-product-cache-atomicity.md
@@ -3,84 +3,119 @@
 ## Verdict for 0.29.2
 
 Sidereon 0.29.2 did not provide a cross-process or crash-consistent exact-cache
-commit. The Rust core derived the full distributor-independent identity and
-source-specific cache path but intentionally performed no cache IO. The Python
-and Elixir acquisition interfaces each wrote the archive, provenance, and
-decompressed product as three independently renamed files. Their locks covered
-only one Python process or one BEAM coordination domain.
+commit. The Rust core derived distributor-independent identity and
+source-specific paths but performed no cache IO. Python and Elixir separately
+wrote product, archive, and provenance files, and their coordination did not
+cover independent OS processes.
 
-The 0.29.2 readers did recheck the full requested and resolved identities,
-distribution source, both SHA-256 digests and lengths, caller checksum, and
-parsed product semantics. Those checks rejected ordinary corruption and most
-mixed triples. They did not establish one atomic acquisition record, prevent
-independent OS processes from interleaving publication, preserve the previous
-entry across every crash boundary, or prevent duplicate cross-process
-downloads. Therefore the required guarantee was absent.
+The 0.29.2 acquisition readers rechecked requested and resolved provenance,
+distribution source, byte lengths and SHA-256 digests, and parsed product
+semantics. Those checks rejected ordinary corruption and most mixed triples.
+They did not make the three files one atomic acquisition record, prevent two
+processes from interleaving publication, preserve the previous entry across
+every process-death boundary, or prevent a duplicate cross-process download.
+The required guarantee was therefore absent.
 
-## Unreleased correction
+The audit also found that the Rust `ProductIdentity` omitted the catalog
+analysis-center selector and parsed format version even though the acquisition
+interfaces retained them. Those fields can distinguish exact products, so the
+shared identity now includes both.
 
-The acquisition-capable interfaces now share one on-disk protocol:
+## 0.30.0 correction
 
-1. The source and complete `ProductIdentity` continue to select the existing
-   collision-resistant identity directory. No identity field is inferred from
-   a filename or modification time.
-2. A POSIX advisory lock file in that directory covers cache check, acquisition,
-   validation, and commit. Python uses `flock` directly; the Elixir NIF uses the
-   same `flock` operation on Unix. Waiting is bounded. Process exit closes the
-   descriptor and releases the lock without a stale-owner deletion decision.
-3. A writer creates a cryptographically unique entry directory and writes the
-   product, archive, and provenance there. Each file is synchronized before the
-   entry and entries directories are synchronized.
-4. The writer creates and synchronizes a small version-2 commit record. It
-   contains the immutable entry identifier and the SHA-256 digest of the exact
-   provenance bytes. A same-directory atomic rename replaces the prior commit
-   record, followed by synchronization of its parent directory.
-5. A reader follows only the commit record. The record binds provenance bytes;
-   provenance binds product/archive digests, lengths, full requested and
-   resolved identities, and source. The reader repeats those checks and fresh
-   SP3/IONEX semantic validation before returning a hit.
-6. A later lock owner removes unreferenced transaction directories. It cannot
-   run cleanup while a cooperating writer is alive. Valid 0.29.0-0.29.2 triples
-   are fully revalidated and republished as one transaction without a new
-   download.
+One Rust implementation now defines the native protocol used by the Rust,
+Python, C, and Elixir interfaces. The WASM/JavaScript interface uses the same
+identity and commit-record builder/verifier, with browser-native coordination
+and storage:
 
-The commit record is the only reader-visible transition. A failure before its
-rename leaves the prior record. A failure after its rename points to an entry
-whose files and directory names were already synchronized. With no prior
-record, the corresponding outcomes are a complete entry or no acceptable
-entry.
+1. The complete `ProductIdentity` includes family, analysis center, publisher,
+   solution class, campaign, filename version, coverage date, issue, span,
+   cadence, official filename, format, parsed format version, and prediction
+   horizon. Its canonical bytes and the explicit distribution source select
+   and bind a cache entry. No field is inferred from filename or modification
+   time.
+2. Native writers hold a bounded advisory `flock` on the entry directory across
+   cache check, acquisition, validation, commit, and cleanup. The kernel
+   releases the lock when a process exits; recovery never guesses an owner PID
+   or deletes a live writer's files.
+3. A native writer creates a cryptographically random immutable entry
+   directory, writes product, archive, and provenance bytes with exclusive file
+   creation, synchronizes each file, and synchronizes the entry directories.
+4. Schema-v3 commit bytes bind the SHA-256 digest and length of all three byte
+   objects, the SHA-256 digest of the complete canonical identity, the explicit
+   distribution source, and the immutable entry identifier.
+5. A synchronized temporary marker is renamed over `current.json` in the same
+   directory, then the directory is synchronized. That marker is the only
+   reader-visible transition. A process death leaves the previous complete
+   entry, the new complete entry, or no acceptable entry; it cannot authorize a
+   mixed entry.
+6. Readers follow only the marker and rehash all three objects. An unlocked
+   native reader retries if the marker changes while a later lock owner removes
+   the previous immutable directory, so refresh yields an old or new complete
+   entry rather than a spurious partial read.
+7. Cleanup runs only under the writer lock and removes only immutable entry
+   directories not named by the current marker. Valid legacy Python and Elixir
+   triples are fully revalidated before transaction migration and do not
+   require another download.
+8. Browser JavaScript uses a Web Lock for same-origin tab/worker coordination.
+   One strict-durability IndexedDB read-write transaction stores the immutable
+   entry and replaces its marker atomically. Reads invoke the shared WASM
+   verifier before returning any bytes.
+
+Transport and format parsing remain outside the low-level cache module. A
+caller must validate product semantics before publication and must parse the
+authenticated product and provenance bytes on a hit. Python and Elixir exact
+acquisition perform those checks themselves.
+
+## Interface parity
+
+- Rust exposes the pure schema-v3 builder/verifier and the native
+  `ExactProductCache` through both `sidereon-core` and `sidereon`.
+- Python exposes `sidereon.exact_cache` and uses that same native implementation
+  in exact acquisition.
+- C exposes lock, locked and unlocked read, publish, cleanup, authenticated-byte
+  and path accessors, and handle release functions in `sidereon.h`.
+- WASM exposes the pure builder/verifier and `BrowserExactProductCache` from the
+  `@neilberkman/sidereon/exact-cache` package export.
+- Elixir exposes `Sidereon.GNSS.ExactCache` and uses that same native
+  implementation in exact acquisition.
+
+Host languages retain their normal ownership and async conventions, but the
+identity fields, accepted sources, commit bindings, corruption behavior,
+bounded coordination, immutable publication, and cleanup rules are shared.
 
 ## Test coverage
 
-Deterministic tests use explicit barriers and named publication failpoints. The
-Python and Elixir suites cover independent OS processes racing one source,
-identical bytes acquired through different allowed sources, duplicate-request
-reuse, a prior entry during refresh, process death after every payload,
-archive, provenance, entry-sync, marker-write, marker-rename, and final-sync
-boundary, corruption, same-filename/different-identity isolation, and abandoned
-cleanup while another OS process owns the lock. Python additionally constructs
-a deliberate payload/provenance mismatch and verifies legacy migration.
+Core tests use child processes, explicit barriers, and named publication
+failpoints compiled only by the non-default `exact-cache-test-failpoints`
+feature. They cover two processes racing the same identity, one-download
+warm-cache reuse, a live owner that cannot be displaced or cleaned, an unlocked
+reader racing refresh cleanup, death after every payload/archive/provenance,
+entry-sync, marker-write, marker-rename, and final-sync boundary, byte
+corruption, source substitution, and same-path identity substitution.
 
-Manual bidirectional compatibility checks also prove that Python accepts an
-Elixir-published entry and Elixir accepts a Python-published entry. Holding the
-lock in either runtime makes the other runtime time out, confirming that both
-use the same OS lock rather than two unrelated coordination mechanisms.
+Python and Elixir acquisition tests cover distributor races, legacy migration,
+parsed-product validation, provenance mismatch, lock timeout, and duplicate
+request reuse through the shared native implementation. C tests exercise lock
+ownership, timeout, publication, locked and unlocked verified reads, and byte
+copying. WASM tests exercise full identity fields, commit substitution
+rejection, Web Lock serialization, one-acquisition reuse, IndexedDB atomic
+publication, and stored-byte corruption rejection.
 
 ## Compatibility and residual risk
 
-- The exact-acquisition function signatures remain compatible. Python adds
-  optional `cache_lock_timeout_s`; Elixir adds optional
-  `:cache_lock_timeout_ms`.
-- `result.path` still names the official product filename, now inside the
-  immutable transaction directory. Code that assumed the undocumented former
-  parent directory should instead use the returned path.
-- The legacy convenience fetch APIs and their separate cache layouts are not
-  changed.
-- The crash and cross-process guarantee applies to local Linux and macOS
-  filesystems that honor POSIX `flock`, atomic same-directory rename, regular
-  file synchronization, and directory synchronization. Network filesystems or
-  mounts that weaken those primitives are outside the guarantee.
-- The cache directory is assumed to be controlled by the caller. Protection
-  from a malicious local user who can replace paths or rewrite committed files
-  is not part of this contract; tampering is detected when it changes bound
-  bytes, but this is not an authenticated storage format.
+- Existing exact-acquisition calls remain compatible. Python adds optional
+  `cache_lock_timeout_s`; Elixir adds optional `:cache_lock_timeout_ms`.
+- `result.path` still names the official product, now inside its immutable
+  entry directory. Consumers should not depend on the undocumented former
+  parent directory.
+- The native guarantee covers local Linux and macOS filesystems that implement
+  advisory `flock`, atomic same-directory rename, file synchronization, and
+  directory synchronization. Network filesystems or mounts that weaken those
+  primitives are outside the guarantee.
+- Browser coordination covers contexts participating in the same origin's Web
+  Locks and IndexedDB databases. It is not an OS filesystem lock and does not
+  coordinate unrelated origins or native processes.
+- The cache directory is caller-controlled trusted storage. Digest verification
+  detects changed bound bytes but is not a signature and does not defend
+  against an attacker able to replace both data and commit records.

--- a/docs/exact-product-cache-atomicity.md
+++ b/docs/exact-product-cache-atomicity.md
@@ -1,0 +1,86 @@
+# Exact-product cache atomicity audit
+
+## Verdict for 0.29.2
+
+Sidereon 0.29.2 did not provide a cross-process or crash-consistent exact-cache
+commit. The Rust core derived the full distributor-independent identity and
+source-specific cache path but intentionally performed no cache IO. The Python
+and Elixir acquisition interfaces each wrote the archive, provenance, and
+decompressed product as three independently renamed files. Their locks covered
+only one Python process or one BEAM coordination domain.
+
+The 0.29.2 readers did recheck the full requested and resolved identities,
+distribution source, both SHA-256 digests and lengths, caller checksum, and
+parsed product semantics. Those checks rejected ordinary corruption and most
+mixed triples. They did not establish one atomic acquisition record, prevent
+independent OS processes from interleaving publication, preserve the previous
+entry across every crash boundary, or prevent duplicate cross-process
+downloads. Therefore the required guarantee was absent.
+
+## Unreleased correction
+
+The acquisition-capable interfaces now share one on-disk protocol:
+
+1. The source and complete `ProductIdentity` continue to select the existing
+   collision-resistant identity directory. No identity field is inferred from
+   a filename or modification time.
+2. A POSIX advisory lock file in that directory covers cache check, acquisition,
+   validation, and commit. Python uses `flock` directly; the Elixir NIF uses the
+   same `flock` operation on Unix. Waiting is bounded. Process exit closes the
+   descriptor and releases the lock without a stale-owner deletion decision.
+3. A writer creates a cryptographically unique entry directory and writes the
+   product, archive, and provenance there. Each file is synchronized before the
+   entry and entries directories are synchronized.
+4. The writer creates and synchronizes a small version-2 commit record. It
+   contains the immutable entry identifier and the SHA-256 digest of the exact
+   provenance bytes. A same-directory atomic rename replaces the prior commit
+   record, followed by synchronization of its parent directory.
+5. A reader follows only the commit record. The record binds provenance bytes;
+   provenance binds product/archive digests, lengths, full requested and
+   resolved identities, and source. The reader repeats those checks and fresh
+   SP3/IONEX semantic validation before returning a hit.
+6. A later lock owner removes unreferenced transaction directories. It cannot
+   run cleanup while a cooperating writer is alive. Valid 0.29.0-0.29.2 triples
+   are fully revalidated and republished as one transaction without a new
+   download.
+
+The commit record is the only reader-visible transition. A failure before its
+rename leaves the prior record. A failure after its rename points to an entry
+whose files and directory names were already synchronized. With no prior
+record, the corresponding outcomes are a complete entry or no acceptable
+entry.
+
+## Test coverage
+
+Deterministic tests use explicit barriers and named publication failpoints. The
+Python and Elixir suites cover independent OS processes racing one source,
+identical bytes acquired through different allowed sources, duplicate-request
+reuse, a prior entry during refresh, process death after every payload,
+archive, provenance, entry-sync, marker-write, marker-rename, and final-sync
+boundary, corruption, same-filename/different-identity isolation, and abandoned
+cleanup while another OS process owns the lock. Python additionally constructs
+a deliberate payload/provenance mismatch and verifies legacy migration.
+
+Manual bidirectional compatibility checks also prove that Python accepts an
+Elixir-published entry and Elixir accepts a Python-published entry. Holding the
+lock in either runtime makes the other runtime time out, confirming that both
+use the same OS lock rather than two unrelated coordination mechanisms.
+
+## Compatibility and residual risk
+
+- The exact-acquisition function signatures remain compatible. Python adds
+  optional `cache_lock_timeout_s`; Elixir adds optional
+  `:cache_lock_timeout_ms`.
+- `result.path` still names the official product filename, now inside the
+  immutable transaction directory. Code that assumed the undocumented former
+  parent directory should instead use the returned path.
+- The legacy convenience fetch APIs and their separate cache layouts are not
+  changed.
+- The crash and cross-process guarantee applies to local Linux and macOS
+  filesystems that honor POSIX `flock`, atomic same-directory rename, regular
+  file synchronization, and directory synchronization. Network filesystems or
+  mounts that weaken those primitives are outside the guarantee.
+- The cache directory is assumed to be controlled by the caller. Protection
+  from a malicious local user who can replace paths or rewrite committed files
+  is not part of this contract; tampering is detected when it changes bound
+  bytes, but this is not an authenticated storage format.

--- a/docs/public-gnss-distribution-sources.md
+++ b/docs/public-gnss-distribution-sources.md
@@ -127,11 +127,32 @@ decompressed product, original downloaded archive, and JSON provenance sidecar
 are retained. A cache hit rechecks identities, byte counts, both hashes, caller
 checksum, and a fresh product parse with semantic checks.
 
-Writes use exclusive temporary files, flush them before atomic promotion, and
-make the decompressed data file visible last. Invalid or interrupted first
-downloads cannot become cache hits. Per-path in-process locks prevent duplicate
-first downloads. A verified existing entry is returned without contacting a
-remote service, including in offline mode.
+The acquisition-capable Python and Elixir interfaces publish the product,
+original archive, and JSON provenance as one immutable transaction. A single
+SHA-256-bound commit record names that transaction and is atomically replaced
+only after the entry files and directories have been synchronized. Readers
+follow only that record and then repeat the identity, source, digest, length,
+caller-checksum, and semantic checks.
+
+On Linux and macOS, both interfaces use the same per-entry POSIX advisory lock
+across cache validation, acquisition, and commit. The wait is bounded; a lock or
+cache-write failure is terminal rather than permission to try another source.
+OS process death releases the lock automatically, allowing a later owner to
+clean abandoned transactions without deleting a live writer's work. Valid
+0.29.0-0.29.2 three-file entries are revalidated and migrated into the committed
+layout without a new download.
+
+The crash guarantee relies on a local filesystem providing atomic
+same-directory rename, POSIX advisory locks, regular-file synchronization, and
+directory synchronization. Under those Linux/macOS guarantees, a process death
+or power loss during publication leaves the previous complete entry or no
+acceptable entry; it cannot expose a mixed payload/provenance pair. A verified
+existing entry is returned without contacting a remote service, including in
+offline mode.
+
+The [cache atomicity audit](exact-product-cache-atomicity.md) records the 0.29.2
+verdict, corrected protocol, process/failpoint coverage, compatibility, and
+residual risks.
 
 ## Compatibility and extension
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -27,6 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +58,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -76,6 +94,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +112,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -97,6 +135,37 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -122,7 +191,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -367,6 +436,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,15 +454,18 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "0.29.2"
+version = "0.30.0"
 dependencies = [
  "cc",
+ "fs2",
+ "getrandom 0.2.17",
  "libm",
  "nalgebra",
  "rayon",
  "roxmltree",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "trust-region-least-squares",
 ]
@@ -463,6 +546,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +575,28 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"


### PR DESCRIPTION
## Summary

- add schema-v3 exact-product cache commits binding the complete distributor-independent identity, explicit source, and SHA-256 digest plus length of product, archive, and provenance bytes
- add bounded cross-process Linux/macOS locking, immutable synchronized entries, atomic marker publication, verified locked/unlocked reads, refresh-race retry, and lock-scoped cleanup
- add analysis center and parsed format version to ProductIdentity so canonical keys retain every exact-product discriminator
- advance sidereon-core and sidereon to 0.30.0 because the externally constructible identity type changes

## Safety and compatibility

- corruption, incomplete entries, identity/source substitution, and same-filename/different-tier substitution are errors rather than misses
- crash instrumentation is compiled only by the non-default exact-cache-test-failpoints feature; ordinary library builds do not react to test environment variables
- native durability requires local Linux/macOS filesystems implementing advisory flock, atomic same-directory rename, file synchronization, and directory synchronization
- transport and product parsing remain caller responsibilities

## Verification

- exact cache suite: 4/4 with default production features
- exact cache suite: 6/6 with deterministic crash/barrier instrumentation
- data catalog: 30 passed, 1 ignored
- clippy with warnings denied
- cargo-semver-checks confirms a patch release would be incorrect
- sidereon-core package build and verification
