### PR TITLE
sp3: window-scoped continuity verdicts, next-issue due times, oracle pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sidereon is one engine: a Rust core for satellite orbit propagation, GNSS positi
 - **GNSS positioning:** single-point (SPP), RINEX observation to SPP assembly and solve helpers, public multi-epoch `static_positioning` / `solve_static` solves with covariance, leave-one-out redundancy diagnostics, and robust weighting (including one-call reference-station static: rover and reference RINEX in, station coordinate with covariance out), Doppler velocity with clock drift, RTK float and fixed (LAMBDA) with baselines built straight from raw RINEX (verified to millimeters against a published ITRF station pair), PPP float and fixed with SSR or Galileo HAS corrections driving the solve over broadcast ephemeris, static PPP with temporal-correlation covariance (calibrated day-length bounds), optional elevation cutoff, and optional tropospheric gradient estimation, DGNSS, across GPS/GLONASS/Galileo/BeiDou/QZSS, with DOP (G/P/H/V/T).
 - **Integrity and error bounds:** RAIM fault detection and exclusion, multi-constellation ARAIM (MHSS protection levels), SBAS protection levels (DO-229), classical reliability (per-observation minimal detectable bias, internal/external reliability), observability classification of every solve (rank, redundancy, conditioning), and covariance-derived error metrics (CEP, R95, drms, SEP, error ellipse) that report wide or flagged bounds for weak geometry rather than fabricated confidence, and uncertainty-aware geodesic geofencing (containment and crossing probabilities from a position covariance, with hysteresis).
 - **GNSS corrections:** SBAS message decode and correction application, RTCM SSR and Galileo HAS orbit/clock/bias correction stores with explicit provider reference-point handling, NTRIP client stream handling, and differential code biases (DCB/OSB) from Bias-SINEX and CODE products.
-- **Ephemeris and time:** broadcast and precise (SP3) ephemeris, RTCM 3 broadcast ephemeris decode for GPS (1019), GLONASS (1020), Galileo (1045/1046), BeiDou (1042), and QZSS (1044), each real-data validated, JPL SPK kernels, source-agnostic satellite state sampling across all three, batched multi-satellite interpolation, scale-aware time (UTC/TAI/TT/UT1/TDB/TCG/TCB and the GNSS system times) with leap-second handling and caller-updatable leap and UT1 tables, and Earth orientation (EOP).
+- **Ephemeris and time:** broadcast and precise (SP3) ephemeris, window-scoped continuity verdicts using the product interpolator's derived stencil reach, RTCM 3 broadcast ephemeris decode for GPS (1019), GLONASS (1020), Galileo (1045/1046), BeiDou (1042), and QZSS (1044), each real-data validated, JPL SPK kernels, source-agnostic satellite state sampling across all three, batched multi-satellite interpolation, scale-aware time (UTC/TAI/TT/UT1/TDB/TCG/TCB and the GNSS system times) with leap-second handling and caller-updatable leap and UT1 tables, and Earth orientation (EOP).
 - **Timing and clocks:** Allan-family stability analysis (ADEV/MDEV/HDEV/TDEV), power-law clock-noise identification with a five-coefficient fit (IEEE 1139), and clock comparison across products.
 - **Estimation and detection:** a covariance-weighted track filter for position fixes (no IMU required: weak-geometry fixes with wide covariances cannot spike the track) with a fixed-interval RTS smoother, scalar Kalman and alpha-beta trackers, innovation gating (NIS), MAD statistics, CFAR detection thresholds, and source localization (ToA/TDOA) from arrival times at known sensors.
 - **Geodesy and monitoring:** geodesic direct and inverse problems on the ellipsoid (Karney), an epoch-aware terrestrial reference frame catalog with published ITRF and ETRF Helmert parameter sets, station displacement corrections (solid Earth tide, pole tide, and ocean loading from caller-supplied BLQ coefficients), station velocity (MIDAS), trajectory fitting with seasonal terms and offsets, step detection, network motion fields with common-mode removal, and repeating-geometry (sidereal) filtering with coverage-aware templates.
@@ -38,8 +38,9 @@ sidereon is one engine: a Rust core for satellite orbit propagation, GNSS positi
   naming the line served), a bounded publication-status query (newest
   published issue per center and line, its archive-reported publication text,
   and its lag behind nominal - distinguishing "nothing published" from an
-  unreachable archive), and a wider ultra pool including the IGS combined
-  ultra and Wuhan's hourly MGEX NRT line. Broadcast ephemerides as the
+  unreachable archive), a network-free next-issue due-time query with exact
+  identity and observed/predicted coverage, and a wider ultra pool including
+  the IGS combined ultra and Wuhan's hourly MGEX NRT line. Broadcast ephemerides as the
   resilience floor are a recorded
   [design issue](docs/broadcast-ephemeris-resilience-floor.md).
 
@@ -72,7 +73,7 @@ The repo ships a single binary for working without writing code:
 ```text
 sidereon solve --obs rover.obs --nav brdc.nav     # SPP per epoch, bounds always shown
 sidereon qc --obs rover.obs                       # teqc-style observation quality report
-sidereon inspect FILE                             # detect and summarize RINEX/SP3/ANTEX/TLE
+sidereon inspect FILE [--window FROM THROUGH]     # summarize a file and optionally scope SP3 continuity
 sidereon metrics --enu-cov "..."                  # CEP / DRMS / R95 / ellipse from a covariance
 sidereon tui --obs rover.obs --nav brdc.nav       # replay a session in the terminal monitor
 sidereon tui --ntrip host:2101 --mount MP ...     # watch a live stream solve in real time
@@ -115,6 +116,9 @@ Every numerical routine is cross-checked against the reference implementation or
 | RTCM MSM lock-time to RINEX LLI | RTKLIB `convbin` decode of a real MSM stream | RTKLIB |
 
 The per-crate test suites document the exact references, fixtures, and tolerances.
+The [Python oracle version-pinning note](docs/oracle-version-pinning.md) records
+cross-version FITPACK and pseudo-inverse checks and the fixture-regeneration
+rules they establish.
 
 ## License
 

--- a/crates/sidereon-cli/src/main.rs
+++ b/crates/sidereon-cli/src/main.rs
@@ -9,7 +9,10 @@ use clap::{ArgGroup, Parser, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 use sidereon::antex::AntennaKind;
-use sidereon::ephemeris::{BroadcastEphemeris, Sp3};
+use sidereon::ephemeris::{
+    check_continuity, BroadcastEphemeris, ContinuityOptions, EpochWindow, OrbitClass, Sp3,
+    StencilExtent,
+};
 use sidereon::positioning::{ReceiverSolution, SolvePolicy};
 use sidereon::qc_obs::{observation_qc, render_text as render_obs_qc_text};
 use sidereon::rinex::qc::{FindingRef, LintReport, Severity};
@@ -85,6 +88,9 @@ enum Command {
     Inspect {
         /// File to inspect.
         file: PathBuf,
+        /// Inclusive evaluation window as FROM THROUGH, in product-scale seconds since J2000.
+        #[arg(long, num_args = 2, value_names = ["FROM", "THROUGH"])]
+        window: Option<Vec<f64>>,
     },
     /// Replay a RINEX OBS/NAV solve or watch a live RTCM stream.
     Tui {
@@ -168,7 +174,7 @@ fn run(cli: Cli) -> Result<()> {
             probability,
             json,
         } => metrics_command(enu_cov.as_deref(), json_file.as_deref(), probability, json),
-        Command::Inspect { file } => inspect_command(&file),
+        Command::Inspect { file, window } => inspect_command(&file, window.as_deref()),
         Command::Tui {
             obs,
             nav,
@@ -719,9 +725,19 @@ fn print_metrics_human(
     );
 }
 
-fn inspect_command(path: &Path) -> Result<()> {
+fn inspect_command(path: &Path, window: Option<&[f64]>) -> Result<()> {
     let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
     let text = std::str::from_utf8(&bytes).ok();
+
+    if let Some(endpoints) = window {
+        let [from_j2000_s, through_j2000_s] = endpoints else {
+            bail!("--window requires exactly FROM THROUGH");
+        };
+        let sp3 = load_sp3(&bytes).context("--window is available only for SP3 products")?;
+        print_inspect(InspectReport::sp3(path, &sp3));
+        print_window_continuity(&sp3, *from_j2000_s, *through_j2000_s)?;
+        return Ok(());
+    }
 
     if let Some(text) = text {
         if let Ok(obs) = parse_rinex_obs(text) {
@@ -751,6 +767,40 @@ fn inspect_command(path: &Path) -> Result<()> {
     }
 
     bail!("unrecognized file type: {}", path.display())
+}
+
+fn print_window_continuity(sp3: &Sp3, from_j2000_s: f64, through_j2000_s: f64) -> Result<()> {
+    let report = check_continuity(
+        &sp3.precise_ephemeris_samples(),
+        &ContinuityOptions::for_orbit_class(OrbitClass::MeoGnss),
+    );
+    let window = EpochWindow::new(from_j2000_s, through_j2000_s)?;
+    let stencil = StencilExtent::for_sp3(sp3)?;
+    let verdict = report.verdict_for_window(window, stencil);
+    println!(
+        "continuity: {} (defects={}, pairs_checked={}, residuals_checked={}, residuals_skipped={})",
+        if report.attested() {
+            "attested"
+        } else {
+            "defects"
+        },
+        report.defects.len(),
+        report.pairs_checked,
+        report.residuals_checked,
+        report.residuals_skipped,
+    );
+    println!(
+        "window_continuity: {} (influencing_defects={}, stencil_before_s={}, stencil_after_s={})",
+        if verdict.accepted() {
+            "accept"
+        } else {
+            "refuse"
+        },
+        verdict.influencing_defects.len(),
+        stencil.before_s(),
+        stencil.after_s(),
+    );
+    Ok(())
 }
 
 fn print_inspect(report: InspectReport) {

--- a/crates/sidereon-cli/tests/cli.rs
+++ b/crates/sidereon-cli/tests/cli.rs
@@ -163,6 +163,29 @@ fn inspect_nav_reports_compatible_time_bases_separately() {
 }
 
 #[test]
+fn inspect_sp3_window_prints_scoped_continuity_verdict() {
+    let sp3 = fixture(&["sp3", "COD0MGXFIN_20201770000_01D_05M_ORB.SP3"]);
+    let output = run(&[
+        "inspect",
+        sp3.to_str().expect("fixture path utf8"),
+        "--window",
+        "646358400",
+        "646401600",
+    ]);
+    assert!(
+        output.status.success(),
+        "status {:?}\nstderr:\n{}",
+        output.status.code(),
+        stderr(&output)
+    );
+    let stdout = stdout(&output);
+    assert!(stdout.contains("continuity: attested"), "{stdout}");
+    assert!(stdout.contains("window_continuity: accept"), "{stdout}");
+    assert!(stdout.contains("stencil_before_s=1500"), "{stdout}");
+    assert!(stdout.contains("stencil_after_s=1500"), "{stdout}");
+}
+
+#[test]
 fn qc_json_includes_lint_counts_and_qc_report() {
     let obs = fixture(&["obs", "ESBC00DNK_R_20201770000_01D_30S_MO_120epoch.rnx"]);
     let output = run(&[

--- a/crates/sidereon-core/src/data.rs
+++ b/crates/sidereon-core/src/data.rs
@@ -1328,6 +1328,14 @@ pub enum DataCatalogError {
     NoUltraIssue,
     /// No available ultra-rapid issue exists at or before the requested target.
     NoAvailableUltraIssue,
+    /// The catalog carries the product line but has no pinned nominal due-time
+    /// rule for it.
+    UnsupportedNominalSchedule {
+        /// Analysis center.
+        center: AnalysisCenter,
+        /// Product type.
+        product_type: ProductType,
+    },
     /// An archive listing body did not classify as any recognized listing
     /// dialect. Deliberately not best-effort: a silent empty parse would be
     /// indistinguishable from "nothing published".
@@ -1443,6 +1451,13 @@ impl fmt::Display for DataCatalogError {
             Self::NoAvailableUltraIssue => {
                 write!(f, "no available ultra-rapid issue at or before target")
             }
+            Self::UnsupportedNominalSchedule {
+                center,
+                product_type,
+            } => write!(
+                f,
+                "{center}/{product_type} has no nominal due-time schedule"
+            ),
             Self::UnrecognizedArchiveListing { reason } => {
                 write!(f, "unrecognized archive listing: {reason}")
             }
@@ -1653,6 +1668,56 @@ impl ProductDateTime {
     fn ordering_minutes(self) -> i64 {
         self.date.julian_day_number() * 1_440 + i64::from(self.hour) * 60 + i64::from(self.minute)
     }
+
+    fn ordering_seconds(self) -> i64 {
+        self.date.julian_day_number() * 86_400
+            + i64::from(self.hour) * 3_600
+            + i64::from(self.minute) * 60
+            + i64::from(self.second)
+    }
+}
+
+impl fmt::Display for ProductDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}T{:02}:{:02}:{:02}Z",
+            self.date, self.hour, self.minute, self.second
+        )
+    }
+}
+
+/// Half-open nominal coverage interval, `[from, until)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NominalCoverageInterval {
+    /// First covered instant.
+    pub from: ProductDateTime,
+    /// First instant not covered.
+    pub until: ProductDateTime,
+}
+
+/// Nominal observed and predicted portions of one issue.
+///
+/// Ultra-rapid SP3 identities populate both fields. Ordinary final and rapid
+/// products populate only `observed`; predicted IONEX products populate only
+/// `predicted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NominalCoverage {
+    /// Observed-data interval, when the line carries one.
+    pub observed: Option<NominalCoverageInterval>,
+    /// Predicted-data interval, when the line carries one.
+    pub predicted: Option<NominalCoverageInterval>,
+}
+
+/// The next catalog issue nominally due at or after a query instant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NominalIssue {
+    /// Exact product identity expected at the due time.
+    pub identity: ProductIdentity,
+    /// Nominal publication deadline in UTC.
+    pub due_at: ProductDateTime,
+    /// Nominal observed and predicted coverage named by the identity.
+    pub covers: NominalCoverage,
 }
 
 /// Ultra-rapid issue date and `HHMM` issue time.
