### PR TITLE
exact-cache: single-flight coalescing for concurrent downloads

### DIFF
--- a/crates/sidereon-core/src/exact_cache.rs
+++ b/crates/sidereon-core/src/exact_cache.rs
@@ -13,6 +13,7 @@ use crate::data::{DataCatalogError, DistributionSource, ProductIdentity};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+use std::time::Duration;
 
 /// Commit-record version shared by all Sidereon interfaces.
 pub const EXACT_CACHE_SCHEMA_VERSION: u8 = 3;
@@ -49,6 +50,15 @@ pub enum ExactCacheError {
     #[cfg(not(target_arch = "wasm32"))]
     #[error("timed out waiting for the exact-cache lock")]
     LockTimeout,
+    /// A live single-flight owner did not commit within the configured wait.
+    #[error("timed out waiting for the exact-cache in-flight owner")]
+    SingleFlightTimeout,
+    /// The single-flight owner token is no longer current or its heartbeat failed.
+    #[error("exact-cache single-flight ownership was lost")]
+    SingleFlightOwnershipLost,
+    /// Single-flight duration options are zero or internally inconsistent.
+    #[error("invalid exact-cache single-flight options")]
+    InvalidSingleFlightOptions,
     /// Cross-process durable cache publication is unsupported on this platform.
     #[cfg(not(target_arch = "wasm32"))]
     #[error("durable exact-cache publication is unsupported on this platform")]
@@ -83,6 +93,108 @@ pub struct VerifiedExactCacheCommit {
     pub entry_id: String,
     /// Verified identity, source, and byte bindings.
     pub digests: ExactCacheDigests,
+}
+
+/// Bounded timing policy for exact-cache single-flight coordination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExactCacheSingleFlightOptions {
+    /// Interval between committed-entry and heartbeat observations.
+    pub poll_interval: Duration,
+    /// Interval between automatic owner heartbeat writes.
+    pub heartbeat_interval: Duration,
+    /// Required continuous no-progress interval before owner retirement.
+    pub liveness_timeout: Duration,
+    /// Maximum total time spent waiting for another owner.
+    pub wait_timeout: Duration,
+}
+
+impl Default for ExactCacheSingleFlightOptions {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_millis(50),
+            heartbeat_interval: Duration::from_secs(5),
+            liveness_timeout: Duration::from_secs(30),
+            wait_timeout: Duration::from_secs(30 * 60),
+        }
+    }
+}
+
+impl ExactCacheSingleFlightOptions {
+    fn validate(self) -> Result<Self, ExactCacheError> {
+        if self.poll_interval.is_zero()
+            || self.heartbeat_interval.is_zero()
+            || self.liveness_timeout.is_zero()
+            || self.wait_timeout.is_zero()
+            || self.heartbeat_interval >= self.liveness_timeout
+        {
+            return Err(ExactCacheError::InvalidSingleFlightOptions);
+        }
+        Ok(self)
+    }
+}
+
+/// Target-neutral next action for an exact-cache single-flight waiter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactCacheSingleFlightDecision {
+    /// Observe the committed entry and owner revision again after this delay.
+    Wait(Duration),
+    /// Recheck the exact owner revision atomically and take over if unchanged.
+    Takeover,
+    /// Stop without downloading because the bounded total wait expired.
+    Timeout,
+}
+
+/// Target-neutral liveness state shared by filesystem and browser substrates.
+#[derive(Debug, Clone)]
+pub struct ExactCacheSingleFlightWait {
+    started: Duration,
+    unchanged_since: Duration,
+    observation_sha256: Option<[u8; 32]>,
+}
+
+impl ExactCacheSingleFlightWait {
+    /// Begin observing an owner at one monotonic timestamp.
+    #[must_use]
+    pub fn new(now: Duration) -> Self {
+        Self {
+            started: now,
+            unchanged_since: now,
+            observation_sha256: None,
+        }
+    }
+
+    /// Observe an opaque owner/heartbeat revision and select the next action.
+    ///
+    /// `now` and the returned delay use a caller-local monotonic clock. The
+    /// revision must change whenever the owner token or heartbeat changes.
+    pub fn observe(
+        &mut self,
+        now: Duration,
+        revision: &[u8],
+        options: ExactCacheSingleFlightOptions,
+    ) -> Result<ExactCacheSingleFlightDecision, ExactCacheError> {
+        let options = options.validate()?;
+        let revision_sha256: [u8; 32] = Sha256::digest(revision).into();
+        if self.observation_sha256 != Some(revision_sha256) {
+            self.observation_sha256 = Some(revision_sha256);
+            self.unchanged_since = now;
+        }
+
+        let no_progress = now.saturating_sub(self.unchanged_since);
+        if no_progress >= options.liveness_timeout {
+            return Ok(ExactCacheSingleFlightDecision::Takeover);
+        }
+        let elapsed = now.saturating_sub(self.started);
+        if elapsed >= options.wait_timeout {
+            return Ok(ExactCacheSingleFlightDecision::Timeout);
+        }
+        Ok(ExactCacheSingleFlightDecision::Wait(
+            options
+                .poll_interval
+                .min(options.wait_timeout - elapsed)
+                .min(options.liveness_timeout - no_progress),
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -218,10 +330,15 @@ mod native {
     use std::fs::{self, File, OpenOptions};
     use std::io::{ErrorKind, Write};
     use std::path::{Path, PathBuf};
-    use std::thread;
-    use std::time::{Duration, Instant};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Condvar, Mutex, OnceLock};
+    use std::thread::{self, JoinHandle};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
     const LOCK_FILENAME: &str = ".sidereon-cache.lock";
+    const INFLIGHT_FILENAME: &str = "in-flight.json";
+    const INFLIGHT_HEARTBEAT_DIRECTORY: &str = "in-flight-heartbeats";
+    const INFLIGHT_PROTOCOL_VERSION: u8 = 1;
 
     /// Paths and exact bytes from one verified immutable cache entry.
     #[derive(Debug, Clone)]
@@ -242,6 +359,231 @@ mod native {
         pub provenance: Vec<u8>,
     }
 
+    /// Result of opening an exact cache with single-flight coordination.
+    #[derive(Debug)]
+    pub enum ExactCacheOpen {
+        /// A complete committed entry was already available or was published
+        /// by the owner observed while waiting.
+        Hit(CommittedExactCacheEntry),
+        /// This process owns acquisition and is the only caller that should fetch.
+        Owner(ExactCacheOwner),
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    #[serde(deny_unknown_fields)]
+    struct InflightRecord {
+        protocol_version: u8,
+        owner_token: String,
+        process_id: u32,
+        process_nonce: String,
+        created_unix_ms: u64,
+        identity_sha256: String,
+        distribution_source: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct InflightSnapshot {
+        marker: Vec<u8>,
+        record: Option<InflightRecord>,
+        heartbeat: Option<HeartbeatFingerprint>,
+    }
+
+    impl InflightSnapshot {
+        fn revision(&self) -> [u8; 32] {
+            let mut digest = Sha256::new();
+            digest.update(self.marker.len().to_be_bytes());
+            digest.update(&self.marker);
+            match &self.heartbeat {
+                Some(heartbeat) => {
+                    digest.update([1]);
+                    digest.update(heartbeat.byte_length.to_be_bytes());
+                    match heartbeat.modified {
+                        Some(modified) => match modified.duration_since(UNIX_EPOCH) {
+                            Ok(duration) => {
+                                digest.update([1]);
+                                digest.update(duration.as_secs().to_be_bytes());
+                                digest.update(duration.subsec_nanos().to_be_bytes());
+                            }
+                            Err(error) => {
+                                digest.update([2]);
+                                digest.update(error.duration().as_secs().to_be_bytes());
+                                digest.update(error.duration().subsec_nanos().to_be_bytes());
+                            }
+                        },
+                        None => digest.update([0]),
+                    }
+                }
+                None => digest.update([0]),
+            }
+            digest.finalize().into()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct HeartbeatFingerprint {
+        byte_length: u64,
+        modified: Option<SystemTime>,
+    }
+
+    #[derive(Debug)]
+    struct HeartbeatControl {
+        stopped: Mutex<bool>,
+        wake: Condvar,
+    }
+
+    impl HeartbeatControl {
+        fn wait(&self, interval: Duration) -> bool {
+            let stopped = self.stopped.lock().expect("heartbeat mutex poisoned");
+            let (stopped, _) = self
+                .wake
+                .wait_timeout_while(stopped, interval, |stopped| !*stopped)
+                .expect("heartbeat condition variable poisoned");
+            *stopped
+        }
+
+        fn stop(&self) {
+            *self.stopped.lock().expect("heartbeat mutex poisoned") = true;
+            self.wake.notify_all();
+        }
+    }
+
+    /// Exclusive right to fetch and publish one single-flight cache miss.
+    pub struct ExactCacheOwner {
+        cache: ExactProductCache,
+        token: String,
+        options: ExactCacheSingleFlightOptions,
+        heartbeat_control: Arc<HeartbeatControl>,
+        heartbeat_failed: Arc<AtomicBool>,
+        heartbeat_thread: Option<JoinHandle<()>>,
+        released: bool,
+    }
+
+    impl std::fmt::Debug for ExactCacheOwner {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("ExactCacheOwner")
+                .field("stable_path", &self.cache.stable_path)
+                .field("token", &self.token)
+                .field("options", &self.options)
+                .field("heartbeat_failed", &self.heartbeat_failed)
+                .field("released", &self.released)
+                .finish_non_exhaustive()
+        }
+    }
+
+    trait MonotonicClock {
+        fn now(&self) -> Duration;
+        fn sleep(&self, duration: Duration);
+    }
+
+    struct SystemMonotonicClock {
+        origin: Instant,
+    }
+
+    impl SystemMonotonicClock {
+        fn new() -> Self {
+            Self {
+                origin: Instant::now(),
+            }
+        }
+    }
+
+    impl MonotonicClock for SystemMonotonicClock {
+        fn now(&self) -> Duration {
+            self.origin.elapsed()
+        }
+
+        fn sleep(&self, duration: Duration) {
+            thread::sleep(duration);
+        }
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    #[derive(Debug, Clone)]
+    #[doc(hidden)]
+    pub struct ExactCacheTestClock {
+        state: Arc<(Mutex<TestClockState>, Condvar)>,
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    #[derive(Debug)]
+    struct TestClockState {
+        now: Duration,
+        sleepers: usize,
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    impl ExactCacheTestClock {
+        /// Create a stopped monotonic clock for deterministic integration tests.
+        #[must_use]
+        pub fn new() -> Self {
+            Self {
+                state: Arc::new((
+                    Mutex::new(TestClockState {
+                        now: Duration::ZERO,
+                        sleepers: 0,
+                    }),
+                    Condvar::new(),
+                )),
+            }
+        }
+
+        /// Advance the clock and wake every cache waiter.
+        pub fn advance(&self, duration: Duration) {
+            let (state, wake) = &*self.state;
+            let mut state = state.lock().expect("test clock mutex poisoned");
+            state.now = state.now.saturating_add(duration);
+            wake.notify_all();
+        }
+
+        /// Block until at least `count` cache sleeps have begun.
+        pub fn wait_for_sleepers(&self, count: usize) {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            let (state, wake) = &*self.state;
+            let mut state = state.lock().expect("test clock mutex poisoned");
+            while state.sleepers < count {
+                let remaining = deadline
+                    .checked_duration_since(Instant::now())
+                    .expect("timed out waiting for test-clock sleeper");
+                let (next, timeout) = wake
+                    .wait_timeout(state, remaining)
+                    .expect("test clock condition variable poisoned");
+                state = next;
+                assert!(
+                    !timeout.timed_out() || state.sleepers >= count,
+                    "timed out waiting for test-clock sleeper"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    impl Default for ExactCacheTestClock {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg(feature = "exact-cache-test-failpoints")]
+    impl MonotonicClock for ExactCacheTestClock {
+        fn now(&self) -> Duration {
+            self.state.0.lock().expect("test clock mutex poisoned").now
+        }
+
+        fn sleep(&self, duration: Duration) {
+            let (state, wake) = &*self.state;
+            let mut state = state.lock().expect("test clock mutex poisoned");
+            let deadline = state.now.saturating_add(duration);
+            state.sleepers += 1;
+            wake.notify_all();
+            while state.now < deadline {
+                state = wake
+                    .wait(state)
+                    .expect("test clock condition variable poisoned");
+            }
+        }
+    }
+
     /// One exact identity/source cache rooted at the caller's stable product path.
     #[derive(Debug, Clone)]
     pub struct ExactProductCache {
@@ -259,6 +601,104 @@ mod native {
     impl Drop for ExactCacheGuard {
         fn drop(&mut self) {
             let _ = FileExt::unlock(&self.lock_file);
+        }
+    }
+
+    impl ExactCacheOwner {
+        fn new(
+            cache: ExactProductCache,
+            token: String,
+            options: ExactCacheSingleFlightOptions,
+        ) -> Self {
+            let heartbeat_control = Arc::new(HeartbeatControl {
+                stopped: Mutex::new(false),
+                wake: Condvar::new(),
+            });
+            let heartbeat_failed = Arc::new(AtomicBool::new(false));
+            let thread_cache = cache.clone();
+            let thread_token = token.clone();
+            let thread_control = Arc::clone(&heartbeat_control);
+            let thread_failed = Arc::clone(&heartbeat_failed);
+            let heartbeat_thread = thread::Builder::new()
+                .name("exact-cache-heartbeat".to_owned())
+                .spawn(move || {
+                    while !thread_control.wait(options.heartbeat_interval) {
+                        if thread_cache
+                            .refresh_inflight_heartbeat(&thread_token)
+                            .is_err()
+                        {
+                            thread_failed.store(true, Ordering::Release);
+                            break;
+                        }
+                    }
+                })
+                .ok();
+            if heartbeat_thread.is_none() {
+                heartbeat_failed.store(true, Ordering::Release);
+            }
+            Self {
+                cache,
+                token,
+                options,
+                heartbeat_control,
+                heartbeat_failed,
+                heartbeat_thread,
+                released: false,
+            }
+        }
+
+        /// Refresh this owner's liveness heartbeat immediately.
+        pub fn heartbeat(&self) -> Result<(), ExactCacheError> {
+            if self.heartbeat_failed.load(Ordering::Acquire) {
+                return Err(ExactCacheError::SingleFlightOwnershipLost);
+            }
+            let result = self.cache.refresh_inflight_heartbeat(&self.token);
+            if result.is_err() {
+                self.heartbeat_failed.store(true, Ordering::Release);
+            }
+            result
+        }
+
+        /// Publish validated bytes and release single-flight ownership.
+        pub fn publish(
+            mut self,
+            product: &[u8],
+            archive: &[u8],
+            provenance: &[u8],
+        ) -> Result<CommittedExactCacheEntry, ExactCacheError> {
+            self.stop_heartbeat();
+            if self.heartbeat_failed.load(Ordering::Acquire) {
+                return Err(ExactCacheError::SingleFlightOwnershipLost);
+            }
+            let guard = self.cache.lock(self.options.wait_timeout)?;
+            if !self.cache.inflight_token_is_current(&self.token)? {
+                return Err(ExactCacheError::SingleFlightOwnershipLost);
+            }
+            let entry = self.cache.publish(&guard, product, archive, provenance)?;
+            self.cache.release_inflight(&guard, &self.token)?;
+            self.released = true;
+            Ok(entry)
+        }
+
+        fn stop_heartbeat(&mut self) {
+            self.heartbeat_control.stop();
+            if let Some(heartbeat_thread) = self.heartbeat_thread.take() {
+                if heartbeat_thread.join().is_err() {
+                    self.heartbeat_failed.store(true, Ordering::Release);
+                }
+            }
+        }
+    }
+
+    impl Drop for ExactCacheOwner {
+        fn drop(&mut self) {
+            self.stop_heartbeat();
+            if self.released {
+                return;
+            }
+            if let Ok(guard) = self.cache.lock(Duration::ZERO) {
+                let _ = self.cache.release_inflight(&guard, &self.token);
+            }
         }
     }
 
@@ -285,6 +725,29 @@ mod native {
         #[must_use]
         pub fn stable_path(&self) -> &Path {
             &self.stable_path
+        }
+
+        /// Open this cache with bounded single-flight miss coalescing.
+        ///
+        /// A hit contains bytes verified by the unchanged schema-v3 commit
+        /// protocol. Only the returned owner should perform acquisition.
+        pub fn open_single_flight(
+            &self,
+            options: ExactCacheSingleFlightOptions,
+        ) -> Result<ExactCacheOpen, ExactCacheError> {
+            let clock = SystemMonotonicClock::new();
+            self.open_single_flight_with_clock(options, &clock)
+        }
+
+        /// Open using an injectable monotonic clock for deterministic tests.
+        #[cfg(feature = "exact-cache-test-failpoints")]
+        #[doc(hidden)]
+        pub fn open_single_flight_with_test_clock(
+            &self,
+            options: ExactCacheSingleFlightOptions,
+            clock: &ExactCacheTestClock,
+        ) -> Result<ExactCacheOpen, ExactCacheError> {
+            self.open_single_flight_with_clock(options, clock)
         }
 
         /// Acquire the per-entry cross-process lock with bounded waiting.
@@ -499,6 +962,304 @@ mod native {
             Ok(())
         }
 
+        fn open_single_flight_with_clock<C: MonotonicClock>(
+            &self,
+            options: ExactCacheSingleFlightOptions,
+            clock: &C,
+        ) -> Result<ExactCacheOpen, ExactCacheError> {
+            let options = options.validate()?;
+            ensure_supported_platform()?;
+            let started = clock.now();
+            let mut wait_state = ExactCacheSingleFlightWait::new(started);
+
+            loop {
+                if let Some(entry) = self.read()? {
+                    return Ok(ExactCacheOpen::Hit(entry));
+                }
+
+                let now = clock.now();
+                let snapshot = self.read_inflight_snapshot()?;
+                match snapshot {
+                    None => {
+                        if let Some(opened) = self.try_claim_transition(options)? {
+                            return Ok(opened);
+                        }
+                        let elapsed = now.saturating_sub(started);
+                        if elapsed >= options.wait_timeout {
+                            return Err(ExactCacheError::SingleFlightTimeout);
+                        }
+                        clock.sleep(options.poll_interval.min(options.wait_timeout - elapsed));
+                    }
+                    Some(snapshot) => {
+                        let decision = wait_state.observe(now, &snapshot.revision(), options)?;
+                        test_failpoint("after_inflight_wait_observation");
+                        match decision {
+                            ExactCacheSingleFlightDecision::Wait(duration) => {
+                                clock.sleep(duration);
+                            }
+                            ExactCacheSingleFlightDecision::Takeover => {
+                                if let Some(opened) =
+                                    self.try_takeover_transition(&snapshot, options)?
+                                {
+                                    return Ok(opened);
+                                }
+                                let elapsed = clock.now().saturating_sub(started);
+                                if elapsed >= options.wait_timeout {
+                                    return Err(ExactCacheError::SingleFlightTimeout);
+                                }
+                                clock.sleep(
+                                    options.poll_interval.min(options.wait_timeout - elapsed),
+                                );
+                            }
+                            ExactCacheSingleFlightDecision::Timeout => {
+                                return Err(ExactCacheError::SingleFlightTimeout);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fn try_claim_transition(
+            &self,
+            options: ExactCacheSingleFlightOptions,
+        ) -> Result<Option<ExactCacheOpen>, ExactCacheError> {
+            let Some(guard) = self.try_transition_guard()? else {
+                return Ok(None);
+            };
+            if let Some(entry) = self.read()? {
+                return Ok(Some(ExactCacheOpen::Hit(entry)));
+            }
+            if self.read_inflight_snapshot()?.is_some() {
+                return Ok(None);
+            }
+            let Some(token) = self.claim_inflight(&guard)? else {
+                return Ok(None);
+            };
+            Ok(Some(ExactCacheOpen::Owner(ExactCacheOwner::new(
+                self.clone(),
+                token,
+                options,
+            ))))
+        }
+
+        fn try_takeover_transition(
+            &self,
+            observed: &InflightSnapshot,
+            options: ExactCacheSingleFlightOptions,
+        ) -> Result<Option<ExactCacheOpen>, ExactCacheError> {
+            let Some(guard) = self.try_transition_guard()? else {
+                return Ok(None);
+            };
+            if let Some(entry) = self.read()? {
+                return Ok(Some(ExactCacheOpen::Hit(entry)));
+            }
+            if self.read_inflight_snapshot()?.as_ref() != Some(observed) {
+                return Ok(None);
+            }
+            if !self.retire_inflight(&guard, observed)? {
+                return Ok(None);
+            }
+            let Some(token) = self.claim_inflight(&guard)? else {
+                return Ok(None);
+            };
+            Ok(Some(ExactCacheOpen::Owner(ExactCacheOwner::new(
+                self.clone(),
+                token,
+                options,
+            ))))
+        }
+
+        fn try_transition_guard(&self) -> Result<Option<ExactCacheGuard>, ExactCacheError> {
+            match self.lock(Duration::ZERO) {
+                Ok(guard) => Ok(Some(guard)),
+                Err(ExactCacheError::LockTimeout) => Ok(None),
+                Err(error) => Err(error),
+            }
+        }
+
+        fn claim_inflight(
+            &self,
+            guard: &ExactCacheGuard,
+        ) -> Result<Option<String>, ExactCacheError> {
+            self.require_guard(guard)?;
+            let control = self.control_directory();
+            let heartbeats = control.join(INFLIGHT_HEARTBEAT_DIRECTORY);
+            durable_create_dir_all(&heartbeats)?;
+            if self.inflight_path().exists() {
+                return Ok(None);
+            }
+
+            let token = random_identifier("random in-flight owner token")?;
+            let heartbeat_path = self.inflight_heartbeat_path(&token)?;
+            write_exclusive(&heartbeat_path, b"\0")?;
+            sync_directory(&heartbeats)?;
+            test_failpoint("after_inflight_heartbeat");
+
+            let record = InflightRecord {
+                protocol_version: INFLIGHT_PROTOCOL_VERSION,
+                owner_token: token.clone(),
+                process_id: std::process::id(),
+                process_nonce: process_nonce()?,
+                created_unix_ms: unix_milliseconds(),
+                identity_sha256: identity_sha256(&self.identity)?,
+                distribution_source: self.source.code().to_owned(),
+            };
+            let marker = serde_json::to_vec(&record)
+                .map_err(|_| ExactCacheError::InvalidCommit("in-flight serialization"))?;
+            if !write_exclusive_if_absent(&self.inflight_path(), &marker)? {
+                let _ = fs::remove_file(heartbeat_path);
+                return Ok(None);
+            }
+            test_failpoint("after_inflight_marker");
+            sync_directory(&control)?;
+            test_failpoint("after_inflight_sync");
+            Ok(Some(token))
+        }
+
+        fn read_inflight_snapshot(&self) -> Result<Option<InflightSnapshot>, ExactCacheError> {
+            let marker = match fs::read(self.inflight_path()) {
+                Ok(marker) => marker,
+                Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+                Err(source) => return Err(io("read in-flight marker", source)),
+            };
+            let record = serde_json::from_slice::<InflightRecord>(&marker)
+                .ok()
+                .filter(|record| {
+                    record.protocol_version == INFLIGHT_PROTOCOL_VERSION
+                        && validate_entry_id(&record.owner_token).is_ok()
+                        && validate_entry_id(&record.process_nonce).is_ok()
+                });
+            if let Some(record) = &record {
+                if record.identity_sha256 != identity_sha256(&self.identity)?
+                    || record.distribution_source != self.source.code()
+                {
+                    return Err(ExactCacheError::InvalidCommit(
+                        "in-flight identity or source",
+                    ));
+                }
+            }
+            let heartbeat = match &record {
+                Some(record) => {
+                    match fs::metadata(self.inflight_heartbeat_path(&record.owner_token)?) {
+                        Ok(metadata) => Some(HeartbeatFingerprint {
+                            byte_length: metadata.len(),
+                            modified: metadata.modified().ok(),
+                        }),
+                        Err(error) if error.kind() == ErrorKind::NotFound => None,
+                        Err(source) => return Err(io("read in-flight heartbeat", source)),
+                    }
+                }
+                None => None,
+            };
+            Ok(Some(InflightSnapshot {
+                marker,
+                record,
+                heartbeat,
+            }))
+        }
+
+        fn refresh_inflight_heartbeat(&self, token: &str) -> Result<(), ExactCacheError> {
+            if !self.inflight_token_is_current(token)? {
+                return Err(ExactCacheError::SingleFlightOwnershipLost);
+            }
+            let heartbeat_path = self.inflight_heartbeat_path(token)?;
+            let mut heartbeat = OpenOptions::new()
+                .append(true)
+                .open(heartbeat_path)
+                .map_err(|source| io("open in-flight heartbeat", source))?;
+            heartbeat
+                .write_all(b"\0")
+                .map_err(|source| io("write in-flight heartbeat", source))?;
+            heartbeat
+                .sync_all()
+                .map_err(|source| io("sync in-flight heartbeat", source))?;
+            test_failpoint("after_inflight_heartbeat_refresh");
+            Ok(())
+        }
+
+        fn inflight_token_is_current(&self, token: &str) -> Result<bool, ExactCacheError> {
+            Ok(self
+                .read_inflight_snapshot()?
+                .and_then(|snapshot| snapshot.record)
+                .is_some_and(|record| record.owner_token == token))
+        }
+
+        fn release_inflight(
+            &self,
+            guard: &ExactCacheGuard,
+            token: &str,
+        ) -> Result<(), ExactCacheError> {
+            self.require_guard(guard)?;
+            let Some(snapshot) = self.read_inflight_snapshot()? else {
+                return Ok(());
+            };
+            if snapshot
+                .record
+                .as_ref()
+                .map(|record| record.owner_token.as_str())
+                != Some(token)
+            {
+                return Ok(());
+            }
+            let _ = self.retire_inflight(guard, &snapshot)?;
+            Ok(())
+        }
+
+        fn retire_inflight(
+            &self,
+            guard: &ExactCacheGuard,
+            expected: &InflightSnapshot,
+        ) -> Result<bool, ExactCacheError> {
+            self.require_guard(guard)?;
+            if self.read_inflight_snapshot()?.as_ref() != Some(expected) {
+                return Ok(false);
+            }
+            let nonce = random_identifier("random retired marker id")?;
+            let token = expected
+                .record
+                .as_ref()
+                .map_or("malformed", |record| record.owner_token.as_str());
+            let retired = self
+                .control_directory()
+                .join(format!(".in-flight.{token}.{nonce}.retired"));
+            match fs::rename(self.inflight_path(), &retired) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+                Err(source) => return Err(io("retire in-flight marker", source)),
+            }
+            test_failpoint("after_inflight_retire");
+
+            let retired_marker =
+                fs::read(&retired).map_err(|source| io("read retired in-flight marker", source))?;
+            if retired_marker != expected.marker {
+                let _ = write_exclusive_if_absent(&self.inflight_path(), &retired_marker)?;
+                let _ = fs::remove_file(&retired);
+                sync_directory(&self.control_directory())?;
+                return Ok(false);
+            }
+
+            sync_directory(&self.control_directory())?;
+            test_failpoint("after_inflight_retire_sync");
+            fs::remove_file(&retired)
+                .map_err(|source| io("remove retired in-flight marker", source))?;
+            if let Some(record) = &expected.record {
+                match fs::remove_file(self.inflight_heartbeat_path(&record.owner_token)?) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == ErrorKind::NotFound => {}
+                    Err(source) => return Err(io("remove in-flight heartbeat", source)),
+                }
+            }
+            test_failpoint("after_inflight_reap");
+            sync_directory(&self.control_directory())?;
+            let heartbeats = self.control_directory().join(INFLIGHT_HEARTBEAT_DIRECTORY);
+            if heartbeats.is_dir() {
+                sync_directory(&heartbeats)?;
+            }
+            test_failpoint("after_inflight_reap_sync");
+            Ok(true)
+        }
+
         fn require_guard(&self, guard: &ExactCacheGuard) -> Result<(), ExactCacheError> {
             if guard.stable_path == self.stable_path {
                 Ok(())
@@ -516,6 +1277,18 @@ mod native {
 
         fn marker_path(&self) -> PathBuf {
             self.control_directory().join(EXACT_CACHE_MARKER_FILENAME)
+        }
+
+        fn inflight_path(&self) -> PathBuf {
+            self.control_directory().join(INFLIGHT_FILENAME)
+        }
+
+        fn inflight_heartbeat_path(&self, token: &str) -> Result<PathBuf, ExactCacheError> {
+            validate_entry_id(token)?;
+            Ok(self
+                .control_directory()
+                .join(INFLIGHT_HEARTBEAT_DIRECTORY)
+                .join(format!("{token}.heartbeat")))
         }
 
         fn entry_paths(&self, entry_id: &str) -> Result<EntryPaths, ExactCacheError> {
@@ -537,14 +1310,7 @@ mod native {
 
         fn allocate_entry_id(&self, entries: &Path) -> Result<String, ExactCacheError> {
             for _ in 0..128 {
-                let mut random = [0_u8; 16];
-                getrandom::getrandom(&mut random).map_err(|error| {
-                    io("random entry id", std::io::Error::other(error.to_string()))
-                })?;
-                let mut entry_id = String::with_capacity(32);
-                for byte in random {
-                    write!(&mut entry_id, "{byte:02x}").expect("writing to String cannot fail");
-                }
+                let entry_id = random_identifier("random entry id")?;
                 match fs::create_dir(entries.join(&entry_id)) {
                     Ok(()) => return Ok(entry_id),
                     Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
@@ -618,6 +1384,57 @@ mod native {
             .map_err(|source| io("sync immutable file", source))
     }
 
+    fn write_exclusive_if_absent(path: &Path, bytes: &[u8]) -> Result<bool, ExactCacheError> {
+        let mut file = match OpenOptions::new().create_new(true).write(true).open(path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => return Ok(false),
+            Err(source) => return Err(io("create in-flight marker", source)),
+        };
+        let result = file
+            .write_all(bytes)
+            .map_err(|source| io("write in-flight marker", source))
+            .and_then(|()| {
+                file.sync_all()
+                    .map_err(|source| io("sync in-flight marker", source))
+            });
+        if result.is_err() {
+            let _ = fs::remove_file(path);
+        }
+        result.map(|()| true)
+    }
+
+    fn random_identifier(operation: &'static str) -> Result<String, ExactCacheError> {
+        let mut random = [0_u8; 16];
+        getrandom::getrandom(&mut random)
+            .map_err(|error| io(operation, std::io::Error::other(error.to_string())))?;
+        let mut identifier = String::with_capacity(32);
+        for byte in random {
+            write!(&mut identifier, "{byte:02x}").expect("writing to String cannot fail");
+        }
+        Ok(identifier)
+    }
+
+    fn process_nonce() -> Result<String, ExactCacheError> {
+        static PROCESS_NONCE: OnceLock<String> = OnceLock::new();
+        if let Some(nonce) = PROCESS_NONCE.get() {
+            return Ok(nonce.clone());
+        }
+        let nonce = random_identifier("random in-flight process nonce")?;
+        let _ = PROCESS_NONCE.set(nonce);
+        Ok(PROCESS_NONCE
+            .get()
+            .expect("process nonce initialized")
+            .clone())
+    }
+
+    fn unix_milliseconds() -> u64 {
+        let milliseconds = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        u64::try_from(milliseconds).unwrap_or(u64::MAX)
+    }
+
     fn sync_directory(path: &Path) -> Result<(), ExactCacheError> {
         File::open(path)
             .and_then(|directory| directory.sync_all())
@@ -626,6 +1443,25 @@ mod native {
 
     #[cfg(feature = "exact-cache-test-failpoints")]
     fn test_failpoint(name: &str) {
+        if std::env::var_os("SIDEREON_TEST_EXACT_CACHE_PAUSE_FAILPOINT").as_deref()
+            == Some(std::ffi::OsStr::new(name))
+        {
+            let barrier = PathBuf::from(
+                std::env::var_os("SIDEREON_TEST_EXACT_CACHE_FAILPOINT_BARRIER")
+                    .expect("exact-cache pause failpoint barrier"),
+            );
+            fs::write(barrier.with_extension("ready"), b"ready")
+                .expect("write exact-cache failpoint barrier");
+            let release = barrier.with_extension("release");
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !release.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for exact-cache failpoint release"
+                );
+                thread::sleep(Duration::from_millis(5));
+            }
+        }
         if std::env::var_os("SIDEREON_TEST_EXACT_CACHE_FAILPOINT").as_deref()
             == Some(std::ffi::OsStr::new(name))
         {
@@ -663,7 +1499,13 @@ mod native {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use native::{CommittedExactCacheEntry, ExactCacheGuard, ExactProductCache};
+pub use native::{
+    CommittedExactCacheEntry, ExactCacheGuard, ExactCacheOpen, ExactCacheOwner, ExactProductCache,
+};
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "exact-cache-test-failpoints"))]
+#[doc(hidden)]
+pub use native::ExactCacheTestClock;
 
 #[cfg(test)]
 mod tests {
@@ -750,5 +1592,69 @@ mod tests {
             )
             .is_err());
         }
+    }
+
+    #[test]
+    fn single_flight_wait_state_resets_on_progress_and_prefers_stale_takeover() {
+        let options = ExactCacheSingleFlightOptions {
+            poll_interval: Duration::from_secs(2),
+            heartbeat_interval: Duration::from_secs(1),
+            liveness_timeout: Duration::from_secs(5),
+            wait_timeout: Duration::from_secs(20),
+        };
+        let mut wait = ExactCacheSingleFlightWait::new(Duration::ZERO);
+        assert_eq!(
+            wait.observe(Duration::ZERO, b"owner-a:1", options)
+                .expect("first observation"),
+            ExactCacheSingleFlightDecision::Wait(Duration::from_secs(2))
+        );
+        assert_eq!(
+            wait.observe(Duration::from_secs(4), b"owner-a:1", options)
+                .expect("unchanged observation"),
+            ExactCacheSingleFlightDecision::Wait(Duration::from_secs(1))
+        );
+        assert_eq!(
+            wait.observe(Duration::from_secs(4), b"owner-a:2", options)
+                .expect("heartbeat progress"),
+            ExactCacheSingleFlightDecision::Wait(Duration::from_secs(2))
+        );
+        assert_eq!(
+            wait.observe(Duration::from_secs(9), b"owner-a:2", options)
+                .expect("stale observation"),
+            ExactCacheSingleFlightDecision::Takeover
+        );
+
+        let options = ExactCacheSingleFlightOptions {
+            wait_timeout: Duration::from_secs(5),
+            ..options
+        };
+        let mut equal_deadlines = ExactCacheSingleFlightWait::new(Duration::ZERO);
+        equal_deadlines
+            .observe(Duration::ZERO, b"owner", options)
+            .expect("initial observation");
+        assert_eq!(
+            equal_deadlines
+                .observe(Duration::from_secs(5), b"owner", options)
+                .expect("equal deadlines"),
+            ExactCacheSingleFlightDecision::Takeover
+        );
+    }
+
+    #[test]
+    fn single_flight_wait_state_times_out_while_owner_is_live() {
+        let options = ExactCacheSingleFlightOptions {
+            poll_interval: Duration::from_secs(1),
+            heartbeat_interval: Duration::from_secs(2),
+            liveness_timeout: Duration::from_secs(10),
+            wait_timeout: Duration::from_secs(3),
+        };
+        let mut wait = ExactCacheSingleFlightWait::new(Duration::ZERO);
+        wait.observe(Duration::ZERO, b"owner:1", options)
+            .expect("initial observation");
+        assert_eq!(
+            wait.observe(Duration::from_secs(3), b"owner:2", options)
+                .expect("live owner at wait bound"),
+            ExactCacheSingleFlightDecision::Timeout
+        );
     }
 }

--- a/crates/sidereon-core/tests/exact_cache_atomicity.rs
+++ b/crates/sidereon-core/tests/exact_cache_atomicity.rs
@@ -3,7 +3,11 @@
 use sidereon_core::data::{
     product, AnalysisCenter, DistributionSource, ProductDate, ProductIdentity, ProductType,
 };
-use sidereon_core::exact_cache::{ExactCacheError, ExactProductCache};
+#[cfg(feature = "exact-cache-test-failpoints")]
+use sidereon_core::exact_cache::ExactCacheTestClock;
+use sidereon_core::exact_cache::{
+    ExactCacheError, ExactCacheOpen, ExactCacheSingleFlightOptions, ExactProductCache,
+};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -34,6 +38,15 @@ fn identity() -> ProductIdentity {
 
 fn cache(path: impl Into<PathBuf>) -> ExactProductCache {
     ExactProductCache::new(path, identity(), DistributionSource::Direct).expect("cache")
+}
+
+fn single_flight_options() -> ExactCacheSingleFlightOptions {
+    ExactCacheSingleFlightOptions {
+        poll_interval: Duration::from_millis(10),
+        heartbeat_interval: Duration::from_millis(25),
+        liveness_timeout: Duration::from_secs(2),
+        wait_timeout: Duration::from_secs(10),
+    }
 }
 
 fn temp_directory(label: &str) -> PathBuf {
@@ -75,6 +88,39 @@ fn child(mode: &str, stable: &Path, root: &Path) -> std::process::Child {
     command.spawn().expect("spawn cache helper")
 }
 
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn paused_child(
+    mode: &str,
+    stable: &Path,
+    root: &Path,
+    failpoint: &str,
+    barrier: &Path,
+) -> std::process::Child {
+    let mut command = Command::new(std::env::current_exe().expect("test executable"));
+    command
+        .arg("--exact")
+        .arg("exact_cache_subprocess")
+        .arg("--nocapture")
+        .env("SIDEREON_EXACT_CACHE_CHILD_MODE", mode)
+        .env("SIDEREON_EXACT_CACHE_CHILD_STABLE", stable)
+        .env("SIDEREON_EXACT_CACHE_CHILD_ROOT", root)
+        .env("SIDEREON_TEST_EXACT_CACHE_PAUSE_FAILPOINT", failpoint)
+        .env("SIDEREON_TEST_EXACT_CACHE_FAILPOINT_BARRIER", barrier)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command.spawn().expect("spawn paused cache helper")
+}
+
+fn count_download(root: &Path) {
+    let mut counter = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(root.join("downloads"))
+        .expect("download counter");
+    counter.write_all(b"download\n").expect("count download");
+    counter.sync_all().expect("sync download counter");
+}
+
 #[test]
 fn exact_cache_subprocess() {
     let Some(mode) = std::env::var_os("SIDEREON_EXACT_CACHE_CHILD_MODE") else {
@@ -108,16 +154,30 @@ fn exact_cache_subprocess() {
             wait_for(&root.join("start"));
             let guard = cache.lock(Duration::from_secs(5)).expect("lock");
             if cache.read().expect("read").is_none() {
-                let mut counter = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(root.join("downloads"))
-                    .expect("download counter");
-                counter.write_all(b"download\n").expect("count download");
-                counter.sync_all().expect("sync download counter");
+                count_download(&root);
                 cache
                     .publish(&guard, OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
                     .expect("publish");
+            }
+        }
+        "singleflight_publish" => {
+            match cache
+                .open_single_flight(single_flight_options())
+                .expect("single-flight open")
+            {
+                ExactCacheOpen::Hit(entry) => {
+                    fs::write(root.join("singleflight-result"), entry.product)
+                        .expect("write single-flight hit");
+                }
+                ExactCacheOpen::Owner(owner) => {
+                    count_download(&root);
+                    owner.heartbeat().expect("download heartbeat");
+                    let entry = owner
+                        .publish(NEW_PRODUCT, NEW_ARCHIVE, NEW_PROVENANCE)
+                        .expect("single-flight publish");
+                    fs::write(root.join("singleflight-result"), entry.product)
+                        .expect("write single-flight publish result");
+                }
             }
         }
         "read_barrier" => {
@@ -162,6 +222,155 @@ fn unlocked_reader_retries_when_cleanup_removes_its_previous_entry() {
 }
 
 #[test]
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn waiter_observes_the_owners_commit_without_downloading() {
+    let root = temp_directory("singleflight-waiter");
+    let stable = root.join("cache").join("product.SP3");
+    let owner_barrier = root.join("owner-pause");
+    let waiter_barrier = root.join("waiter-pause");
+    let mut owner = paused_child(
+        "singleflight_publish",
+        &stable,
+        &root,
+        "after_inflight_heartbeat_refresh",
+        &owner_barrier,
+    );
+    wait_for(&owner_barrier.with_extension("ready"));
+    assert!(root
+        .join("cache")
+        .join(".sidereon-cache-v3")
+        .join("in-flight.json")
+        .is_file());
+
+    let mut waiter = paused_child(
+        "singleflight_publish",
+        &stable,
+        &root,
+        "after_inflight_wait_observation",
+        &waiter_barrier,
+    );
+    wait_for(&waiter_barrier.with_extension("ready"));
+    fs::write(owner_barrier.with_extension("release"), b"release").expect("release owner");
+    assert!(owner.wait().expect("owner status").success());
+    fs::write(waiter_barrier.with_extension("release"), b"release").expect("release waiter");
+    assert!(waiter.wait().expect("waiter status").success());
+
+    let downloads = fs::read_to_string(root.join("downloads")).expect("download counter");
+    assert_eq!(downloads.lines().count(), 1);
+    assert_eq!(
+        fs::read(root.join("singleflight-result")).expect("single-flight result"),
+        NEW_PRODUCT
+    );
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+#[cfg(all(feature = "exact-cache-test-failpoints", unix))]
+fn sigkill_dead_owner_is_taken_over_after_injected_liveness_timeout() {
+    let root = temp_directory("singleflight-dead-owner");
+    let stable = root.join("cache").join("product.SP3");
+    let owner_barrier = root.join("dead-owner-pause");
+    let mut owner = paused_child(
+        "singleflight_publish",
+        &stable,
+        &root,
+        "after_inflight_heartbeat_refresh",
+        &owner_barrier,
+    );
+    wait_for(&owner_barrier.with_extension("ready"));
+    assert!(root
+        .join("cache")
+        .join(".sidereon-cache-v3")
+        .join("in-flight.json")
+        .is_file());
+    owner.kill().expect("SIGKILL dead owner");
+    assert!(!owner.wait().expect("dead owner status").success());
+
+    let clock = ExactCacheTestClock::new();
+    let waiter_clock = clock.clone();
+    let waiter_root = root.clone();
+    let waiter_stable = stable.clone();
+    let takeover = thread::spawn(move || {
+        let options = ExactCacheSingleFlightOptions {
+            poll_interval: Duration::from_secs(1),
+            heartbeat_interval: Duration::from_secs(1),
+            liveness_timeout: Duration::from_secs(5),
+            wait_timeout: Duration::from_secs(10),
+        };
+        let owner = match cache(waiter_stable)
+            .open_single_flight_with_test_clock(options, &waiter_clock)
+            .expect("dead-owner takeover")
+        {
+            ExactCacheOpen::Owner(owner) => owner,
+            ExactCacheOpen::Hit(_) => panic!("dead owner unexpectedly committed"),
+        };
+        count_download(&waiter_root);
+        owner
+            .publish(NEW_PRODUCT, NEW_ARCHIVE, NEW_PROVENANCE)
+            .expect("takeover publish")
+    });
+    clock.wait_for_sleepers(1);
+    clock.advance(Duration::from_secs(5));
+    let entry = takeover.join().expect("takeover thread");
+    assert_eq!(entry.product, NEW_PRODUCT);
+
+    let downloads = fs::read_to_string(root.join("downloads")).expect("download counter");
+    assert_eq!(downloads.lines().count(), 2);
+    let entries = root
+        .join("cache")
+        .join(".sidereon-cache-v3")
+        .join("entries");
+    assert_eq!(fs::read_dir(entries).expect("entries").count(), 1);
+    assert_eq!(
+        cache(&stable)
+            .read()
+            .expect("coherent read")
+            .expect("committed takeover")
+            .product,
+        NEW_PRODUCT
+    );
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn live_owner_total_wait_timeout_does_not_create_a_second_owner() {
+    let root = temp_directory("singleflight-timeout");
+    let stable = root.join("cache").join("product.SP3");
+    let first = match cache(&stable)
+        .open_single_flight(single_flight_options())
+        .expect("first owner")
+    {
+        ExactCacheOpen::Owner(owner) => owner,
+        ExactCacheOpen::Hit(_) => panic!("cold cache returned a hit"),
+    };
+
+    let clock = ExactCacheTestClock::new();
+    let waiter_clock = clock.clone();
+    let waiter_stable = stable.clone();
+    let waiter = thread::spawn(move || {
+        cache(waiter_stable).open_single_flight_with_test_clock(
+            ExactCacheSingleFlightOptions {
+                poll_interval: Duration::from_secs(1),
+                heartbeat_interval: Duration::from_secs(5),
+                liveness_timeout: Duration::from_secs(10),
+                wait_timeout: Duration::from_secs(3),
+            },
+            &waiter_clock,
+        )
+    });
+    clock.wait_for_sleepers(1);
+    clock.advance(Duration::from_secs(3));
+    assert!(matches!(
+        waiter.join().expect("waiter thread"),
+        Err(ExactCacheError::SingleFlightTimeout)
+    ));
+    first.heartbeat().expect("first owner remains live");
+    drop(first);
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn two_processes_publish_one_download_for_the_same_identity() {
     let root = temp_directory("race");
     let stable = root.join("cache").join("product.SP3");
@@ -174,6 +383,39 @@ fn two_processes_publish_one_download_for_the_same_identity() {
     assert_eq!(downloads.lines().count(), 1);
     let entry = cache(&stable).read().expect("read").expect("entry");
     assert_eq!(entry.product, OLD_PRODUCT);
+    assert!(!root
+        .join("cache")
+        .join(".sidereon-cache-v3")
+        .join("in-flight.json")
+        .exists());
+    fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn single_flight_owner_publishes_and_the_next_open_is_a_hit() {
+    let root = temp_directory("singleflight-cold-hit");
+    let stable = root.join("cache").join("product.SP3");
+    let cache = cache(&stable);
+    let owner = match cache
+        .open_single_flight(single_flight_options())
+        .expect("cold single-flight open")
+    {
+        ExactCacheOpen::Owner(owner) => owner,
+        ExactCacheOpen::Hit(_) => panic!("cold cache returned a hit"),
+    };
+    let published = owner
+        .publish(OLD_PRODUCT, OLD_ARCHIVE, OLD_PROVENANCE)
+        .expect("owner publish");
+    assert_eq!(published.product, OLD_PRODUCT);
+
+    let hit = match cache
+        .open_single_flight(single_flight_options())
+        .expect("warm single-flight open")
+    {
+        ExactCacheOpen::Hit(hit) => hit,
+        ExactCacheOpen::Owner(_) => panic!("warm cache returned an owner"),
+    };
+    assert_eq!(hit.product, OLD_PRODUCT);
     fs::remove_dir_all(root).expect("cleanup");
 }
 
@@ -250,6 +492,50 @@ fn process_death_at_each_publication_boundary_leaves_old_or_complete_new_entry()
                 && entry.archive == NEW_ARCHIVE
                 && entry.provenance == NEW_PROVENANCE);
         assert!(accepted, "mixed entry accepted after {step}");
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+}
+
+#[test]
+#[cfg(feature = "exact-cache-test-failpoints")]
+fn process_death_at_each_single_flight_boundary_preserves_committed_atomicity() {
+    for step in [
+        "after_inflight_heartbeat",
+        "after_inflight_marker",
+        "after_inflight_sync",
+        "after_inflight_heartbeat_refresh",
+        "after_inflight_retire",
+        "after_inflight_retire_sync",
+        "after_inflight_reap",
+        "after_inflight_reap_sync",
+    ] {
+        let root = temp_directory(step);
+        let stable = root.join("cache").join("product.SP3");
+        let cache = cache(&stable);
+
+        let mut publisher = Command::new(std::env::current_exe().expect("test executable"))
+            .arg("--exact")
+            .arg("exact_cache_subprocess")
+            .arg("--nocapture")
+            .env("SIDEREON_EXACT_CACHE_CHILD_MODE", "singleflight_publish")
+            .env("SIDEREON_EXACT_CACHE_CHILD_STABLE", &stable)
+            .env("SIDEREON_EXACT_CACHE_CHILD_ROOT", &root)
+            .env("SIDEREON_TEST_EXACT_CACHE_FAILPOINT", step)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn crashing single-flight publisher");
+        assert_eq!(
+            publisher.wait().expect("publisher status").code(),
+            Some(86),
+            "single-flight failpoint did not fire at {step}"
+        );
+
+        if let Some(entry) = cache.read().expect("coherent read") {
+            assert_eq!(entry.product, NEW_PRODUCT, "product after {step}");
+            assert_eq!(entry.archive, NEW_ARCHIVE, "archive after {step}");
+            assert_eq!(entry.provenance, NEW_PROVENANCE, "provenance after {step}");
+        }
         fs::remove_dir_all(root).expect("cleanup");
     }
 }

--- a/docs/exact-cache-single-flight.md
+++ b/docs/exact-cache-single-flight.md
@@ -1,0 +1,275 @@
+# Exact-cache single-flight coalescing
+
+## Decision
+
+Exact-cache single-flight is an opt-in open mode on `ExactProductCache`. A
+single call returns either a verified cache hit or an owner object. Only the
+owner may fetch, validate, and publish. Other callers remain inside the core
+state machine until the owner publishes, abandons the attempt, loses its
+lease, or their bounded wait expires.
+
+The committed data format remains schema v3. Coordination uses sidecars under
+the existing `.sidereon-cache-v3` control directory and never changes the
+meaning or encoding of `current.json`. This is deliberately not schema v4:
+coordination state is temporary, is not evidence that bytes are committed,
+and may be ignored or removed without changing what a reader accepts.
+
+Transport and semantic validation remain outside the cache. The core owns all
+coordination transitions; a caller only branches on `Hit` versus `Owner` and
+uses the owner object to publish validated bytes.
+
+## On-disk representation
+
+For one exact identity/source cache directory, the additions are:
+
+```text
+.sidereon-cache-v3/
+  current.json                         # unchanged schema-v3 commit record
+  entries/                             # unchanged immutable entries
+  in-flight.json                       # current owner record, if any
+  in-flight-heartbeats/
+    <owner-token>.heartbeat            # append-only liveness pulse
+  .in-flight.<token>.<nonce>.retired   # transient retired owner record
+```
+
+`in-flight.json` is JSON with a coordination protocol version, the canonical
+identity digest, distribution source, 128-bit random owner token, process ID,
+128-bit process nonce, and creation time in Unix milliseconds. The identity
+digest and source prevent an accidentally shared stable path from coalescing
+different requests.
+
+The owner token is the authority. PID is diagnostic only: PIDs are reused and
+can collide across containers or hosts sharing a cache. A portable boot ID is
+not available on Linux, macOS, and Windows with consistent privacy and
+permission properties. A cryptographically random process nonce therefore
+provides the boot/session disambiguation that a boot-derived value was meant
+to provide, without depending on a host-global identifier. Creation time is
+also diagnostic and is never used to decide liveness. The token plus process
+nonce makes accidental identity collision independent of PID, host, container,
+and clock values.
+
+The heartbeat is initialized before `in-flight.json` becomes visible. Each
+refresh appends one byte and synchronizes the file. Waiters observe its length
+and modification time. Length makes progress visible even on filesystems with
+coarse mtime resolution; mtime remains useful on implementations that delay
+length metadata. Heartbeat contents carry no authority and need no parser.
+
+Exclusive creation elects an owner when `in-flight.json` is absent. A partial
+or malformed record left by process death is not a cache error and cannot
+authorize data; if it remains unchanged for a full liveness window it is
+retired like a dead owner's record. A well-formed record for a different
+identity or source is an error rather than a request to steal unrelated work.
+
+## Liveness mechanism
+
+The primary mechanism is a progress heartbeat, not PID probing, an absolute
+expiry timestamp, or an advisory lock. It uses regular file create, append,
+metadata, rename, and directory synchronization operations available on local
+and network filesystems on Linux, macOS, and Windows.
+
+A waiter records the complete owner-record bytes and the heartbeat metadata,
+then starts an injectable local monotonic timer. Any observed change resets
+that timer. An owner is eligible for retirement only after one complete
+`liveness_timeout` with no observed progress. A newly arrived waiter therefore
+waits its own full liveness window even if the file's wall-clock mtime looks
+old. This deliberately trades slower dead-owner recovery for immunity to host
+clock skew, timestamp truncation, clock steps, copied directories, and a
+future-dated mtime.
+
+The owner refreshes in a background thread at `heartbeat_interval`; callers
+may also request an immediate heartbeat. The default interval is one fifth of
+the liveness window. Publication stops the heartbeat thread and checks that
+the same token is still current before committing.
+
+The existing advisory file lock is retained around short coordination
+transitions and publication. On reliable local implementations it cheaply
+serializes the final recheck/retire/create sequence and fences publication. It
+is not the liveness oracle, is not held during a download, and a waiter's
+liveness decision does not depend on the kernel reporting owner death. On a
+network mount that ignores or weakens advisory locks, exclusive creation still
+elects one marker and the immutable-entry/schema-v3 commit protocol still
+prevents torn entries. A lease protocol cannot guarantee exactly-once work
+during a partition or metadata-coherence failure; in that case redundant
+downloads or bounded timeout errors are allowed, while cache safety is not.
+
+Failure behavior is explicit:
+
+- A slow but refreshing owner remains owner. Waiters do not download.
+- A process death stops progress. After a full liveness window, one waiter
+  retires the unchanged record and competes for ownership.
+- A suspended process longer than the liveness window is treated as dead. It
+  is fenced by its token when it resumes and may not publish through the owner
+  API.
+- A heartbeat write failure marks the owner unusable. Publication returns an
+  ownership-lost error; dropping the owner attempts to release its record.
+- A transient waiter read or metadata error is returned. IO failure is not
+  silently reinterpreted as owner death.
+- A network partition can make both sides believe progress stopped. Each side
+  may fetch, but every publication is still a complete atomic schema-v3
+  transaction. After coherence returns, only `current.json` selects an entry.
+- A filesystem without the atomic create/rename and durability guarantees
+  already required by the native exact cache remains outside the native
+  durability guarantee. Heartbeats do not weaken or enlarge that guarantee.
+
+## Waiter algorithm and bounds
+
+The public options are `poll_interval`, `heartbeat_interval`,
+`liveness_timeout`, and `wait_timeout`. All are positive and the heartbeat
+interval must be shorter than the liveness timeout.
+
+Each pass performs these steps:
+
+1. Read and fully verify `current.json`. If present, return `Hit`.
+2. Read `in-flight.json` and its token-specific heartbeat fingerprint.
+3. If no marker exists, take the short transition lock, repeat steps 1 and 2,
+   and attempt exclusive marker creation. The winner returns `Owner`; losers
+   resume waiting.
+4. If the snapshot changed, reset the monotonic no-progress timer.
+5. If the snapshot is unchanged for `liveness_timeout`, take the short
+   transition lock and repeat the committed-entry and exact-snapshot checks.
+   Only an exact match may be retired. The retiring waiter then attempts
+   exclusive creation of its own record while still in that transition.
+6. Otherwise sleep for the smaller of the poll interval and the remaining
+   liveness/total-wait budget.
+
+The total wait is bounded by `wait_timeout`. An unchanged owner reaching the
+liveness threshold is considered for takeover before the total-time check, so
+equal liveness and wait deadlines do not spuriously fail. If total wait expires
+while the owner is still live, the call returns `SingleFlightTimeout`. It does
+not steal a live lease and does not tell the caller to download independently.
+Applications that deliberately want today's duplicate-download behavior can
+continue using `read`, `lock`, and `publish` without selecting single-flight.
+
+### Takeover race interleavings
+
+The difficult interleavings are handled as follows:
+
+- Two waiters see the same stale snapshot. Both request the transition lock.
+  The first rechecks, renames the exact record to a unique retired name, and
+  creates a new marker. The second then sees a different snapshot and cannot
+  retire it. If advisory locking is ineffective, exclusive creation still
+  selects one visible successor; a contender that moved a record other than
+  its observed bytes restores/abandons it and restarts without becoming owner.
+- The old owner refreshes before retirement. The heartbeat fingerprint no
+  longer matches, so retirement is rejected and the no-progress timer resets.
+- The old owner refreshes after its record was retired. The pulse is attached
+  to the old token and cannot refresh a successor. Its next explicit heartbeat
+  or publication check reports lost ownership.
+- The old owner begins publication while a waiter attempts retirement. On
+  normal local filesystems the short advisory lock orders the final token
+  check and publication against retirement. If a mount violates advisory-lock
+  exclusion, both writers can at worst publish complete immutable entries;
+  schema-v3 atomic replacement still admits no mixed entry.
+- A contender is paused after its stale recheck. On resumption it must compare
+  the record it retired with the bytes it observed. A newer token is not
+  accepted as stale. A brief marker absence can cause another contender to win
+  exclusive creation, but neither contender can publish without later proving
+  that its own token is current.
+
+Strict exactly-once execution is impossible for a filesystem lease during an
+unbounded partition or pause: choosing availability permits duplicate work,
+while choosing strict exclusion can strand the cache forever. This design
+chooses bounded recovery and token-fenced publication. In the ordinary coherent
+filesystem case, the transition recheck plus exclusive creation provides one
+owner and one download.
+
+## Crash safety and failpoints
+
+`in-flight.json` is never read as a commit record and never points at entry
+bytes. Readers continue to accept only a verified schema-v3 `current.json`.
+The existing publication ordering is unchanged: immutable files and their
+directories are synchronized before the temporary commit marker is renamed,
+and the control directory is synchronized afterward.
+
+New crash boundaries are instrumented by the existing
+`exact-cache-test-failpoints` feature:
+
+- `after_inflight_heartbeat`: initial token heartbeat is durable but no owner
+  record need exist.
+- `after_inflight_marker`: the owner record file is synchronized but its
+  directory entry may not be durable.
+- `after_inflight_sync`: the visible owner record and directory are durable.
+- `after_inflight_heartbeat_refresh`: one progress pulse is synchronized.
+- `after_inflight_retire`: the active record was renamed to a unique retired
+  name but the directory rename may not be durable.
+- `after_inflight_retire_sync`: retirement is directory-durable.
+- `after_inflight_reap`: retired owner/heartbeat files were removed but the
+  removals may not be durable.
+- `after_inflight_reap_sync`: retirement cleanup is directory-durable.
+
+Death at the first four boundaries leaves no committed change. Death during
+retirement can leave an active record, no active record, or an ignored retired
+record. If publication preceded retirement, `current.json` already selects the
+complete new entry; otherwise it still selects the old entry or is absent.
+Recovery treats remaining coordination artifacts only as liveness state. Thus
+every new boundary preserves the original invariant: old complete entry, new
+complete entry, or no entry, never a torn entry.
+
+The process-kill suite covers every listed boundary. Separate process tests
+cover a live owner/waiter handoff and dead-owner takeover. Expiry tests use an
+injectable monotonic clock; filesystem and scheduling wall time is used only
+for test-harness safety deadlines.
+
+## API and compatibility
+
+`ExactProductCache::new`, `read`, `lock`, `publish`, and
+`cleanup_abandoned` retain their signatures and behavior. The additive API is:
+
+- `ExactCacheSingleFlightOptions`, including the four bounded durations;
+- target-neutral `ExactCacheSingleFlightWait` and
+  `ExactCacheSingleFlightDecision`, which own progress, liveness, takeover,
+  and total-timeout decisions for native and browser substrates;
+- `ExactProductCache::open_single_flight(options)`;
+- `ExactCacheOpen::{Hit, Owner}`; and
+- `ExactCacheOwner::{heartbeat, publish}`.
+
+Dropping an owner abandons the attempt and best-effort releases its marker.
+Publishing consumes the owner, verifies its token, performs the unchanged
+schema-v3 commit, and retires coordination state. Code that never calls
+`open_single_flight` creates no sidecars and behaves exactly as before.
+
+The coordination representation and decision kernel use portable primitives.
+The native cache as a whole retains its existing Linux/macOS platform gate
+because schema-v3 directory durability has not yet been implemented and
+qualified on Windows. A Windows native port can reuse this single-flight
+protocol, but must first provide the pre-existing atomic publication guarantee;
+single-flight does not relax that prerequisite.
+
+### Mixed-version matrix
+
+| Participants | Committed-entry safety | Download coalescing |
+| --- | --- | --- |
+| old + old | Unchanged schema-v3 lock/commit guarantee | Only when both old callers hold the legacy lock across acquisition, as before |
+| old writer + new waiter | New code respects the old transition/publication lock and verifies schema v3 | The new waiter normally returns the old writer's commit; no sidecar is required |
+| new owner + old requester | Both publish only complete schema-v3 entries; the old code ignores sidecars safely | Not guaranteed: the old requester cannot know about the new sidecar and may download concurrently |
+| new + new | Unchanged schema-v3 safety plus token fencing | One download on coherent filesystems; bounded recovery rules apply on failure |
+| old reader + new writer | Old reader follows only unchanged `current.json` | Not applicable to reads |
+
+No new code removes or rewrites an old version's committed marker because of
+in-flight state. Old cleanup ignores the new filenames. New cleanup may remove
+only retired coordination artifacts and the heartbeat belonging to the token
+it retired. This makes the sidecar safe for rolling upgrades and downgrades.
+
+## Binding follow-up
+
+- Python adds one optional exact-cache single-flight option object/field with
+  poll, heartbeat, liveness, and total-wait durations. Its extension maps
+  `Hit` and `Owner`; acquisition and filesystem transitions stay in Rust.
+- Elixir adds the equivalent option keys in `Sidereon.GNSS.ExactCache`; the NIF
+  maps the same two outcomes and owner publication. The Elixir module adds no
+  filesystem logic.
+- C adds an options struct (size/version guarded in the normal ABI style), an
+  open result discriminant, and opaque owner heartbeat/publish/release calls.
+- WASM keeps schema-v3 `buildExactCacheCommit`/`verifyExactCacheCommit` bytes.
+  `BrowserExactProductCache` maps the open decision into one IndexedDB
+  read-write transaction: return the committed record if present, otherwise
+  create/read the in-flight object and choose owner or waiter. IndexedDB
+  serializes conflicting read-write transactions, so compare-and-swap,
+  takeover, and commit ordering are transaction outcomes; the JavaScript file
+  does not reproduce native rename races or advisory-lock reasoning. A timer
+  updates the token's heartbeat object; bounded polling passes the transaction's
+  opaque owner/heartbeat revision and browser monotonic time to core's
+  `ExactCacheSingleFlightWait`, then performs the returned wait, takeover, or
+  timeout action. JavaScript therefore owns storage/timer adaptation but no
+  liveness rules. Web Locks may remain a same-origin accelerator, not a second
+  state machine.


### PR DESCRIPTION
A waiter observes an in-flight download and blocks on the winner's committed entry instead of re-downloading - the answer to the alias-prone ultra-target pairs that currently must stay serial.

Ownership is a random 128-bit token; liveness is append-only heartbeat growth judged on each waiter's own monotonic clock (mtimes and wall clocks are diagnostic only); takeover re-verifies the marker snapshot under the existing transition lock and claims by exclusive creation; a slow live owner yields a bounded SingleFlightTimeout, never a second download. The sidecar is v3-compatible: commit encoding and current.json are byte-unchanged, and the mixed-version matrix is in docs/exact-cache-single-flight.md.

Nine new failpoint boundaries with process-kill tests, plus real-process integration tests: waiter-observes-commit-without-downloading (counting fetch stub), SIGKILLed-owner takeover after the injected liveness window with exactly one commit, and live-owner timeout without a second owner.