### PR TITLE
core: fix lenient RINEX 4 CNAV routing and RTKLIB SBAS wire form

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `sidereon-core` are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- `rinex_band_frequency_hz_classified` reports
+  `Error::MissingGlonassChannel` when GLONASS G1/G2 needs an FDMA channel,
+  while existing lookup behavior and frequency values remain unchanged.
+
+### Fixed
+
+- Lenient RINEX 4 NAV parsing now decodes GPS/QZSS CNAV-family EPH frames
+  instead of skipping them.
+- RTKLIB SBAS parsing now preserves the `Framed250` wire form for valid
+  32-byte blocks without changing the parsed bytes.
+
 ## [1.1.1] - 2026-08-26
 
 ### Changed

--- a/crates/sidereon-core/src/error.rs
+++ b/crates/sidereon-core/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     Parse(String),
     /// A requested satellite is not present in the product.
     UnknownSatellite(crate::GnssSatelliteId),
+    /// A GLONASS G1/G2 frequency lookup did not receive an FDMA channel.
+    MissingGlonassChannel,
     /// A requested terrain tile is not present in the terrain store.
     MissingTerrainTile {
         /// Integer latitude tile id.
@@ -38,6 +40,7 @@ impl fmt::Display for Error {
         match self {
             Error::Parse(msg) => write!(f, "parse error: {msg}"),
             Error::UnknownSatellite(id) => write!(f, "unknown satellite: {id}"),
+            Error::MissingGlonassChannel => write!(f, "missing GLONASS FDMA channel"),
             Error::MissingTerrainTile {
                 lat_index,
                 lon_index,

--- a/crates/sidereon-core/src/frequencies.rs
+++ b/crates/sidereon-core/src/frequencies.rs
@@ -322,6 +322,24 @@ pub fn rinex_band_frequency_hz(
     rinex_signal_frequency_hz(system, band, None, None, glonass_channel)
 }
 
+/// Carrier frequency in hertz for a system and RINEX band digit.
+///
+/// Unlike [`rinex_band_frequency_hz`], this classified lookup distinguishes a
+/// missing GLONASS FDMA channel.
+pub fn rinex_band_frequency_hz_classified(
+    system: GnssSystem,
+    band: char,
+    glonass_channel: Option<i8>,
+) -> crate::Result<Option<f64>> {
+    if matches!(
+        (system, band, glonass_channel),
+        (GnssSystem::Glonass, '1' | '2', None)
+    ) {
+        return Err(crate::Error::MissingGlonassChannel);
+    }
+    Ok(rinex_band_frequency_hz(system, band, glonass_channel))
+}
+
 /// RINEX observation-code frequency in hertz for a system and full code.
 ///
 /// BeiDou's band labels changed across RINEX 3 minor versions: in RINEX 3.02
@@ -546,6 +564,40 @@ mod tests {
             rinex_band_frequency_hz(GnssSystem::Glonass, '1', None),
             None
         );
+    }
+
+    #[test]
+    fn classified_rinex_band_lookup_distinguishes_missing_channels() {
+        for band in ['1', '2'] {
+            assert_eq!(
+                rinex_band_frequency_hz_classified(GnssSystem::Glonass, band, None),
+                Err(crate::Error::MissingGlonassChannel)
+            );
+            assert_eq!(
+                rinex_band_frequency_hz(GnssSystem::Glonass, band, None),
+                None
+            );
+        }
+        assert_eq!(
+            rinex_band_frequency_hz_classified(GnssSystem::Glonass, '3', None),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn classified_rinex_band_lookup_preserves_frequency_bits() {
+        let cases: [(GnssSystem, char, Option<i8>, f64); 3] = [
+            (GnssSystem::Gps, '1', None, 1_575_420_000.0),
+            (GnssSystem::Glonass, '1', Some(-7), 1_598_062_500.0),
+            (GnssSystem::Glonass, '2', Some(6), 1_248_625_000.0),
+        ];
+        for (system, band, channel, expected) in cases {
+            assert_eq!(
+                rinex_band_frequency_hz_classified(system, band, channel)
+                    .map(|frequency| frequency.map(f64::to_bits)),
+                Ok(Some(expected.to_bits()))
+            );
+        }
     }
 
     #[test]

--- a/crates/sidereon-core/src/rinex_nav/mod.rs
+++ b/crates/sidereon-core/src/rinex_nav/mod.rs
@@ -1045,8 +1045,13 @@ where
             continue;
         }
         if let Some(message) = nav_message_from_v4_token(msg_token, system) {
-            let parsed = validate_v4_ephemeris_marker(sv, message, body)
-                .and_then(|()| parse_keplerian_block(body, Some(message), version));
+            let parsed = validate_v4_ephemeris_marker(sv, message, body).and_then(|()| {
+                if message.is_cnav_family() {
+                    parse_cnav_block(body, message)
+                } else {
+                    parse_keplerian_block(body, Some(message), version)
+                }
+            });
             match parsed {
                 Ok(record) => records.push(record),
                 Err(error) => skipped.push(SkippedNavBlock {

--- a/crates/sidereon-core/src/rinex_nav/tests.rs
+++ b/crates/sidereon-core/src/rinex_nav/tests.rs
@@ -2510,6 +2510,57 @@ fn real_brdc4_cnav_fixture_counts_and_skips_unsupported_frames() {
 }
 
 #[test]
+fn real_brdc4_lenient_matches_strict_and_keeps_cnav_records() {
+    let text = cnav_fixture_text();
+    let strict = parse_nav(&text).expect("strictly parse real CNAV fixture");
+    let lenient = parse_nav_lenient(&text).expect("leniently parse real CNAV fixture");
+
+    assert_eq!(lenient.records, strict);
+    assert!(lenient.skipped.is_empty(), "fixture blocks were skipped");
+    assert_eq!(
+        lenient
+            .records
+            .iter()
+            .filter(|record| record.message.is_cnav_family())
+            .count(),
+        4
+    );
+}
+
+#[test]
+fn real_brdc4_truncated_cnav_reports_strict_and_lenient_diagnostic() {
+    let fixture = cnav_fixture_text();
+    let header = fixture
+        .split_once("END OF HEADER")
+        .map(|(before, _)| format!("{before}END OF HEADER\n"))
+        .expect("CNAV fixture header");
+    let marker = "> EPH G01 CNAV\n";
+    let body = fixture
+        .split_once(marker)
+        .map(|(_, after)| after.lines().take(8).collect::<Vec<_>>().join("\n"))
+        .expect("G01 CNAV frame in fixture");
+    // The real G01 body line keeps marker validation valid; its missing ninth
+    // line must therefore take the CNAV-specific parser path.
+    let malformed = format!("{header}{marker}{body}\n");
+    let expected = NavParseError::TruncatedRecord("G01".to_string());
+
+    assert_eq!(parse_nav(&malformed), Err(expected.clone()));
+
+    let lenient = parse_nav_lenient(&malformed).expect("leniently parse truncated CNAV");
+    assert!(
+        lenient.records.is_empty(),
+        "truncated CNAV must not be accepted"
+    );
+    assert_eq!(
+        lenient.skipped,
+        vec![SkippedNavBlock {
+            satellite: "G01".to_string(),
+            message: expected.to_string(),
+        }]
+    );
+}
+
+#[test]
 fn real_brdc4_cnav_field_decode_assertions() {
     let recs = cnav_fixture_records();
 

--- a/crates/sidereon-core/src/sbas/format.rs
+++ b/crates/sidereon-core/src/sbas/format.rs
@@ -111,11 +111,11 @@ fn parse_rtklib_line(line: &str) -> Result<Option<SbasLogBlock>> {
     };
     let epoch = GnssWeekTow::new(TimeScale::Gpst, week, tow_s)
         .map_err(|e| Error::Parse(format!("invalid SBAS RTKLIB epoch: {e}")))?;
-    let (_, bytes) = decode_hex_block(hex.trim())?;
+    let (form, bytes) = decode_hex_block(hex.trim())?;
     Ok(Some(SbasLogBlock {
         satellite_id,
         epoch,
-        form: SbasWireForm::Body226,
+        form,
         bytes,
     }))
 }
@@ -166,38 +166,68 @@ fn parse_f64(value: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sbas::message::{SbasBlock, SbasMessage, SbasPrnMask, SpareBits};
+    use crate::astro::time::model::{GnssWeekTow, TimeScale};
+    use crate::sbas::message::{SbasBlock, SbasFastCorrections, SbasMessage, SpareBits};
 
-    fn sample_body_hex() -> String {
-        let mut mask = [false; 210];
-        mask[0] = true;
-        let bytes = SbasBlock {
-            form: SbasWireForm::Body226,
-            message: SbasMessage::PrnMask(SbasPrnMask {
-                preamble: 0x53,
-                iodp: 1,
-                mask,
-                reserved: SpareBits::new(),
-            }),
-        }
-        .encode();
-        bytes.iter().map(|b| format!("{b:02X}")).collect()
+    // The body bytes are the MT2 capture in tests/sbas_real_vectors.rs. The
+    // Framed250 counterpart is derived once from those 226 body bits with the
+    // public framing convention: CRC-24Q followed by six zero pad bits.
+    const RTKLIB_MT2_BODY: [u8; 29] = [
+        0x53, 0x08, 0xDF, 0xFC, 0x01, 0x00, 0x05, 0xFF, 0xC0, 0x0D, 0xFF, 0xC0, 0x09, 0xFF, 0xDF,
+        0xFC, 0x00, 0x1F, 0xFD, 0xFF, 0xDF, 0xFF, 0xBA, 0xBB, 0xBB, 0xBB, 0x9B, 0xBB, 0x80,
+    ];
+    const RTKLIB_MT2_FRAMED: [u8; 32] = [
+        0x53, 0x08, 0xDF, 0xFC, 0x01, 0x00, 0x05, 0xFF, 0xC0, 0x0D, 0xFF, 0xC0, 0x09, 0xFF, 0xDF,
+        0xFC, 0x00, 0x1F, 0xFD, 0xFF, 0xDF, 0xFF, 0xBA, 0xBB, 0xBB, 0xBB, 0x9B, 0xBB, 0x83, 0xA9,
+        0xCE, 0x00,
+    ];
+
+    fn block_hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02X}")).collect()
     }
 
     #[test]
-    fn rtklib_lines_parse_body_blocks_and_skip_malformed_lines() {
-        let hex = sample_body_hex();
-        let text = format!("bad line\n2360 259200 120 1 : {hex}\n");
-        let parsed = parse_rtklib_lines(&text).expect("parse RTKLIB lines");
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].satellite_id.to_string(), "S20");
-        assert_eq!(parsed[0].form, SbasWireForm::Body226);
-        assert_eq!(parsed[0].bytes.len(), 29);
+    fn rtklib_lines_parse_public_body_and_framed_blocks() {
+        let expected_message = SbasMessage::FastCorrections(SbasFastCorrections {
+            preamble: 0x53,
+            message_type: 2,
+            iodf: 0,
+            iodp: 3,
+            prc: [
+                2047, 4, 1, 2047, 3, 2047, 2, 2047, 2047, 0, 2047, 2047, 2047,
+            ],
+            udrei: [14, 14, 10, 14, 14, 14, 14, 14, 14, 6, 14, 14, 14],
+            reserved: SpareBits::new(),
+        });
+        let expected_epoch =
+            GnssWeekTow::new(TimeScale::Gpst, 2360, 259_200.0).expect("valid RTKLIB epoch");
+
+        for (form, expected_bytes) in [
+            (SbasWireForm::Body226, RTKLIB_MT2_BODY.as_slice()),
+            (SbasWireForm::Framed250, RTKLIB_MT2_FRAMED.as_slice()),
+        ] {
+            let text = format!(
+                "bad line\n2360 259200 120 1 : {}\n",
+                block_hex(expected_bytes)
+            );
+            let parsed = parse_rtklib_lines(&text).expect("parse RTKLIB lines");
+            assert_eq!(parsed.len(), 1);
+            assert_eq!(parsed[0].satellite_id.to_string(), "S20");
+            assert_eq!(parsed[0].epoch, expected_epoch);
+            assert_eq!(parsed[0].form, form);
+            assert_eq!(parsed[0].bytes.len(), expected_bytes.len());
+            assert_eq!(parsed[0].bytes, expected_bytes);
+
+            let decoded = SbasBlock::decode(&parsed[0].bytes, parsed[0].form)
+                .expect("public SBAS block decoder accepts parsed form");
+            assert_eq!(decoded.form, form);
+            assert_eq!(decoded.message, expected_message);
+        }
     }
 
     #[test]
     fn ems_lines_parse_calendar_epochs() {
-        let hex = sample_body_hex();
+        let hex = block_hex(&RTKLIB_MT2_BODY);
         let text = format!("120,26,7,1,0,0,1,1,{hex}\nnot,enough\n");
         let parsed = parse_ems_lines(&text).expect("parse EMS lines");
         assert_eq!(parsed.len(), 1);


### PR DESCRIPTION
Two public-API defects in 1.1.1, each reproduced against the published crate before fixing.

**Lenient RINEX 4 NAV dropped every CNAV/CNV2 record.** The strict version-4 path dispatches on `is_cnav_family()` and calls `parse_cnav_block`; the lenient path called `parse_keplerian_block` unconditionally. CNAV frames failed against the Keplerian field roster and became skips reported as `bad/missing week field`. On the committed `BRD400DLR` fixture, strict returned 7 records with 4 CNAV, lenient returned 3 with 0 CNAV and 4 skips. The lenient path now uses the same dispatch, and both parsers return identical vectors.

**`parse_rtklib_lines` discarded the decoded SBAS wire form.** `decode_hex_block` detects `Framed250` versus `Body226` and returns it; `parse_rtklib_line` dropped it and hardcoded `Body226`, so a 32-byte framed message was labeled as a body and decoded with the wrong decoder downstream. The sibling `parse_ems_line` already used the returned form. The form is now preserved.

Also adds `rinex_band_frequency_hz_classified`, which returns a new `Error::MissingGlonassChannel` for GLONASS G1/G2 without an FDMA channel instead of the ambiguous `None` shared with unsupported bands. Purely additive: the legacy helper's signature, values, and call paths are unchanged.

A before/after harness links crates.io 1.1.1 and this tree simultaneously and compares every public record field by `f64::to_bits()` across all eight committed NAV products and five public SBAS vectors. Previously successful results are unchanged; the only deltas are the 4 recovered CNAV records, the 4 removed false skips, and the corrected RTKLIB form.