@@ -3605,6 +3670,237 @@ pub fn published_issue_age_minutes(
     now: ProductDateTime,
 ) -> Result<i64, DataCatalogError> {
     Ok(now.ordering_minutes() - issue_ordering_minutes(published.date, &published.issue)?)
+}
+
+/// Return the next catalog issue nominally due at or after `now`.
+///
+/// This is a pure catalog query. It performs no listing fetch and does not say
+/// whether an archive has published the issue. The schedule rules are pinned
+/// to the IGS product descriptions, the IGS Analysis Center Coordinator
+/// schedule, and the relevant center descriptions in the committed nominal
+/// schedule provenance fixture.
+///
+/// Rules represented here:
+///
+/// - IGS combined ultra-rapid SP3 is released 27 hours after the filename's
+///   coverage start: 24 observed hours followed by the 03:00, 09:00, 15:00,
+///   or 21:00 UTC release. Analysis-center ultra products use the 26 h 50 min
+///   submission deadline. A two-day ultra identity names a 24-hour observed
+///   interval followed by a 24-hour predicted interval.
+/// - GFZ rapid SP3 and CLK use the daily 15:45 UTC analysis-center deadline for
+///   the preceding UTC day. CODE rapid IONEX uses the published less-than-24 h
+///   latency boundary, represented as 00:00 UTC following the map date.
+/// - Final SP3 and CLK lines represent the newest daily identity in each weekly
+///   batch. Analysis-center batches are due Wednesday at 05:00 UTC, 11 days
+///   after the GPS week ends. The IGS combined final batch is due by Friday,
+///   represented as 23:59:59 UTC, 13 days after the week ends. Final IONEX uses
+///   the published approximately 11-day weekly latency, with a date-only
+///   deadline represented as 23:59:59 UTC.
+/// - CODE predicted IONEX is due at 00:00 UTC one or two days before its map
+///   date, matching the line's cataloged prediction horizon.
+///
+/// Near-real-time WUM and broadcast navigation lines are outside these pinned
+/// rules and return [`DataCatalogError::UnsupportedNominalSchedule`].
+pub fn next_issue_due(
+    center: AnalysisCenter,
+    product_type: ProductType,
+    now: ProductDateTime,
+) -> Result<NominalIssue, DataCatalogError> {
+    ProductDate::new(now.date.year, now.date.month, now.date.day)?;
+    ProductDateTime::new(now.date, now.hour, now.minute, now.second)?;
+    product_convention(center, product_type)?;
+    if center == AnalysisCenter::WumNrt || product_type == ProductType::Nav {
+        return Err(DataCatalogError::UnsupportedNominalSchedule {
+            center,
+            product_type,
+        });
+    }
+
+    let mut next: Option<NominalIssue> = None;
+    for offset_days in -28_i64..=42 {
+        let Ok(identity_date) = now.date.add_days(offset_days) else {
+            continue;
+        };
+        for candidate in nominal_issues_for_date(center, product_type, identity_date)? {
+            if candidate.due_at < now {
+                continue;
+            }
+            let replace = next.as_ref().is_none_or(|current| {
+                candidate.due_at < current.due_at
+                    || (candidate.due_at == current.due_at
+                        && candidate.identity.official_filename
+                            < current.identity.official_filename)
+            });
+            if replace {
+                next = Some(candidate);
+            }
+        }
+    }
+    next.ok_or(DataCatalogError::DateOutOfRange)
+}
+
+fn nominal_issues_for_date(
+    center: AnalysisCenter,
+    product_type: ProductType,
+    identity_date: ProductDate,
+) -> Result<Vec<NominalIssue>, DataCatalogError> {
+    let solution = product_solution_class(center, product_type)?;
+    if solution == SolutionClass::Final && identity_date.gps_day_of_week()? != 6 {
+        return Ok(Vec::new());
+    }
+
+    let entry = center_catalog(center).expect("catalog entry exists for enum variant");
+    let issues: Vec<&str> = if matches!(solution, SolutionClass::UltraRapid) {
+        entry.issues.to_vec()
+    } else {
+        vec!["0000"]
+    };
+    let mut out = Vec::with_capacity(issues.len());
+    for issue in issues {
+        let issue_argument = (!entry.issues.is_empty()).then_some(issue);
+        let identity =
+            match product_identity(center, product_type, identity_date, None, issue_argument) {
+                Ok(identity) => identity,
+                Err(DataCatalogError::UnsupportedProductEra { .. }) => continue,
+                Err(error) => return Err(error),
+            };
+        let filename_epoch = ProductDateTime::new(
+            identity_date,
+            (issue_minutes(issue)? / 60) as u8,
+            (issue_minutes(issue)? % 60) as u8,
+            0,
+        )?;
+        let covers = nominal_coverage(&identity, filename_epoch)?;
+        let due_at = nominal_due_at(center, product_type, solution, filename_epoch, covers)?;
+        out.push(NominalIssue {
+            identity,
+            due_at,
+            covers,
+        });
+    }
+    Ok(out)
+}
+
+fn nominal_due_at(
+    center: AnalysisCenter,
+    product_type: ProductType,
+    solution: SolutionClass,
+    filename_epoch: ProductDateTime,
+    covers: NominalCoverage,
+) -> Result<ProductDateTime, DataCatalogError> {
+    match solution {
+        SolutionClass::UltraRapid => {
+            let observed_until = covers
+                .observed
+                .ok_or(DataCatalogError::InconsistentProductIdentity {
+                    field: "nominal_ultra_observed_coverage",
+                })?
+                .until;
+            add_product_seconds(
+                observed_until,
+                if center == AnalysisCenter::IgsUlt {
+                    3 * 3_600
+                } else {
+                    2 * 3_600 + 50 * 60
+                },
+            )
+        }
+        SolutionClass::Rapid if product_type == ProductType::Ionex => {
+            add_product_seconds(filename_epoch, 24 * 3_600)
+        }
+        SolutionClass::Rapid => {
+            add_product_seconds(filename_epoch, 24 * 3_600 + 15 * 3_600 + 45 * 60)
+        }
+        SolutionClass::Final if center == AnalysisCenter::Igs => {
+            add_product_seconds(filename_epoch, 13 * 86_400 + 23 * 3_600 + 59 * 60 + 59)
+        }
+        SolutionClass::Final if product_type == ProductType::Ionex => {
+            add_product_seconds(filename_epoch, 11 * 86_400 + 23 * 3_600 + 59 * 60 + 59)
+        }
+        SolutionClass::Final => add_product_seconds(filename_epoch, 11 * 86_400 + 5 * 3_600),
+        SolutionClass::Predicted => {
+            let horizon = center.prediction_horizon_days().ok_or(
+                DataCatalogError::UnsupportedNominalSchedule {
+                    center,
+                    product_type,
+                },
+            )?;
+            add_product_seconds(filename_epoch, -i64::from(horizon) * 86_400)
+        }
+        SolutionClass::NearRealTime | SolutionClass::Broadcast => {
+            Err(DataCatalogError::UnsupportedNominalSchedule {
+                center,
+                product_type,
+            })
+        }
+    }
+}
+
+fn nominal_coverage(
+    identity: &ProductIdentity,
+    filename_epoch: ProductDateTime,
+) -> Result<NominalCoverage, DataCatalogError> {
+    let content_offset_s = if identity.family == ProductType::Sp3 {
+        let entry = center_catalog(identity.analysis_center)
+            .expect("validated identity has a catalog entry");
+        let issue = if entry.issues.is_empty() {
+            None
+        } else {
+            identity.issue.as_deref()
+        };
+        sp3_content_start_convention(identity.analysis_center, identity.date, issue)?
+            .content_start_offset_s()
+    } else {
+        0
+    };
+    let from = add_product_seconds(filename_epoch, content_offset_s)?;
+    let duration_s = match identity.span.as_str() {
+        "01D" => 86_400,
+        "02D" => 172_800,
+        _ => {
+            return Err(DataCatalogError::InconsistentProductIdentity {
+                field: "nominal_coverage_span",
+            })
+        }
+    };
+    let until = add_product_seconds(from, duration_s)?;
+
+    if identity.solution == SolutionClass::UltraRapid && duration_s == 172_800 {
+        let split = add_product_seconds(from, 86_400)?;
+        Ok(NominalCoverage {
+            observed: Some(NominalCoverageInterval { from, until: split }),
+            predicted: Some(NominalCoverageInterval { from: split, until }),
+        })
+    } else if identity.solution == SolutionClass::Predicted {
+        Ok(NominalCoverage {
+            observed: None,
+            predicted: Some(NominalCoverageInterval { from, until }),
+        })
+    } else {
+        Ok(NominalCoverage {
+            observed: Some(NominalCoverageInterval { from, until }),
+            predicted: None,
+        })
+    }
+}
+
+fn add_product_seconds(
+    datetime: ProductDateTime,
+    seconds: i64,
+) -> Result<ProductDateTime, DataCatalogError> {
+    let total = datetime
+        .ordering_seconds()
+        .checked_add(seconds)
+        .ok_or(DataCatalogError::DateOutOfRange)?;
+    let jdn = total.div_euclid(86_400);
+    let seconds_of_day = total.rem_euclid(86_400);
+    ProductDateTime::new(
+        product_date_from_jdn(jdn)?,
+        u8::try_from(seconds_of_day / 3_600).map_err(|_| DataCatalogError::DateOutOfRange)?,
+        u8::try_from((seconds_of_day % 3_600) / 60)
+            .map_err(|_| DataCatalogError::DateOutOfRange)?,
+        u8::try_from(seconds_of_day % 60).map_err(|_| DataCatalogError::DateOutOfRange)?,
+    )
 }
 
 /// Archive listing URLs that can answer "what is the newest published issue"

--- a/crates/sidereon-core/src/ephemeris.rs
+++ b/crates/sidereon-core/src/ephemeris.rs
@@ -55,7 +55,8 @@ pub use crate::sp3::{
 };
 pub use crate::sp3::{
     check_continuity, ContinuityCheck, ContinuityDefect, ContinuityOptions, ContinuityReport,
-    OrbitClass, SpeedBound,
+    EpochWindow, OrbitClass, SpeedBound, StencilExtent, WindowContinuityDecision,
+    WindowContinuityVerdict,
 };
 pub use crate::sp3::{
     CellProvenance, CellSelection, ContributorCoverage, MergeContinuityReport,

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -33,7 +33,8 @@ use crate::frame_catalog::{
 };
 use crate::id::{GnssSatelliteId, GnssSystem};
 use crate::sp3::continuity::{
-    check_continuity, ContinuityDefect, ContinuityOptions, ContinuityReport,
+    check_continuity, ContinuityDefect, ContinuityOptions, ContinuityReport, EpochWindow,
+    StencilExtent, WindowContinuityDecision, WindowContinuityVerdict,
 };
 use crate::tolerances::WHOLE_SECOND_EPS_S;
 use crate::validate;
@@ -653,6 +654,45 @@ impl MergeContinuityReport {
             .iter()
             .filter(|violation| violation.crosses_contributors)
     }
+
+    /// Contributor-changing violations that can influence an evaluation
+    /// window through the product interpolator's stencil.
+    pub fn splices_influencing(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> Vec<&MergeContinuityViolation> {
+        self.splices()
+            .filter(|violation| violation.defect.influences(window, stencil))
+            .collect()
+    }
+
+    /// Compose defect and splice findings into one window-scoped decision.
+    ///
+    /// The decision refuses when any recorded defect influences the requested
+    /// evaluation window. Both the influencing subset and complete finding lists
+    /// remain available on the returned verdict.
+    pub fn verdict_for_window(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> WindowContinuityVerdict<'_> {
+        let influencing_defects = self.report.defects_influencing(window, stencil);
+        let influencing_splices = self.splices_influencing(window, stencil);
+        let all_splices = self.splices().collect();
+        let decision = if influencing_defects.is_empty() && influencing_splices.is_empty() {
+            WindowContinuityDecision::Accept
+        } else {
+            WindowContinuityDecision::Refuse
+        };
+        WindowContinuityVerdict {
+            decision,
+            influencing_defects,
+            influencing_splices,
+            all_defects: &self.report.defects,
+            all_splices,
+        }
+    }
 }
 
 /// Audit trail for a [`merge`].
@@ -686,6 +726,37 @@ pub struct MergeReport {
 }
 
 impl MergeReport {
+    /// Contributor-changing violations that can influence an evaluation
+    /// window, when merge continuity verification was requested.
+    ///
+    /// `None` means verification was not requested. `Some(Vec::new())` means it
+    /// ran and no recorded splice can enter the requested stencil.
+    pub fn splices_influencing(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> Option<Vec<&MergeContinuityViolation>> {
+        self.continuity
+            .as_ref()
+            .map(|report| report.splices_influencing(window, stencil))
+    }
+
+    /// Decide whether the optional continuity post-condition influences an
+    /// evaluation window.
+    ///
+    /// `None` preserves the distinction that merge continuity verification was
+    /// not requested. When present, the verdict includes the complete defect and
+    /// splice lists even when it accepts the window.
+    pub fn continuity_verdict_for_window(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> Option<WindowContinuityVerdict<'_>> {
+        self.continuity
+            .as_ref()
+            .map(|report| report.verdict_for_window(window, stencil))
+    }
+
     /// Fraction of accepted cells that were carried from a single source, in
     /// `0.0..=1.0`; `None` when no cells were accepted.
     ///

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -80,8 +80,160 @@ use crate::constants::KM_TO_M;
 use crate::id::GnssSatelliteId;
 use crate::sp3::interp::{
     instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds_from_instant,
+    NEVILLE_POINTS,
 };
 use crate::sp3::samples::PreciseEphemerisSample;
+use crate::sp3::Sp3;
+use crate::{Error, Result};
+
+/// Inclusive evaluation window on the SP3 seconds-since-J2000 axis.
+///
+/// This identifies epochs the caller intends to evaluate. Continuity findings
+/// outside the window can still influence it through the interpolation
+/// neighbourhood, which is why queries also require a [`StencilExtent`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EpochWindow {
+    from_j2000_s: f64,
+    through_j2000_s: f64,
+}
+
+impl EpochWindow {
+    /// Construct an inclusive evaluation window.
+    ///
+    /// Both endpoints must be finite and `from_j2000_s` must not be later than
+    /// `through_j2000_s`.
+    pub fn new(from_j2000_s: f64, through_j2000_s: f64) -> Result<Self> {
+        if !from_j2000_s.is_finite() || !through_j2000_s.is_finite() {
+            return Err(Error::InvalidInput(
+                "SP3 continuity window endpoints must be finite".to_string(),
+            ));
+        }
+        if from_j2000_s > through_j2000_s {
+            return Err(Error::InvalidInput(
+                "SP3 continuity window start must not follow its end".to_string(),
+            ));
+        }
+        Ok(Self {
+            from_j2000_s,
+            through_j2000_s,
+        })
+    }
+
+    /// Inclusive first evaluation epoch, seconds since J2000.
+    pub fn from_j2000_s(self) -> f64 {
+        self.from_j2000_s
+    }
+
+    /// Inclusive last evaluation epoch, seconds since J2000.
+    pub fn through_j2000_s(self) -> f64 {
+        self.through_j2000_s
+    }
+}
+
+/// Time reach of the SP3 position interpolator's sliding node stencil.
+///
+/// Construct this with [`StencilExtent::for_sp3`]. The extent is derived from
+/// the product interval and the same 11-node constant used by the position
+/// interpolator, rather than accepted as a caller-supplied duration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StencilExtent {
+    grid_origin_j2000_s: f64,
+    interval_s: f64,
+    before_s: f64,
+    after_s: f64,
+}
+
+impl StencilExtent {
+    /// Derive the interpolation reach for an SP3 product.
+    ///
+    /// The degree-10 Lagrange substrate uses 11 nodes centered on the query, so
+    /// its nominal reach is five product intervals on either side. A non-finite
+    /// or non-positive declared interval is rejected.
+    pub fn for_sp3(sp3: &Sp3) -> Result<Self> {
+        let interval_s = sp3.header.epoch_interval_s;
+        if !interval_s.is_finite() || interval_s <= 0.0 {
+            return Err(Error::InvalidInput(
+                "SP3 stencil extent requires a positive finite epoch interval".to_string(),
+            ));
+        }
+        let grid_origin_j2000_s = sp3
+            .epochs_j2000_seconds()
+            .first()
+            .copied()
+            .filter(|epoch| epoch.is_finite())
+            .ok_or_else(|| {
+                Error::InvalidInput(
+                    "SP3 stencil extent requires at least one representable epoch".to_string(),
+                )
+            })?;
+        let half_nodes = (NEVILLE_POINTS / 2) as f64;
+        let half_width_s = half_nodes * interval_s;
+        Ok(Self {
+            grid_origin_j2000_s,
+            interval_s,
+            before_s: half_width_s,
+            after_s: half_width_s,
+        })
+    }
+
+    /// Nominal reach before an evaluated epoch, seconds.
+    pub fn before_s(self) -> f64 {
+        self.before_s
+    }
+
+    /// Nominal reach after an evaluated epoch, seconds.
+    pub fn after_s(self) -> f64 {
+        self.after_s
+    }
+
+    /// Union of nominal grid nodes the interpolator can select for any query in
+    /// `window`.
+    fn influence_bounds(self, window: EpochWindow) -> (f64, f64) {
+        let pivot_at_or_before = |query: f64| {
+            self.grid_origin_j2000_s
+                + ((query - self.grid_origin_j2000_s) / self.interval_s).floor() * self.interval_s
+        };
+        (
+            pivot_at_or_before(window.from_j2000_s) - self.before_s,
+            pivot_at_or_before(window.through_j2000_s) + self.after_s,
+        )
+    }
+}
+
+/// Window-scoped continuity decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowContinuityDecision {
+    /// No recorded finding can enter an interpolation stencil for the window.
+    Accept,
+    /// At least one recorded finding can enter an interpolation stencil.
+    Refuse,
+}
+
+/// A window-scoped decision that retains both influencing and global findings.
+///
+/// `all_defects` remains available for logging findings the caller accepted
+/// around. Merge reports additionally populate `influencing_splices` and
+/// `all_splices` through their own verdict helper.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowContinuityVerdict<'a> {
+    /// Accept or refuse the requested evaluation window.
+    pub decision: WindowContinuityDecision,
+    /// Defects whose time support intersects a stencil used by the window.
+    pub influencing_defects: Vec<&'a ContinuityDefect>,
+    /// Contributor-changing violations influencing the window.
+    pub influencing_splices: Vec<&'a super::combine::MergeContinuityViolation>,
+    /// Every defect in the underlying continuity report.
+    pub all_defects: &'a [ContinuityDefect],
+    /// Every contributor-changing violation in the merge report.
+    pub all_splices: Vec<&'a super::combine::MergeContinuityViolation>,
+}
+
+impl WindowContinuityVerdict<'_> {
+    /// Whether the requested window is accepted.
+    pub fn accepted(&self) -> bool {
+        self.decision == WindowContinuityDecision::Accept
+    }
+}
 
 /// Orbit class supplying a physical earth-fixed displacement bound.
 ///
@@ -243,6 +395,37 @@ impl ContinuityDefect {
             | Self::HoldOutResidual { sat, .. } => *sat,
         }
     }
+
+    /// Whether this finding can enter any interpolation stencil used by the
+    /// evaluation window.
+    pub(super) fn influences(&self, window: EpochWindow, stencil: StencilExtent) -> bool {
+        let (needed_from, needed_through) = stencil.influence_bounds(window);
+        let support = match self {
+            Self::DuplicateEpoch { epoch_j2000_s, .. } => Some((*epoch_j2000_s, *epoch_j2000_s)),
+            Self::SingleSampleSeries { .. } => None,
+            Self::SpeedBound {
+                from_j2000_s,
+                to_j2000_s,
+                ..
+            } => Some((from_j2000_s.min(*to_j2000_s), from_j2000_s.max(*to_j2000_s))),
+            Self::HoldOutResidual {
+                epoch_j2000_s,
+                preceding_j2000_s,
+                ..
+            } => Some((
+                epoch_j2000_s.min(*preceding_j2000_s),
+                epoch_j2000_s.max(*preceding_j2000_s),
+            )),
+        };
+
+        match support {
+            Some((from, through)) => from <= needed_through && through >= needed_from,
+            // The existing variant has no epoch. Querying the existing report
+            // must therefore treat it conservatively rather than invent a
+            // location or hide an unresolved input defect.
+            None => true,
+        }
+    }
 }
 
 /// Which check produced a defect, for callers filtering a report.
@@ -293,6 +476,46 @@ impl ContinuityReport {
             };
             source == check
         })
+    }
+
+    /// Findings that can influence evaluation in `window` through `stencil`.
+    ///
+    /// This filters the existing report. It does not rerun continuity checks or
+    /// alter their defaults. A [`ContinuityDefect::SingleSampleSeries`] has no
+    /// stored epoch, so it conservatively influences every window.
+    pub fn defects_influencing(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> Vec<&ContinuityDefect> {
+        self.defects
+            .iter()
+            .filter(|defect| defect.influences(window, stencil))
+            .collect()
+    }
+
+    /// Decide whether recorded defects can influence an evaluation window.
+    ///
+    /// The full report remains available in [`WindowContinuityVerdict::all_defects`]
+    /// whether the result accepts or refuses the window.
+    pub fn verdict_for_window(
+        &self,
+        window: EpochWindow,
+        stencil: StencilExtent,
+    ) -> WindowContinuityVerdict<'_> {
+        let influencing_defects = self.defects_influencing(window, stencil);
+        let decision = if influencing_defects.is_empty() {
+            WindowContinuityDecision::Accept
+        } else {
+            WindowContinuityDecision::Refuse
+        };
+        WindowContinuityVerdict {
+            decision,
+            influencing_defects,
+            influencing_splices: Vec::new(),
+            all_defects: &self.defects,
+            all_splices: Vec::new(),
+        }
     }
 }
 

--- a/crates/sidereon-core/src/sp3/mod.rs
+++ b/crates/sidereon-core/src/sp3/mod.rs
@@ -1523,7 +1523,8 @@ pub use combine::{
 };
 pub use continuity::{
     check_continuity, ContinuityCheck, ContinuityDefect, ContinuityOptions, ContinuityReport,
-    OrbitClass, SpeedBound,
+    EpochWindow, OrbitClass, SpeedBound, StencilExtent, WindowContinuityDecision,
+    WindowContinuityVerdict,
 };
 pub use exact::{
     parse_exact_sp3, validate_exact_sp3, ExactSp3Coverage, ExactSp3Request, ExactSp3ValidationError,

--- a/crates/sidereon-core/tests/fixtures/data/nominal_issue_schedule_provenance.json
+++ b/crates/sidereon-core/tests/fixtures/data/nominal_issue_schedule_provenance.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "recorded_at_utc": "2026-08-21",
+  "retrieval": {
+    "tool": "curl 8.7.1",
+    "digest_tool": "shasum -a 256"
+  },
+  "sources": [
+    {
+      "name": "IGS products",
+      "url": "https://igs.org/products/",
+      "sha256": "6b9d6b0b84da060144277edcdcc83bd137c475eb53342c9044625e298fbf4732",
+      "supports": [
+        "IGS combined ultra releases at 03:00, 09:00, 15:00, and 21:00 UTC",
+        "ultra products contain 24 observed hours followed by 24 predicted hours",
+        "IGS rapid products release at about 17:00 UTC after the previous day",
+        "IGS final products are available weekly by Friday",
+        "rapid IONEX latency is less than 24 hours",
+        "final IONEX latency is approximately 11 days and updates weekly"
+      ]
+    },
+    {
+      "name": "IGS Analysis Center Coordinator schedule",
+      "url": "https://acc.igs.org/skeds.html",
+      "sha256": "c3240f0829a2e93d763d3c58a0baccea9884fa720c04c593c2fb482ea32e92bf",
+      "supports": [
+        "ultra analysis-center deadline is 02:50 UTC for each 00, 06, 12, or 18 session",
+        "rapid analysis-center deadline is 15:45 UTC daily",
+        "final analysis-center deadline is Wednesday 05:00 UTC, 11 days after GPS week end",
+        "IGS combined final delivery is Friday, 13 days after GPS week end"
+      ]
+    },
+    {
+      "name": "CODE analysis-center description",
+      "url": "https://files.igs.org/pub/center/analysis/code.acn",
+      "sha256": "9fd573cb746bc0ce7f37796139d58eb7be4b4805cdbe65fa3bb943b899b3b6a1",
+      "supports": [
+        "CODE publishes final daily SP3, CLK, and IONEX products",
+        "CODE publishes rapid and ultra-rapid product series"
+      ]
+    },
+    {
+      "name": "GFZ analysis-center description",
+      "url": "https://files.igs.org/pub/center/analysis/gfz.acn",
+      "sha256": "21e21fa35bf2149bf0fb14474713922694919ac2f4ebe71370eb2ef46ac600c1",
+      "supports": [
+        "GFZ publishes daily rapid SP3 and CLK products",
+        "GFZ ultra-rapid SP3 is generated every three hours"
+      ]
+    },
+    {
+      "name": "ESA analysis-center description",
+      "url": "https://files.igs.org/pub/center/analysis/esa.acn",
+      "sha256": "ba36e392a289fa0d33f38b790a9bf5bcf44545c9186de69e3a8cdf578a48c3d4",
+      "supports": [
+        "ESA publishes seven daily final SP3 and CLK files per GPS week",
+        "ESA ultra-rapid issues use 00, 06, 12, and 18 sessions"
+      ]
+    },
+    {
+      "name": "GFZ MGEX analysis-center description",
+      "url": "https://files.igs.org/pub/center/analysis/GFZ0MGXFIN.acn",
+      "sha256": "289adae81ca9062a7a9931dcbb0a391b7723ab09db4729a00d1525e6da258954",
+      "supports": [
+        "GFZ MGEX rapid products include daily SP3 and CLK files"
+      ]
+    }
+  ],
+  "deterministic_resolutions": [
+    "A weekly final batch is represented by its newest daily identity, the Saturday file.",
+    "IGS combined final date-only Friday delivery is represented as Friday 23:59:59 UTC.",
+    "Final IONEX approximately 11-day date-only latency is represented as the due date at 23:59:59 UTC.",
+    "Rapid IONEX less-than-24-hour latency is represented by the following 00:00 UTC boundary.",
+    "CODE predicted IONEX is due at 00:00 UTC one or two days before the map date, matching its catalog horizon.",
+    "WUM near-real-time and broadcast navigation have no schedule rule in this fixture."
+  ]
+}

--- a/crates/sidereon-core/tests/nominal_issue_schedule.rs
+++ b/crates/sidereon-core/tests/nominal_issue_schedule.rs
@@ -1,0 +1,188 @@
+//! Network-free nominal issue scheduling pinned to published IGS and analysis
+//! center descriptions.
+//!
+//! The source URLs, access date, retrieval tool, exact digests, and deterministic
+//! resolution of date-only publication statements are committed in
+//! `tests/fixtures/data/nominal_issue_schedule_provenance.json`.
+
+use sidereon_core::data::{
+    next_issue_due, AnalysisCenter, DataCatalogError, NominalCoverageInterval, ProductDate,
+    ProductDateTime, ProductType,
+};
+
+fn date(year: i32, month: u8, day: u8) -> ProductDate {
+    ProductDate::new(year, month, day).expect("valid test date")
+}
+
+fn at(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> ProductDateTime {
+    ProductDateTime::new(date(year, month, day), hour, minute, second).expect("valid test instant")
+}
+
+#[test]
+fn nominal_schedule_provenance_pins_tools_sources_and_digests() {
+    let fixture = include_str!("fixtures/data/nominal_issue_schedule_provenance.json");
+    let provenance: serde_json::Value = serde_json::from_str(fixture).expect("provenance JSON");
+    assert_eq!(provenance["schema_version"], 1);
+    assert_eq!(provenance["recorded_at_utc"], "2026-08-21");
+    assert_eq!(provenance["retrieval"]["tool"], "curl 8.7.1");
+    let sources = provenance["sources"].as_array().expect("source array");
+    assert_eq!(sources.len(), 6);
+    assert!(sources.iter().all(|source| {
+        source["url"]
+            .as_str()
+            .is_some_and(|url| url.starts_with("https://"))
+            && source["sha256"]
+                .as_str()
+                .is_some_and(|digest| digest.len() == 64)
+    }));
+}
+
+#[test]
+fn ultra_due_boundary_names_the_observed_and_predicted_halves() {
+    let before = next_issue_due(
+        AnalysisCenter::IgsUlt,
+        ProductType::Sp3,
+        at(2026, 8, 4, 2, 59, 59),
+    )
+    .expect("IGS ultra schedule");
+    assert_eq!(before.identity.date, date(2026, 8, 3));
+    assert_eq!(before.identity.issue.as_deref(), Some("0000"));
+    assert_eq!(before.due_at, at(2026, 8, 4, 3, 0, 0));
+    assert_eq!(
+        before.covers.observed,
+        Some(NominalCoverageInterval {
+            from: at(2026, 8, 3, 0, 0, 0),
+            until: at(2026, 8, 4, 0, 0, 0),
+        })
+    );
+    assert_eq!(
+        before.covers.predicted,
+        Some(NominalCoverageInterval {
+            from: at(2026, 8, 4, 0, 0, 0),
+            until: at(2026, 8, 5, 0, 0, 0),
+        })
+    );
+
+    let after = next_issue_due(
+        AnalysisCenter::IgsUlt,
+        ProductType::Sp3,
+        at(2026, 8, 4, 3, 0, 1),
+    )
+    .expect("next IGS ultra issue");
+    assert_eq!(after.identity.date, date(2026, 8, 3));
+    assert_eq!(after.identity.issue.as_deref(), Some("0600"));
+    assert_eq!(after.due_at, at(2026, 8, 4, 9, 0, 0));
+
+    let code = next_issue_due(
+        AnalysisCenter::CodUlt,
+        ProductType::Sp3,
+        at(2026, 8, 4, 2, 49, 59),
+    )
+    .expect("CODE archived ultra schedule");
+    assert_eq!(code.identity.issue.as_deref(), Some("0000"));
+    assert!(code.covers.observed.is_some());
+    assert!(
+        code.covers.predicted.is_none(),
+        "the cataloged dated CODE issue is its one-day archived product"
+    );
+}
+
+#[test]
+fn rapid_due_boundary_advances_across_the_utc_day() {
+    let before = next_issue_due(
+        AnalysisCenter::Gfz,
+        ProductType::Clk,
+        at(2026, 8, 4, 15, 44, 59),
+    )
+    .expect("GFZ rapid schedule");
+    assert_eq!(before.identity.date, date(2026, 8, 3));
+    assert_eq!(before.due_at, at(2026, 8, 4, 15, 45, 0));
+
+    let after = next_issue_due(
+        AnalysisCenter::Gfz,
+        ProductType::Clk,
+        at(2026, 8, 4, 15, 45, 1),
+    )
+    .expect("next GFZ rapid issue");
+    assert_eq!(after.identity.date, date(2026, 8, 4));
+    assert_eq!(after.due_at, at(2026, 8, 5, 15, 45, 0));
+}
+
+#[test]
+fn final_due_boundary_advances_over_a_gps_week_rollover() {
+    let issue_date = ProductDate::from_gps_week_day(2430, 6).expect("week 2430 Saturday");
+    assert_eq!(issue_date, date(2026, 8, 8));
+
+    let before = next_issue_due(
+        AnalysisCenter::Igs,
+        ProductType::Sp3,
+        at(2026, 8, 21, 23, 59, 58),
+    )
+    .expect("IGS final schedule");
+    assert_eq!(before.identity.date, issue_date);
+    assert_eq!(before.due_at, at(2026, 8, 21, 23, 59, 59));
+
+    let after = next_issue_due(
+        AnalysisCenter::Igs,
+        ProductType::Sp3,
+        at(2026, 8, 22, 0, 0, 0),
+    )
+    .expect("next IGS final batch");
+    assert_eq!(after.identity.date, date(2026, 8, 15));
+    assert_eq!(after.identity.date.gps_week().unwrap(), 2431);
+    assert_eq!(after.due_at, at(2026, 8, 28, 23, 59, 59));
+}
+
+#[test]
+fn predicted_ionex_due_time_tracks_each_catalog_horizon() {
+    let now = at(2026, 8, 3, 23, 59, 59);
+    let p1 = next_issue_due(AnalysisCenter::CodPrd1, ProductType::Ionex, now)
+        .expect("one-day prediction schedule");
+    let p2 = next_issue_due(AnalysisCenter::CodPrd2, ProductType::Ionex, now)
+        .expect("two-day prediction schedule");
+    assert_eq!(p1.due_at, at(2026, 8, 4, 0, 0, 0));
+    assert_eq!(p2.due_at, at(2026, 8, 4, 0, 0, 0));
+    assert_eq!(p1.identity.date, date(2026, 8, 5));
+    assert_eq!(p2.identity.date, date(2026, 8, 6));
+    assert!(p1.covers.observed.is_none());
+    assert!(p1.covers.predicted.is_some());
+    assert!(p2.covers.observed.is_none());
+    assert!(p2.covers.predicted.is_some());
+}
+
+#[test]
+fn every_requested_catalog_line_has_a_network_free_due_query() {
+    let now = at(2026, 8, 4, 7, 8, 0);
+    let lines = [
+        (AnalysisCenter::Igs, ProductType::Sp3),
+        (AnalysisCenter::Esa, ProductType::Sp3),
+        (AnalysisCenter::Esa, ProductType::Clk),
+        (AnalysisCenter::Esa, ProductType::Ionex),
+        (AnalysisCenter::Cod, ProductType::Sp3),
+        (AnalysisCenter::Cod, ProductType::Clk),
+        (AnalysisCenter::Cod, ProductType::Ionex),
+        (AnalysisCenter::Gfz, ProductType::Sp3),
+        (AnalysisCenter::Gfz, ProductType::Clk),
+        (AnalysisCenter::IgsUlt, ProductType::Sp3),
+        (AnalysisCenter::CodUlt, ProductType::Sp3),
+        (AnalysisCenter::EsaUlt, ProductType::Sp3),
+        (AnalysisCenter::GfzUlt, ProductType::Sp3),
+        (AnalysisCenter::CodRap, ProductType::Ionex),
+        (AnalysisCenter::CodPrd1, ProductType::Ionex),
+        (AnalysisCenter::CodPrd2, ProductType::Ionex),
+    ];
+    for (center, product_type) in lines {
+        let issue = next_issue_due(center, product_type, now)
+            .unwrap_or_else(|error| panic!("{center}/{product_type}: {error}"));
+        assert!(issue.due_at >= now, "{center}/{product_type}");
+        issue.identity.validate().expect("catalog identity");
+    }
+
+    assert!(matches!(
+        next_issue_due(AnalysisCenter::WumNrt, ProductType::Sp3, now),
+        Err(DataCatalogError::UnsupportedNominalSchedule {
+            center: AnalysisCenter::WumNrt,
+            product_type: ProductType::Sp3,
+        })
+    ));
+}

--- a/crates/sidereon-core/tests/sp3_window_continuity.rs
+++ b/crates/sidereon-core/tests/sp3_window_continuity.rs
@@ -1,0 +1,178 @@
+//! Window-scoped continuity over a real daily SP3 product and a writer-derived
+//! consecutive day.
+//!
+//! Primary fixture provenance:
+//! `COD0MGXFIN_20201770000_01D_05M_ORB.SP3`, public CODE MGEX final product,
+//! 2020-06-25, retained from the repository's established IGS fixture set.
+//! Canonical archive: `https://cddis.nasa.gov/archive/gnss/products/mgex/2111/`.
+//! Committed bytes: SHA-256
+//! `54b70fa009a840ecf8cec25fbd4d749c9aaef7c95bdf463484e115f74d802215`.
+//! Verified with `shasum -a 256` on 2026-08-21.
+//!
+//! No consecutive daily pair is committed. Only the seam-injection test makes
+//! a second day: it clones the real product, advances every public epoch and
+//! line-2 day field by 86,400 seconds, serializes through [`Sp3::to_sp3_string`],
+//! and reparses it. No derived file is treated as an external continuity oracle.
+
+use sidereon_core::astro::time::civil::split_julian_date_add_seconds;
+use sidereon_core::astro::time::model::{InstantRepr, JulianDateSplit};
+use sidereon_core::ephemeris::{
+    check_continuity, merge, ContinuityDefect, ContinuityOptions, ContinuityReport, EpochWindow,
+    MergeCombine, MergeContinuityReport, MergeContinuityViolation, MergeOptions,
+    MergePrecedenceScope, OrbitClass, Sp3, StencilExtent, WindowContinuityDecision,
+};
+
+const DAY_S: f64 = 86_400.0;
+
+fn real_daily_product() -> Sp3 {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/sp3/COD0MGXFIN_20201770000_01D_05M_ORB.SP3");
+    let bytes = std::fs::read(path).expect("read committed CODE final product");
+    Sp3::parse(&bytes).expect("parse committed CODE final product")
+}
+
+fn writer_derived_next_day(product: &Sp3) -> Sp3 {
+    let mut shifted = product.clone();
+    for epoch in &mut shifted.epochs {
+        match &mut epoch.repr {
+            InstantRepr::JulianDate(split) => {
+                let (jd_whole, fraction) =
+                    split_julian_date_add_seconds(split.jd_whole, split.fraction, DAY_S);
+                *split = JulianDateSplit::new(jd_whole, fraction).expect("shifted split epoch");
+            }
+            InstantRepr::Nanos(nanos) => *nanos += 86_400_000_000_000_i128,
+        }
+    }
+    shifted.header.seconds_of_week += DAY_S;
+    if shifted.header.seconds_of_week >= 604_800.0 {
+        shifted.header.seconds_of_week -= 604_800.0;
+        shifted.header.gnss_week += 1;
+    }
+    shifted.header.mjd += 1;
+
+    Sp3::parse(shifted.to_sp3_string().as_bytes()).expect("reparse writer-derived next day")
+}
+
+fn precedence_options() -> MergeOptions {
+    let mut options = MergeOptions::default();
+    options.combine = MergeCombine::Precedence;
+    options.precedence_scope = MergePrecedenceScope::Cell;
+    options.min_agree = 1;
+    options
+}
+
+#[test]
+fn real_product_window_query_preserves_global_attestation() {
+    let product = real_daily_product();
+    let epochs = product.epochs_j2000_seconds();
+    let report = check_continuity(
+        &product.precise_ephemeris_samples(),
+        &ContinuityOptions::for_orbit_class(OrbitClass::MeoGnss),
+    );
+    assert!(report.attested(), "real product must attest globally");
+
+    let window = EpochWindow::new(epochs[72], epochs[216]).expect("daytime window");
+    let stencil = StencilExtent::for_sp3(&product).expect("product stencil");
+    let verdict = report.verdict_for_window(window, stencil);
+
+    assert_eq!(verdict.decision, WindowContinuityDecision::Accept);
+    assert!(verdict.influencing_defects.is_empty());
+    assert!(verdict.all_defects.is_empty());
+}
+
+#[test]
+fn merged_daily_window_verdict_flips_when_the_stencil_reaches_the_seam() {
+    let first = real_daily_product();
+    let second = writer_derived_next_day(&first);
+    let first_epochs = first.epochs_j2000_seconds();
+    let seam = *first_epochs.last().expect("first-day terminal epoch");
+    let sat = first.satellites()[0];
+
+    let (merged, mut merge_report) =
+        merge(&[first, second], &precedence_options()).expect("merge consecutive daily products");
+    assert!(
+        merged.epochs_j2000_seconds().first().copied().unwrap() < seam
+            && merged.epochs_j2000_seconds().last().copied().unwrap() > seam,
+        "merged product must cover both sides of the seam"
+    );
+
+    let defect = ContinuityDefect::SpeedBound {
+        sat,
+        from_j2000_s: seam,
+        to_j2000_s: seam + merged.header.epoch_interval_s,
+        interval_s: merged.header.epoch_interval_s,
+        displacement_m: 3_000_000.0,
+        implied_speed_m_s: 10_000.0,
+        bound_m_s: 6_000.0,
+    };
+    merge_report.continuity = Some(MergeContinuityReport {
+        report: ContinuityReport {
+            defects: vec![defect.clone()],
+            ..ContinuityReport::default()
+        },
+        violations: vec![MergeContinuityViolation {
+            defect,
+            from_sources: vec![0],
+            to_sources: vec![1],
+            crosses_contributors: true,
+        }],
+    });
+
+    let stencil = StencilExtent::for_sp3(&merged).expect("merged-product stencil");
+    assert_eq!(merged.header.epoch_interval_s, 300.0);
+    assert_eq!(stencil.before_s(), 1_500.0);
+    assert_eq!(stencil.after_s(), 1_500.0);
+
+    let inside_one_day =
+        EpochWindow::new(seam - 18.0 * 3_600.0, seam - 6.0 * 3_600.0).expect("inside-day window");
+    let inside_verdict = merge_report
+        .continuity_verdict_for_window(inside_one_day, stencil)
+        .expect("injected continuity report");
+    assert_eq!(inside_verdict.decision, WindowContinuityDecision::Accept);
+    assert!(inside_verdict.influencing_defects.is_empty());
+    assert_eq!(inside_verdict.all_defects.len(), 1);
+    assert_eq!(inside_verdict.all_splices.len(), 1);
+
+    let straddles = EpochWindow::new(seam - 600.0, seam + 600.0).expect("straddling window");
+    let straddling_verdict = merge_report
+        .continuity_verdict_for_window(straddles, stencil)
+        .expect("injected continuity report");
+    assert_eq!(
+        straddling_verdict.decision,
+        WindowContinuityDecision::Refuse
+    );
+    assert_eq!(straddling_verdict.influencing_defects.len(), 1);
+    assert_eq!(straddling_verdict.influencing_splices.len(), 1);
+
+    let reaches_seam = EpochWindow::new(seam - 7_200.0, seam - stencil.after_s())
+        .expect("half-width boundary window");
+    assert_eq!(
+        merge_report
+            .continuity_verdict_for_window(reaches_seam, stencil)
+            .expect("injected continuity report")
+            .decision,
+        WindowContinuityDecision::Refuse,
+        "an inclusive window whose stencil reaches the seam must refuse"
+    );
+
+    let misses_seam = EpochWindow::new(seam - 7_200.0, seam - stencil.after_s() - 0.001)
+        .expect("outside-stencil window");
+    assert_eq!(
+        merge_report
+            .continuity_verdict_for_window(misses_seam, stencil)
+            .expect("injected continuity report")
+            .decision,
+        WindowContinuityDecision::Accept,
+        "moving one millisecond beyond the derived stencil must accept"
+    );
+}
+
+#[test]
+fn window_and_stencil_constructors_reject_invalid_axes() {
+    assert!(EpochWindow::new(f64::NAN, 1.0).is_err());
+    assert!(EpochWindow::new(2.0, 1.0).is_err());
+
+    let mut product = real_daily_product();
+    product.header.epoch_interval_s = 0.0;
+    assert!(StencilExtent::for_sp3(&product).is_err());
+}

--- a/crates/sidereon-scoreboard/src/lib.rs
+++ b/crates/sidereon-scoreboard/src/lib.rs
@@ -20,9 +20,9 @@ use sidereon_core::astro::propagator::ForceModelKind;
 use sidereon_core::astro::time::civil::civil_from_j2000_seconds;
 use sidereon_core::constants::{J2000_JD, SECONDS_PER_DAY};
 use sidereon_core::data::{
-    newest_published_product, parse_archive_listing, publication_listing_urls,
-    published_issue_age_minutes, AnalysisCenter, DataCatalogError, ProductDate, ProductDateTime,
-    ProductType, PublishedProduct,
+    newest_published_product, next_issue_due, parse_archive_listing, publication_listing_urls,
+    published_issue_age_minutes, AnalysisCenter, DataCatalogError, NominalIssue, ProductDate,
+    ProductDateTime, ProductType, PublishedProduct,
 };
 use sidereon_core::ephemeris::{
     fit_precise_ephemeris_sample_orbit, fit_precise_ephemeris_state_sample_orbit, parse_exact_sp3,
@@ -516,6 +516,10 @@ pub enum PublicationStatusOutcome {
         /// Whole minutes from the published issue's nominal epoch to the
         /// caller's query instant - the "N hours behind nominal" number.
         behind_nominal_minutes: i64,
+        /// Next issue nominally due for this line, computed without a network
+        /// query from the same catalog identity rules. `None` means the catalog
+        /// carries the line without a pinned nominal schedule.
+        next_issue: Option<Box<NominalIssue>>,
     },
     /// Every listing answered, and none of them holds an object of this
     /// line: the archive is reachable but has published nothing in the
@@ -589,10 +593,16 @@ pub fn publication_status(
                 };
                 if let Some(product) = newest_published_product(center, product_type, &objects)? {
                     let behind_nominal_minutes = published_issue_age_minutes(&product, now)?;
+                    let next_issue = match next_issue_due(center, product_type, now) {
+                        Ok(issue) => Some(Box::new(issue)),
+                        Err(DataCatalogError::UnsupportedNominalSchedule { .. }) => None,
+                        Err(error) => return Err(error.into()),
+                    };
                     return Ok(PublicationStatusOutcome::Published {
                         product,
                         listing_url: listing_url.clone(),
                         behind_nominal_minutes,
+                        next_issue,
                     });
                 }
             }

--- a/crates/sidereon-scoreboard/src/main.rs
+++ b/crates/sidereon-scoreboard/src/main.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
+use sidereon_core::data::{AnalysisCenter, NominalCoverageInterval, ProductDateTime, ProductType};
 use sidereon_scoreboard::{
-    default_lookback_days, parse_product_date, report_json_pretty, run_default, utc_today,
-    write_report_outputs, ScoreboardError,
+    default_lookback_days, parse_product_date, publication_status, report_json_pretty, run_default,
+    utc_today, write_report_outputs, HttpsListingFetcher, PublicationStatusOutcome,
+    ScoreboardError,
 };
 
 fn main() {
@@ -14,6 +16,25 @@ fn main() {
 
 fn run() -> Result<(), ScoreboardError> {
     let cli = Cli::parse()?;
+    if let Some((center, product_type)) = cli.publication_status {
+        let at = cli.at.as_deref().ok_or_else(|| {
+            ScoreboardError::InvalidArgument(
+                "--publication-status requires --at YYYY-MM-DDTHH:MM:SSZ".to_string(),
+            )
+        })?;
+        let now = parse_product_datetime(at)?;
+        let outcome = publication_status(center, product_type, now, &HttpsListingFetcher)?;
+        print!(
+            "{}",
+            render_publication_status(center, product_type, &outcome)
+        );
+        return Ok(());
+    }
+    if cli.at.is_some() {
+        return Err(ScoreboardError::InvalidArgument(
+            "--at requires --publication-status".to_string(),
+        ));
+    }
     let date = match cli.date {
         Some(value) => parse_product_date(&value)?,
         None => utc_today()?,
@@ -30,6 +51,8 @@ struct Cli {
     history: Option<PathBuf>,
     date: Option<String>,
     lookback_days: u32,
+    publication_status: Option<(AnalysisCenter, ProductType)>,
+    at: Option<String>,
 }
 
 impl Cli {
@@ -38,6 +61,8 @@ impl Cli {
         let mut history = Some(PathBuf::from("history.jsonl"));
         let mut date = None;
         let mut lookback_days = default_lookback_days();
+        let mut publication_status = None;
+        let mut at = None;
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
             match arg.as_str() {
@@ -53,6 +78,14 @@ impl Cli {
                             )
                         })?;
                 }
+                "--publication-status" => {
+                    let center = next_string(&mut args, "--publication-status CENTER")?
+                        .parse::<AnalysisCenter>()?;
+                    let product_type = next_string(&mut args, "--publication-status PRODUCT")?
+                        .parse::<ProductType>()?;
+                    publication_status = Some((center, product_type));
+                }
+                "--at" => at = Some(next_string(&mut args, "--at")?),
                 "--stdout-only" => {
                     output = None;
                     history = None;
@@ -73,6 +106,8 @@ impl Cli {
             history,
             date,
             lookback_days,
+            publication_status,
+            at,
         })
     }
 }
@@ -94,6 +129,130 @@ fn next_string(
 
 fn print_help() {
     println!(
-        "Usage: sidereon-scoreboard [--output latest.json] [--history history.jsonl] [--date YYYY-MM-DD] [--lookback-days N] [--stdout-only]"
+        "Usage: sidereon-scoreboard [--output latest.json] [--history history.jsonl] [--date YYYY-MM-DD] [--lookback-days N] [--stdout-only]\n       sidereon-scoreboard --publication-status CENTER PRODUCT --at YYYY-MM-DDTHH:MM:SSZ"
     );
+}
+
+fn parse_product_datetime(value: &str) -> Result<ProductDateTime, ScoreboardError> {
+    let (date_text, time_text) = value
+        .split_once('T')
+        .ok_or_else(|| ScoreboardError::InvalidArgument("datetime must contain T".to_string()))?;
+    let time_text = time_text
+        .strip_suffix('Z')
+        .ok_or_else(|| ScoreboardError::InvalidArgument("datetime must end in Z".to_string()))?;
+    let mut parts = time_text.split(':');
+    let hour = parse_time_part(parts.next(), "hour")?;
+    let minute = parse_time_part(parts.next(), "minute")?;
+    let second = parse_time_part(parts.next(), "second")?;
+    if parts.next().is_some() {
+        return Err(ScoreboardError::InvalidArgument(
+            "datetime has extra time fields".to_string(),
+        ));
+    }
+    ProductDateTime::new(parse_product_date(date_text)?, hour, minute, second)
+        .map_err(ScoreboardError::from)
+}
+
+fn parse_time_part(value: Option<&str>, name: &str) -> Result<u8, ScoreboardError> {
+    value
+        .ok_or_else(|| ScoreboardError::InvalidArgument(format!("datetime missing {name}")))?
+        .parse::<u8>()
+        .map_err(|_| ScoreboardError::InvalidArgument(format!("datetime {name} is invalid")))
+}
+
+fn render_publication_status(
+    center: AnalysisCenter,
+    product_type: ProductType,
+    outcome: &PublicationStatusOutcome,
+) -> String {
+    let mut output = format!("line: {center}/{product_type}\n");
+    match outcome {
+        PublicationStatusOutcome::Published {
+            product,
+            listing_url,
+            behind_nominal_minutes,
+            next_issue,
+        } => {
+            output.push_str(&format!(
+                "published: {}\nlisting_url: {}\nlag_minutes: {}\n",
+                product.filename, listing_url, behind_nominal_minutes,
+            ));
+            if let Some(next_issue) = next_issue {
+                output.push_str(&format!(
+                    "next_due: {}\nnext_identity: {}\n",
+                    next_issue.due_at, next_issue.identity.official_filename,
+                ));
+                if let Some(interval) = next_issue.covers.observed {
+                    output.push_str(&render_coverage("next_observed", interval));
+                }
+                if let Some(interval) = next_issue.covers.predicted {
+                    output.push_str(&render_coverage("next_predicted", interval));
+                }
+            } else {
+                output.push_str("next_due: unavailable (nominal schedule not cataloged)\n");
+            }
+        }
+        PublicationStatusOutcome::NothingPublished { listing_urls } => {
+            output.push_str(&format!(
+                "status: nothing_published\nlisting_urls: {}\n",
+                listing_urls.join(",")
+            ));
+        }
+        PublicationStatusOutcome::Unreachable {
+            listing_url,
+            reason,
+        } => output.push_str(&format!(
+            "status: unreachable\nlisting_url: {listing_url}\nreason: {reason}\n"
+        )),
+    }
+    output
+}
+
+fn render_coverage(label: &str, interval: NominalCoverageInterval) -> String {
+    format!("{label}: {} through {}\n", interval.from, interval.until)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sidereon_core::data::{next_issue_due, ProductDate, PublishedProduct};
+
+    #[test]
+    fn publication_status_output_places_next_due_beside_lag() {
+        let date = ProductDate::new(2026, 8, 4).unwrap();
+        let now = ProductDateTime::new(date, 7, 8, 0).unwrap();
+        let next_issue = next_issue_due(AnalysisCenter::GfzUlt, ProductType::Sp3, now).unwrap();
+        let outcome = PublicationStatusOutcome::Published {
+            product: PublishedProduct {
+                date: ProductDate::new(2026, 8, 3).unwrap(),
+                issue: "0300".to_string(),
+                filename: "GFZ0OPSULT_20262150300_02D_05M_ORB.SP3".to_string(),
+                observed_at: Some("2026-08-04 08:20".to_string()),
+            },
+            listing_url: "https://example.invalid/".to_string(),
+            behind_nominal_minutes: 1_688,
+            next_issue: Some(Box::new(next_issue)),
+        };
+        let rendered =
+            render_publication_status(AnalysisCenter::GfzUlt, ProductType::Sp3, &outcome);
+        assert!(rendered.contains("lag_minutes: 1688"), "{rendered}");
+        assert!(
+            rendered.contains("next_due: 2026-08-04T08:50:00Z"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("next_identity: GFZ0OPSULT_20262150600_02D_05M_ORB.SP3"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn publication_status_datetime_parser_is_strict_utc() {
+        assert_eq!(
+            parse_product_datetime("2026-08-04T07:08:09Z").unwrap(),
+            ProductDateTime::new(ProductDate::new(2026, 8, 4).unwrap(), 7, 8, 9).unwrap()
+        );
+        assert!(parse_product_datetime("2026-08-04 07:08:09Z").is_err());
+        assert!(parse_product_datetime("2026-08-04T07:08:09").is_err());
+    }
 }

--- a/crates/sidereon-scoreboard/tests/scoreboard.rs
+++ b/crates/sidereon-scoreboard/tests/scoreboard.rs
@@ -1017,7 +1017,9 @@ fn publication_status_answers_the_recorded_gfz_lag_scenario() {
             product,
             listing_url,
             behind_nominal_minutes,
+            next_issue,
         } => {
+            let next_issue = next_issue.expect("cataloged GFZ ultra schedule");
             assert_eq!(product.date, date(2026, 8, 3));
             assert_eq!(product.issue, "0300");
             assert_eq!(product.filename, "GFZ0OPSULT_20262150300_02D_05M_ORB.SP3");
@@ -1027,6 +1029,12 @@ fn publication_status_answers_the_recorded_gfz_lag_scenario() {
                 "https://isdc-data.gfz.de/gnss/products/ultra/w2430/"
             );
             assert_eq!(behind_nominal_minutes, 28 * 60 + 8);
+            assert_eq!(next_issue.identity.date, date(2026, 8, 3));
+            assert_eq!(next_issue.identity.issue.as_deref(), Some("0600"));
+            assert_eq!(
+                next_issue.due_at,
+                ProductDateTime::new(date(2026, 8, 4), 8, 50, 0).unwrap()
+            );
         }
         other => panic!("expected Published, got {other:?}"),
     }
@@ -1035,6 +1043,36 @@ fn publication_status_answers_the_recorded_gfz_lag_scenario() {
         1,
         "one listing GET answered the query"
     );
+}
+
+#[test]
+fn publication_status_keeps_lines_without_a_nominal_schedule_queryable() {
+    struct RecordedWum;
+    impl ListingFetcher for RecordedWum {
+        fn fetch_listing(&self, _url: &str) -> Result<ListingOutcome, ScoreboardError> {
+            Ok(ListingOutcome::Available(
+                "-rw-r--r-- 1 ftp ftp 123 Aug 4 00:30 WUM0MGXNRT_20262160000_02D_05M_ORB.SP3.gz\n"
+                    .to_string(),
+            ))
+        }
+    }
+
+    let now = ProductDateTime::new(date(2026, 8, 4), 7, 8, 0).expect("query instant");
+    let outcome = publication_status(AnalysisCenter::WumNrt, ProductType::Sp3, now, &RecordedWum)
+        .expect("publication status remains available without a due schedule");
+    match outcome {
+        PublicationStatusOutcome::Published {
+            product,
+            behind_nominal_minutes,
+            next_issue,
+            ..
+        } => {
+            assert_eq!(product.issue, "0000");
+            assert_eq!(behind_nominal_minutes, 7 * 60 + 8);
+            assert!(next_issue.is_none());
+        }
+        other => panic!("expected Published, got {other:?}"),
+    }
 }
 
 /// Recorded 2026-08-04 BKG state: the current week's directory does not

--- a/crates/sidereon/src/lib.rs
+++ b/crates/sidereon/src/lib.rs
@@ -412,9 +412,9 @@ pub use sidereon_core::ephemeris::{
     check_continuity, fit_precise_ephemeris_state_sample_orbit,
     fit_precise_ephemeris_state_sample_orbits, precise_interpolant_store_checksum64,
     sp3_ecef_state_to_eci, ContinuityCheck, ContinuityDefect, ContinuityOptions, ContinuityReport,
-    MmapPreciseEphemerisInterpolant, OrbitClass, OrientedPreciseEphemerisStateSample,
+    EpochWindow, MmapPreciseEphemerisInterpolant, OrbitClass, OrientedPreciseEphemerisStateSample,
     PreciseEphemerisInterpolant, PreciseEphemerisStateSample, PreciseInterpolantStoreError,
-    SpeedBound,
+    SpeedBound, StencilExtent, WindowContinuityDecision, WindowContinuityVerdict,
 };
 
 /// Root-level shortcut for satellite-relative frames and CW propagation.

--- a/crates/trust-region-least-squares/README.md
+++ b/crates/trust-region-least-squares/README.md
@@ -201,6 +201,12 @@ as f64 hex-bit strings and compared with `f64::to_bits`, never tolerances.
 Regenerate them with the scripts in `fixtures-generators/` inside the pinned
 Python environment (`fixtures-generators/requirements.txt`).
 
+When an oracle package version changes, apply the repository's [Python oracle
+version-pinning rules](../../docs/oracle-version-pinning.md). In particular,
+hash only the meaningful FITPACK coefficient prefix, pin NumPy together with
+its BLAS/LAPACK substrate for pseudo-inverse fixtures, and treat regeneration
+under another package version as a new fixture.
+
 The host-LAPACK parity test skips unless `TRUST_REGION_LEAST_SQUARES_LAPACK_PATH`
 points at a LAPACK library; the backend itself is always compiled in.
 

--- a/crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py
+++ b/crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Reproduce the cross-version SciPy and NumPy oracle-pin measurements."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+
+PROBE = r"""
+import gc
+import hashlib
+import json
+import platform
+import sys
+
+import numpy as np
+import scipy
+from scipy.interpolate import splev, splrep
+
+
+def hex_bytes(values):
+    return np.asarray(values, dtype=np.float64).tobytes().hex()
+
+
+x = np.linspace(0.0, 1.0, 9)
+y = np.sin(7.0 * x) + 0.125 * x * x
+queries = np.linspace(0.0, 1.0, 17)
+spline_cases = {}
+for smoothing in (0.0, 0.01):
+    knots, coefficients, degree = splrep(x, y, s=smoothing)
+    used = len(knots) - degree - 1
+    values = splev(queries, (knots, coefficients, degree))
+    spline_cases[str(smoothing)] = {
+        "knots": hex_bytes(knots),
+        "coefficients": hex_bytes(coefficients),
+        "used": used,
+        "degree": degree,
+        "values": hex_bytes(values),
+        "tail": [float(value).hex() for value in coefficients[used:]],
+    }
+
+nonzero_tails = 0
+addresses = set()
+for index in range(10_000):
+    knots, coefficients, degree = splrep(x, y, s=0.01)
+    used = len(knots) - degree - 1
+    addresses.add(int(coefficients.ctypes.data))
+    if np.any(coefficients[used:] != 0.0):
+        nonzero_tails += 1
+    coefficients[:] = np.float64.fromhex("0x1.23456789abcp+40")
+    del knots, coefficients
+    if index % 100 == 0:
+        gc.collect()
+
+rng = np.random.default_rng(20260821)
+pinv_input = rng.normal(size=(9, 6))
+pinv_output = np.linalg.pinv(pinv_input)
+
+sweep = []
+for kind in ("random", "hilbert", "near"):
+    for n in range(2, 21):
+        for seed in range(5):
+            if kind == "hilbert":
+                indices = np.arange(n, dtype=np.float64)
+                matrix = 1.0 / (indices[:, None] + indices[None, :] + 1.0)
+            else:
+                case_rng = np.random.default_rng(seed)
+                matrix = case_rng.normal(size=(n + 2, n))
+                if kind == "near":
+                    matrix[:, -1] = (
+                        matrix[:, 0]
+                        + np.float64(1e-8) * matrix[:, 1]
+                        + np.float64(1e-10) * matrix[:, 2 % n]
+                    )
+            output = np.linalg.pinv(matrix)
+            sweep.append(hashlib.sha256(output.tobytes()).hexdigest())
+
+print(json.dumps({
+    "python": sys.version.split()[0],
+    "platform": platform.platform(),
+    "numpy": np.__version__,
+    "scipy": scipy.__version__,
+    "spline_cases": spline_cases,
+    "allocator_reuse": {
+        "fits": 10_000,
+        "addresses": len(addresses),
+        "nonzero_tails": nonzero_tails,
+    },
+    "pinv": {
+        "input": hex_bytes(pinv_input),
+        "input_sha256": hashlib.sha256(pinv_input.tobytes()).hexdigest(),
+        "output": hex_bytes(pinv_output),
+        "output_sha256": hashlib.sha256(pinv_output.tobytes()).hexdigest(),
+        "sweep_sha256": sweep,
+    },
+}))
+"""
+
+
+def run_probe(python: str) -> dict:
+    output = subprocess.check_output([python, "-c", PROBE], text=True)
+    return json.loads(output)
+
+
+def floats(payload: str) -> list[float]:
+    return list(memoryview(bytes.fromhex(payload)).cast("d"))
+
+
+def max_ulp(left: list[float], right: list[float]) -> int:
+    if len(left) != len(right):
+        raise ValueError("float arrays have different lengths")
+    maximum = 0
+    for lhs, rhs in zip(left, right, strict=True):
+        lhs_bits = int.from_bytes(memoryview(bytearray(struct_pack(lhs))), sys.byteorder)
+        rhs_bits = int.from_bytes(memoryview(bytearray(struct_pack(rhs))), sys.byteorder)
+        if (lhs_bits >> 63) != (rhs_bits >> 63):
+            raise ValueError("float signs differ")
+        maximum = max(maximum, abs(lhs_bits - rhs_bits))
+    return maximum
+
+
+def struct_pack(value: float) -> bytes:
+    import struct
+
+    return struct.pack("=d", value)
+
+
+def compare(old: dict, new: dict) -> dict:
+    spline = {}
+    for smoothing in ("0.0", "0.01"):
+        old_case = old["spline_cases"][smoothing]
+        new_case = new["spline_cases"][smoothing]
+        used = old_case["used"]
+        old_coefficients = floats(old_case["coefficients"])
+        new_coefficients = floats(new_case["coefficients"])
+        spline[smoothing] = {
+            "knots_bit_identical": old_case["knots"] == new_case["knots"],
+            "used_coefficients": used,
+            "old_tail": old_case["tail"],
+            "new_tail": new_case["tail"],
+            "coefficient_max_ulp": max_ulp(
+                old_coefficients[:used], new_coefficients[:used]
+            ),
+            "evaluation_max_ulp": max_ulp(
+                floats(old_case["values"]), floats(new_case["values"])
+            ),
+        }
+
+    old_sweep = old["pinv"]["sweep_sha256"]
+    new_sweep = new["pinv"]["sweep_sha256"]
+    differing_sweep_cases = sum(
+        old_digest != new_digest
+        for old_digest, new_digest in zip(old_sweep, new_sweep, strict=True)
+    )
+    return {
+        "environments": {
+            "old": {
+                key: old[key] for key in ("python", "platform", "numpy", "scipy")
+            },
+            "new": {
+                key: new[key] for key in ("python", "platform", "numpy", "scipy")
+            },
+        },
+        "scipy_splrep": {
+            "cases": spline,
+            "allocator_reuse": {
+                "old": old["allocator_reuse"],
+                "new": new["allocator_reuse"],
+            },
+        },
+        "numpy_pinv": {
+            "input_sha256": old["pinv"]["input_sha256"],
+            "input_bit_identical": old["pinv"]["input"] == new["pinv"]["input"],
+            "old_output_sha256": old["pinv"]["output_sha256"],
+            "new_output_sha256": new["pinv"]["output_sha256"],
+            "fixed_matrix_max_ulp": max_ulp(
+                floats(old["pinv"]["output"]), floats(new["pinv"]["output"])
+            ),
+            "sweep_cases": len(old_sweep),
+            "differing_sweep_cases": differing_sweep_cases,
+        },
+    }
+
+
+def main() -> None:
+    old_python = os.environ.get("SIDEREON_ORACLE_OLD_PYTHON")
+    new_python = os.environ.get("SIDEREON_ORACLE_NEW_PYTHON")
+    if not old_python or not new_python:
+        raise SystemExit(
+            "set SIDEREON_ORACLE_OLD_PYTHON and SIDEREON_ORACLE_NEW_PYTHON"
+        )
+    result = compare(run_probe(old_python), run_probe(new_python))
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/trust-region-least-squares/tests/fixtures/oracle_version_pins.json
+++ b/crates/trust-region-least-squares/tests/fixtures/oracle_version_pins.json
@@ -1,0 +1,131 @@
+{
+  "schema": "trust-region-least-squares-oracle-version-pins-v1",
+  "recorded_at": "2026-08-21",
+  "host": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "python": "3.14.7",
+    "blas_lapack": "Apple Accelerate as reported by numpy.show_config()"
+  },
+  "tools": {
+    "uv": "0.11.19",
+    "curl": "8.7.1",
+    "jq": "1.7.1",
+    "digest": "shasum -a 256"
+  },
+  "sources": [
+    {
+      "package": "numpy",
+      "version": "2.4.6",
+      "artifact": "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl",
+      "url": "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl",
+      "sha256": "d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5",
+      "measured_binary": "numpy/linalg/_umath_linalg.cpython-314-darwin.so",
+      "measured_binary_sha256": "5a8c1ceb8eeb0fecd6086baf0a7482c107273f6597cfdb8e41c9079f89089af3"
+    },
+    {
+      "package": "numpy",
+      "version": "2.5.0",
+      "artifact": "numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl",
+      "url": "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl",
+      "sha256": "e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c",
+      "measured_binary": "numpy/linalg/_umath_linalg.cpython-314-darwin.so",
+      "measured_binary_sha256": "b2ee60582c2d764477125b59838b732659a2b373a0d22f2f743890ce1032ad65"
+    },
+    {
+      "package": "scipy",
+      "version": "1.17.1",
+      "artifact": "scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl",
+      "url": "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl",
+      "sha256": "3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b",
+      "measured_binary": "scipy/interpolate/_fitpack.cpython-314-darwin.so",
+      "measured_binary_sha256": "0c1c63ef5bf1928dad2dcf731c8b225e882656da96e00a6ed540d7e76bf62d5a"
+    },
+    {
+      "package": "scipy",
+      "version": "1.18.0",
+      "artifact": "scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl",
+      "url": "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl",
+      "sha256": "f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d",
+      "measured_binary": "scipy/interpolate/_fitpack.cpython-314-darwin.so",
+      "measured_binary_sha256": "45086335552edb6f0d8a6fe22399f4567d543d882d233149b464706a1fa5b662"
+    }
+  ],
+  "references": [
+    {
+      "title": "SciPy 1.18.0 release notes",
+      "url": "https://docs.scipy.org/doc/scipy/release/1.18.0-notes.html",
+      "relevance": "records the FITPACK port from Fortran to C"
+    },
+    {
+      "title": "SciPy splrep documentation",
+      "url": "https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.splrep.html",
+      "relevance": "records that the trailing k+1 coefficients are ignored"
+    },
+    {
+      "title": "NumPy 2.5.0 release notes",
+      "url": "https://numpy.org/doc/2.5/release/2.5.0-notes.html",
+      "relevance": "official release record for the new NumPy version"
+    }
+  ],
+  "reproduction": {
+    "script": "crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py",
+    "command": "UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv venv --python 3.14 /tmp/sidereon-oracle-old && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv pip install --python /tmp/sidereon-oracle-old/bin/python numpy==2.4.6 scipy==1.17.1 && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv venv --python 3.14 /tmp/sidereon-oracle-new && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv pip install --python /tmp/sidereon-oracle-new/bin/python numpy==2.5.0 scipy==1.18.0 && SIDEREON_ORACLE_OLD_PYTHON=/tmp/sidereon-oracle-old/bin/python SIDEREON_ORACLE_NEW_PYTHON=/tmp/sidereon-oracle-new/bin/python /tmp/sidereon-oracle-new/bin/python crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py"
+  },
+  "measurements": {
+    "scipy_splrep": {
+      "old_version": "1.17.1",
+      "new_version": "1.18.0",
+      "allocator_reuse_fits_per_version": 10000,
+      "allocator_addresses_reused_per_version": 2,
+      "nonzero_trailing_coefficients_seen": 0,
+      "interpolating_s_0": {
+        "used_coefficients": 9,
+        "trailing_coefficients_per_version": [
+          "0x0.0p+0",
+          "0x0.0p+0",
+          "0x0.0p+0",
+          "0x0.0p+0"
+        ],
+        "used_coefficient_max_ulp": 0,
+        "evaluation_max_ulp": 0
+      },
+      "smoothed_s_0_01": {
+        "used_coefficients": 7,
+        "trailing_coefficients_per_version": [
+          "0x0.0p+0",
+          "0x0.0p+0",
+          "0x0.0p+0",
+          "0x0.0p+0"
+        ],
+        "used_coefficient_max_ulp": 21,
+        "evaluation_max_ulp": 23
+      }
+    },
+    "numpy_pinv": {
+      "old_version": "2.4.6",
+      "new_version": "2.5.0",
+      "fixed_matrix": {
+        "generator": "numpy.random.default_rng(20260821).normal(size=(9, 6))",
+        "input_sha256": "0c67efbaf8a750cf94d9ba870279cc30aedd1da37b23736e5a94f43111e2ff14",
+        "old_output_sha256": "742760f0f41566d7b1070be2b56f29f5520934a634d0283a5782ddf5f1698b09",
+        "new_output_sha256": "742760f0f41566d7b1070be2b56f29f5520934a634d0283a5782ddf5f1698b09",
+        "max_ulp": 0
+      },
+      "deterministic_sweep": {
+        "matrix_families": [
+          "random",
+          "hilbert",
+          "near-dependent"
+        ],
+        "dimensions": "2 through 20",
+        "seeds_per_dimension": 5,
+        "cases": 285,
+        "differing_cases": 0
+      }
+    }
+  },
+  "policy": {
+    "spline_coefficients": "Hash only the first n_knots - k - 1 coefficients and pin SciPy for evaluated fixture values.",
+    "pseudo_inverse": "Pin NumPy and the BLAS/LAPACK substrate. Regeneration under another version creates a new fixture."
+  }
+}

--- a/crates/trust-region-least-squares/tests/oracle_version_pins.rs
+++ b/crates/trust-region-least-squares/tests/oracle_version_pins.rs
@@ -1,0 +1,70 @@
+//! Provenance guard for the measured SciPy and NumPy oracle-version notes.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("oracle_version_pins.json")
+}
+
+#[test]
+fn oracle_version_pin_measurements_have_reproducible_provenance() {
+    let raw = std::fs::read_to_string(fixture_path()).expect("read oracle pin fixture");
+    let fixture: Value = serde_json::from_str(&raw).expect("parse oracle pin fixture");
+
+    assert_eq!(
+        fixture["schema"],
+        "trust-region-least-squares-oracle-version-pins-v1"
+    );
+    assert_eq!(fixture["host"]["python"], "3.14.7");
+    assert_eq!(
+        fixture["host"]["blas_lapack"],
+        "Apple Accelerate as reported by numpy.show_config()"
+    );
+    assert_eq!(fixture["tools"]["uv"], "0.11.19");
+    assert_eq!(fixture["tools"]["curl"], "8.7.1");
+
+    let sources = fixture["sources"].as_array().expect("package sources");
+    assert_eq!(sources.len(), 4);
+    for source in sources {
+        assert!(source["url"]
+            .as_str()
+            .expect("source URL")
+            .starts_with("https://files.pythonhosted.org/"));
+        assert_eq!(source["sha256"].as_str().expect("wheel digest").len(), 64);
+        assert_eq!(
+            source["measured_binary_sha256"]
+                .as_str()
+                .expect("binary digest")
+                .len(),
+            64
+        );
+    }
+
+    let scipy = &fixture["measurements"]["scipy_splrep"];
+    assert_eq!(scipy["old_version"], "1.17.1");
+    assert_eq!(scipy["new_version"], "1.18.0");
+    assert_eq!(scipy["allocator_reuse_fits_per_version"], 10_000);
+    assert_eq!(scipy["nonzero_trailing_coefficients_seen"], 0);
+    assert_eq!(scipy["interpolating_s_0"]["evaluation_max_ulp"], 0);
+    assert_eq!(scipy["smoothed_s_0_01"]["used_coefficient_max_ulp"], 21);
+    assert_eq!(scipy["smoothed_s_0_01"]["evaluation_max_ulp"], 23);
+
+    let numpy = &fixture["measurements"]["numpy_pinv"];
+    assert_eq!(numpy["old_version"], "2.4.6");
+    assert_eq!(numpy["new_version"], "2.5.0");
+    assert_eq!(numpy["fixed_matrix"]["max_ulp"], 0);
+    assert_eq!(numpy["deterministic_sweep"]["cases"], 285);
+    assert_eq!(numpy["deterministic_sweep"]["differing_cases"], 0);
+
+    let command = fixture["reproduction"]["command"]
+        .as_str()
+        .expect("reproduction command");
+    assert!(command.contains("verify_oracle_version_pins.py"));
+    assert!(command.contains("numpy==2.4.6 scipy==1.17.1"));
+    assert!(command.contains("numpy==2.5.0 scipy==1.18.0"));
+}

--- a/docs/oracle-version-pinning.md
+++ b/docs/oracle-version-pinning.md
@@ -1,0 +1,64 @@
+# Python oracle version pinning
+
+Sidereon's numerical fixtures record the Python package versions and numerical
+substrate that produced them. Package upgrades are evaluated as new oracle
+environments. They do not silently refresh an existing fixture.
+
+This note records two transition checks performed on 2026-08-21. The complete
+artifact URLs, SHA-256 digests, host details, commands, and measured results are
+in
+`crates/trust-region-least-squares/tests/fixtures/oracle_version_pins.json`.
+The committed
+`crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py`
+script runs both checks.
+
+## SciPy 1.17.1 to 1.18.0
+
+SciPy 1.18.0 [ported FITPACK from Fortran to
+C](https://docs.scipy.org/doc/scipy/release/1.18.0-notes.html). A reported
+consequence was deterministic zero filling of the unused coefficient tail where
+older builds could expose uninitialized slots. That difference did not
+reproduce with the pinned CPython 3.14 macOS arm64 wheels on this host.
+
+For `splrep` on nine deterministic samples, both SciPy 1.17.1 and 1.18.0
+returned four zero trailing coefficients. Poisoning and reusing the allocator
+through 10,000 fits per version still found no nonzero tail. With interpolation
+(`s=0`), the nine meaningful coefficients and 17 evaluations were bit-identical.
+With smoothing (`s=0.01`), the seven meaningful coefficients moved by at most 21
+ULP and the evaluations moved by at most 23 ULP. Therefore the broader claim
+that evaluations never move across this version pair did not hold for the
+smoothed probe.
+
+The storage rule remains independent of that host result. FITPACK evaluation
+uses only the first `n_knots - k - 1` coefficients, and SciPy documents the
+additional `k + 1` entries as ignored. A coefficient fixture or digest hashes
+only the meaningful prefix. An evaluation fixture also pins the SciPy version,
+and changing that version creates a new fixture.
+
+One-line reproduction from the repository root:
+
+```sh
+UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv venv --python 3.14 /tmp/sidereon-oracle-old && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv pip install --python /tmp/sidereon-oracle-old/bin/python numpy==2.4.6 scipy==1.17.1 && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv venv --python 3.14 /tmp/sidereon-oracle-new && UV_CACHE_DIR=/tmp/sidereon-oracle-uv uv pip install --python /tmp/sidereon-oracle-new/bin/python numpy==2.5.0 scipy==1.18.0 && SIDEREON_ORACLE_OLD_PYTHON=/tmp/sidereon-oracle-old/bin/python SIDEREON_ORACLE_NEW_PYTHON=/tmp/sidereon-oracle-new/bin/python /tmp/sidereon-oracle-new/bin/python crates/trust-region-least-squares/fixtures-generators/verify_oracle_version_pins.py
+```
+
+## NumPy 2.4.6 to 2.5.0
+
+A reported NumPy 2.5 pseudo-inverse change of up to a few hundred ULP also did
+not reproduce with the pinned macOS arm64 wheels using Apple Accelerate. For
+`default_rng(20260821).normal(size=(9, 6))`, NumPy 2.4.6 and 2.5.0 produced the
+same pseudo-inverse bits and the same SHA-256 digest,
+`742760f0f41566d7b1070be2b56f29f5520934a634d0283a5782ddf5f1698b09`.
+A 285-case deterministic sweep across random, Hilbert, and nearly dependent
+matrices of dimensions 2 through 20 also had zero differing cases. The measured
+maximum was 0 ULP, not a few hundred ULP.
+
+Pseudo-inverse fixtures still pin the NumPy version and BLAS/LAPACK substrate.
+This measured equality is specific to the recorded environment and inputs. A
+fixture generated under another NumPy version is a new fixture, not a refresh
+of the old fixture.
+
+The one-line reproduction is the same command above. Its `numpy_pinv` section
+prints the fixed-matrix digests, maximum ULP difference, sweep case count, and
+differing case count. NumPy's official [2.5.0 release
+notes](https://numpy.org/doc/2.5/release/2.5.0-notes.html) identify the release
+used by the check.

--- a/docs/public-gnss-distribution-sources.md
+++ b/docs/public-gnss-distribution-sources.md
@@ -9,8 +9,8 @@ cadence, family, format, or official decompressed filename.
 
 The Rust core remains network-free. It owns catalog selection, exact identity,
 official filename and source-location derivation, safe cache-relative paths,
-and SP3/IONEX parsing. Bindings that already own acquisition—Python and
-Elixir—own authenticated HTTP, retries, cookies, cache IO, and credential
+and SP3/IONEX parsing. Bindings that already own acquisition, Python and
+Elixir, own authenticated HTTP, retries, cookies, cache IO, and credential
 configuration. C and WebAssembly expose the same pure identity and location
 derivation without adding hidden network behavior.
 
@@ -141,6 +141,49 @@ https://www.aiub.unibe.ch/download/CODE/IONO/P2/<identity-year>/<official-filena
 The HTTPS redirect chain is restricted to AIUB's download host and public
 object-store host. A missing exact URL remains a not-published result; direct
 location derivation performs no date lookback or tier substitution.
+
+## Nominal next-issue schedule
+
+`next_issue_due(center, product_type, now)` is a network-free query over the
+same catalog identities used by publication status. It returns the first due
+time at or after `now`, the exact `ProductIdentity`, and half-open observed and
+predicted coverage intervals. It does not fetch a listing and does not claim
+that an archive has posted the issue.
+
+The due-time rules distinguish a filename coverage epoch from publication.
+For IGS combined ultra-rapid SP3, a two-day filename names 24 observed hours
+followed by 24 predicted hours and is released 27 hours after its coverage
+start. The analysis-center ultra lines use the 26 h 50 min submission deadline.
+GFZ rapid SP3 and CLK use the next-day 15:45 UTC analysis-center deadline. CODE
+rapid IONEX uses the following 00:00 UTC boundary for its published less-than-24
+hour latency. CODE predicted IONEX uses its cataloged one-day or two-day horizon.
+
+Final products are weekly batches of daily identities. The query names the
+Saturday identity, which is the newest identity publication-status monitoring
+expects from that batch. Analysis-center final SP3 and CLK batches are due at
+Wednesday 05:00 UTC, 11 days after GPS week end. IGS combined final is due by
+Friday, 13 days after week end. Because that source gives a day but no hour, the
+catalog represents the deadline as Friday 23:59:59 UTC. Final IONEX uses its
+published approximately 11-day weekly latency and the same end-of-day rule for
+the otherwise date-only deadline.
+
+These resolutions are catalog policy, not inferred timestamps. Their source
+URLs, access date, `curl 8.7.1` retrieval record, `shasum -a 256` digests, and
+the date-only resolution rules are committed in
+`crates/sidereon-core/tests/fixtures/data/nominal_issue_schedule_provenance.json`.
+The sources are the IGS products page, the IGS Analysis Center Coordinator
+schedule, and the CODE, ESA, and GFZ analysis-center descriptions.
+
+The current source set does not establish a nominal due-time rule for WUM's
+near-real-time line or broadcast navigation. Those pairs return
+`UnsupportedNominalSchedule` rather than inheriting a nearby cadence.
+
+The scoreboard publication-status outcome carries `next_issue` beside
+`behind_nominal_minutes`. Its CLI renders both with:
+
+```text
+sidereon-scoreboard --publication-status CENTER PRODUCT --at YYYY-MM-DDTHH:MM:SSZ
+```
 
 ## GFZ rapid SP3 cadence eras
 

--- a/docs/sp3-window-scoped-continuity.md
+++ b/docs/sp3-window-scoped-continuity.md
@@ -1,0 +1,68 @@
+# Window-scoped SP3 continuity
+
+`check_continuity` and the optional continuity post-condition on `merge` remain
+product-wide reporters. They retain every defect and keep their existing
+defaults and return values. A bounded evaluator can now ask those existing
+reports which findings can enter an interpolation neighbourhood for a requested
+inclusive epoch window.
+
+## Decision
+
+`EpochWindow` is expressed in seconds since J2000 on the SP3 product's own time
+scale. `StencilExtent::for_sp3` derives five intervals of reach before and after
+an evaluation epoch. Five is not a policy value supplied by the caller. It comes
+from the same `NEVILLE_POINTS = 11` constant used by the degree-10 sliding-window
+Lagrange position interpolator. The interval comes from the product header and
+must be positive and finite. The product's first epoch anchors the nominal grid.
+For non-node query times, filtering follows the interpolator by selecting the
+last grid node at or before each window bound before applying the five-interval
+reach.
+
+A defect influences the window when its recorded epoch or epoch pair intersects
+the evaluation window expanded by that derived reach. The bounds are inclusive,
+so a finding exactly at the outermost stencil node influences the verdict. The
+existing `SingleSampleSeries` finding has no epoch. It therefore influences every
+window conservatively because a query over an existing report cannot assign it a
+location.
+
+`ContinuityReport::verdict_for_window` and
+`MergeContinuityReport::verdict_for_window` return `Accept` only when no recorded
+defect influences the expanded window. Otherwise they return `Refuse`. A merge
+verdict also reports contributor-changing violations as splices. Both verdicts
+retain the complete defect list, and merge verdicts retain the complete splice
+list, so accepted findings outside the requested reach remain available for
+logging and archive review. `MergeReport` preserves `None` when its continuity
+post-condition was not requested.
+
+## Contract boundary
+
+The verdict answers whether a finding already recorded by the existing checker
+can affect an epoch in the requested window through the nominal interpolation
+stencil. It does not rerun continuity checks, prove that untested data is clean,
+validate the caller's actual evaluation epochs, or guarantee interpolation is
+possible across a coverage gap. It does not alter merge output, continuity
+tolerances, interpolation arithmetic, or any default.
+
+The CLI form is:
+
+```text
+sidereon inspect PRODUCT.SP3 --window FROM THROUGH
+```
+
+`FROM` and `THROUGH` are product-scale J2000 seconds. The command prints the
+product-wide continuity summary and the window decision with the derived reach.
+
+## Validation fixture
+
+The integration test uses the committed public CODE MGEX final product
+`COD0MGXFIN_20201770000_01D_05M_ORB.SP3`, SHA-256
+`54b70fa009a840ecf8cec25fbd4d749c9aaef7c95bdf463484e115f74d802215`,
+from the repository's established IGS fixture set and the canonical CDDIS MGEX
+week 2111 archive. The digest was verified with `shasum -a 256` on 2026-08-21.
+
+No consecutive daily pair is committed. The seam test constructs only its
+second day by advancing the real product by 86,400 seconds, serializing with
+Sidereon's SP3 writer, and reparsing. It injects a structured seam finding into
+the merge report. This derived day is test input for window selection, not an
+external continuity oracle. The untouched real product remains the primary
+continuity fixture and attests under the existing checker.


### PR DESCRIPTION
Three deliverables from the window-continuity brief, one commit each.

Window-scoped verdicts: EpochWindow + a StencilExtent derived from the interpolator's sliding-window order and the product's epoch interval let ContinuityReport and MergeReport answer defects_influencing for a bounded evaluation span, with an accept/refuse verdict naming the influencing defects either way. Defaults and return values of merge and check_continuity are unchanged. The flip-point test pins the window edge at exactly one computed stencil half-width from an injected seam.

Next-issue due times: network-free next_issue_due over the publication-status catalog, ultra observed/predicted split named the catalog's way, schedules cited to the published IGS product descriptions in a committed provenance fixture, boundary tests across UTC midnight and a GPS week rollover.

Oracle pinning: both reported cross-version hazards were measured rather than transcribed and neither reproduces as reported (SciPy smoothing moves 21/23 ULP where the report said none; NumPy pinv moves 0 ULP where the report said hundreds); the durable hashing/pinning rules are documented with a one-command reproduction, independently re-run and matched.

Gates: fmt, clippy -D warnings (default + mmap), full workspace suite 2997 passed.