### PR TITLE
facade: expose estimation, scenario, and NTRIP APIs

### DIFF
--- a/crates/sidereon/README.md
+++ b/crates/sidereon/README.md
@@ -122,8 +122,10 @@ of epochs across a rayon pool, bit-identical to the serial path.
 - **Bodies & almanac:** Sun/Moon/planet apparent places (geocentric or topocentric RA/Dec and az/el), Sun and Moon rise/set, Moon illumination, seasons, moon phases, eclipses, planetary transits, plus JPL SPK (DAF/.bsp) kernels
 - **Observation geometry:** angular separation and position angle, phase/beta/parallactic angles, sub-solar and sub-observer points, terminator, satellite visual magnitude
 - **Positioning:** SPP, RINEX observation to SPP assembly and solve helpers, RTK (float/fixed), PPP (float/fixed), DOP, velocity, robust fault detection and exclusion
+- **Estimation and detection:** scalar alpha-beta and Kalman trackers, NIS innovation gates, EWMA/MAD/CFAR detectors, covariance-weighted `TrackFilter`, and fixed-interval RTS smoothing
 - **GNSS/INS fusion:** loose and tight updates, inertial checkpoint serialization, RTS smoothing, outage velocity matching, stationary and non-holonomic pseudo-updates
 - **GNSS data:** SP3, RINEX (obs/nav/clock), CRINEX encode/decode, ANTEX, broadcast ephemeris, Bias-SINEX / CODE DCB biases, source-agnostic ephemeris sampling
+- **Protocol and simulation:** sans-I/O NTRIP requests, handshakes, sourcetables, chunked streams, and GGA formatting (live transport remains caller-owned); deterministic synthetic GNSS scenarios with media/source variants and a typed truth ledger
 - **Corrections:** SBAS, RTCM SSR and Galileo HAS orbit/clock/bias correction stores
 - **Space situational awareness:** conjunction/TCA screening, collision probability, CDM, covariance, relative motion (RIC/RTN/LVLH, Clohessy-Wiltshire)
 - **RF:** link budget (FSPL, EIRP, C/N0, antenna gain)

--- a/crates/sidereon/src/lib.rs
+++ b/crates/sidereon/src/lib.rs
@@ -38,6 +38,11 @@
 //!   [`ppp_corrections`], [`rtk`],
 //!   [`staleness`], [`tides`], [`ils`], and [`terrain`] expose the core helper
 //!   surface,
+//! - [`estimation`] exposes deterministic scalar estimation and detection
+//!   primitives, covariance-weighted track filtering, and RTS smoothing,
+//! - [`ntrip`] exposes the sans-I/O NTRIP request, handshake, stream, and GGA
+//!   helpers, while [`scenario`] exposes deterministic synthetic-observable
+//!   simulation and its typed truth ledger,
 //! - [`astro`] exposes time/frame conversions, Sun/Moon positions, RF link
 //!   budgets, solar beta angles, equinoctial element transforms, eclipse
 //!   events, conjunction/covariance utilities, CDM/OMM/TDM parsing, TCA
@@ -201,6 +206,13 @@ pub use sidereon_core::astro::frames::{
     EarthOrientation, EarthOrientationProvider, TdbEarthOrientationProvider,
 };
 pub use sidereon_core::astro::propagator::{ForceModelComponents, ForceModelKind};
+/// Deterministic scalar estimation and detection primitives, covariance-weighted
+/// track filtering, and fixed-interval RTS smoothing.
+///
+/// This is the public [`sidereon_core::estimation`] module re-exported without
+/// an additional facade layer, so its public submodules and native result and
+/// error types remain available unchanged.
+pub use sidereon_core::estimation;
 pub use sidereon_core::exact_cache;
 pub use sidereon_core::geometry_quality::{
     classify, GeometryQuality, GeometryQualityThresholds, ObservabilityTier,
@@ -228,6 +240,20 @@ pub use sidereon_core::{
     rinex, rtcm, rtk, sbas, sbas_pl, sidereal, signal, source_localization, ssr, staleness,
     static_positioning, terrain, terrain_store, tides, velocity,
 };
+
+/// Sans-I/O NTRIP request, handshake, stream, sourcetable, and GGA APIs.
+///
+/// The facade exposes [`ntrip::NtripClientMachine`], request/configuration
+/// types, sourcetable and chunk decoders, and [`ntrip::format_gga`] without
+/// taking ownership of HTTP, sockets, DNS, TLS, clocks, retries, or storage.
+pub use sidereon_core::ntrip;
+
+/// Deterministic synthetic GNSS scenario generation and its typed truth ledger.
+///
+/// The facade exposes [`scenario::simulate_scenario`] and its source/media
+/// variants, synthetic observables, declared external sources, optional media,
+/// and per-observation ground-truth terms.
+pub use sidereon_core::scenario;
 pub use sidereon_core::{
     catalog, catalog_entry, propagate_position, transform, transform_from_epoch, FrameCatalogError,
     HelmertParameters, HelmertRates, HelmertTransform, TerrestrialFrame, TerrestrialPositionM,

--- a/crates/sidereon/tests/estimation_facade.rs
+++ b/crates/sidereon/tests/estimation_facade.rs
@@ -1,0 +1,135 @@
+use sidereon::estimation::{
+    alpha_beta_apply_measurement, alpha_beta_filter_step, alpha_beta_predict,
+    alpha_beta_steady_state_gains, cfar_ca_false_alarm_probability, cfar_ca_multiplier_from_pfa,
+    cfar_ca_pfa_from_multiplier, cfar_ca_threshold, ewma_update, ewma_update_power_of_two,
+    kalman_cv_steady_state_gains, mad_spread, nis_expected_value, nis_gate_test,
+    nis_gate_threshold, nis_statistic, normalized_innovation, rts_smooth, smooth_track_rts,
+    AlphaBetaGains, AlphaBetaState, TrackCoordinateFrame, TrackFilter, TrackRtsHistoryBuilder,
+};
+
+#[test]
+fn scalar_estimation_and_detection_are_reachable_through_facade() {
+    let gains = alpha_beta_steady_state_gains(4.0).expect("alpha-beta gains");
+    assert!((gains.alpha - 0.864_145_399_682_717_8).abs() < 1.0e-12);
+    assert!((gains.beta - 0.737_169_180_900_238_8).abs() < 1.0e-12);
+
+    let state = AlphaBetaState {
+        level: 5.0,
+        rate: 2.0,
+    };
+    let predicted = alpha_beta_predict(state, 2.0).expect("alpha-beta prediction");
+    assert_eq!(predicted.level, 9.0);
+    assert_eq!(predicted.rate, 2.0);
+
+    let explicit_gains = AlphaBetaGains {
+        alpha: 0.6,
+        beta: 0.8,
+    };
+    let updated = alpha_beta_apply_measurement(predicted, 8.0, 2.0, explicit_gains)
+        .expect("alpha-beta update");
+    assert_eq!(updated.level, 8.4);
+    assert_eq!(updated.rate, 1.6);
+
+    let step = alpha_beta_filter_step(state, 8.0, 2.0, explicit_gains).expect("filter step");
+    assert_eq!(step.predicted, predicted);
+    assert_eq!(step.updated, updated);
+    assert_eq!(step.innovation, -1.0);
+
+    let kalman = kalman_cv_steady_state_gains(4.0, 1.0, 1.0).expect("scalar Kalman gains");
+    assert!((kalman.position_gain - gains.alpha).abs() < 1.0e-12);
+    assert!((kalman.rate_gain - gains.beta).abs() < 1.0e-12);
+
+    assert_eq!(
+        normalized_innovation(2.0, 4.0).expect("normalized innovation"),
+        1.0
+    );
+    assert_eq!(nis_statistic(2.0, 4.0).expect("NIS"), 1.0);
+    assert_eq!(nis_expected_value(2).expect("NIS expectation"), 2.0);
+    let threshold = nis_gate_threshold(1, 0.95).expect("NIS gate threshold");
+    assert!(threshold > 3.8 && threshold < 3.9);
+    assert!(
+        nis_gate_test(1.0, 1.0, 1, 0.95)
+            .expect("accepted NIS gate")
+            .in_gate
+    );
+    assert!(
+        !nis_gate_test(10.0, 1.0, 1, 0.95)
+            .expect("rejected NIS gate")
+            .in_gate
+    );
+
+    assert_eq!(ewma_update(10.0, 14.0, 0.25).expect("EWMA"), 11.0);
+    assert_eq!(
+        ewma_update_power_of_two(10.0, 14.0, 2).expect("power-of-two EWMA"),
+        11.0
+    );
+    assert!(
+        (mad_spread(&[1.0, 2.0, 3.0], 0.0).expect("MAD") - 1.482_602_218_505_602).abs() < 1.0e-15
+    );
+
+    let false_alarm_probability = 1.0e-3;
+    let multiplier =
+        cfar_ca_multiplier_from_pfa(16, false_alarm_probability).expect("CA-CFAR multiplier");
+    assert!(
+        (cfar_ca_pfa_from_multiplier(16, multiplier).expect("CA-CFAR PFA")
+            - false_alarm_probability)
+            .abs()
+            < 1.0e-15
+    );
+    let absolute_threshold =
+        cfar_ca_threshold(16, false_alarm_probability, 2.0).expect("CA-CFAR threshold");
+    assert_eq!(absolute_threshold, 2.0 * multiplier);
+    assert!(
+        (cfar_ca_false_alarm_probability(16, absolute_threshold, 2.0)
+            .expect("CA-CFAR inverse threshold")
+            - false_alarm_probability)
+            .abs()
+            < 1.0e-15
+    );
+}
+
+#[test]
+fn track_filter_and_rts_smoothing_are_reachable_through_facade() {
+    let mut filter = TrackFilter::from_position(
+        TrackCoordinateFrame::CallerDefinedCartesian,
+        0.0,
+        vec![0.0],
+        vec![vec![1.0]],
+        1.0,
+        0.1,
+    )
+    .expect("track filter");
+    let mut history = TrackRtsHistoryBuilder::from_filter(&filter).expect("RTS history");
+
+    let prediction = filter
+        .predict_recorded(1.0, &mut history)
+        .expect("recorded prediction");
+    assert_eq!(prediction.predicted.position_m, vec![0.0]);
+    assert_eq!(filter.state().t_s, 1.0);
+
+    let innovation = filter
+        .position_innovation(&[1.0], &[vec![0.25]])
+        .expect("track innovation");
+    assert_eq!(innovation.innovation, vec![1.0]);
+    assert!(
+        innovation
+            .gate(0.95)
+            .expect("track innovation gate")
+            .in_gate
+    );
+
+    let update = filter
+        .update_position_recorded(&[1.0], &[vec![0.25]], &mut history)
+        .expect("recorded position update");
+    assert!(update.updated.position_m[0] > 0.0);
+    assert_eq!(filter.state(), &update.updated);
+
+    let history = history.finish().expect("finished RTS history");
+    let smoothed = rts_smooth(&history).expect("RTS smoothing");
+    assert_eq!(smoothed.epochs.len(), 2);
+    assert_eq!(
+        smooth_track_rts(&history).expect("RTS smoothing alias"),
+        smoothed
+    );
+    assert_eq!(smoothed.epochs[1].state, history.epochs[1].updated);
+}

--- a/crates/sidereon/tests/ntrip_facade.rs
+++ b/crates/sidereon/tests/ntrip_facade.rs
@@ -1,0 +1,114 @@
+use sidereon::ntrip::{
+    format_gga, parse_sourcetable, ChunkedDecoder, GgaPosition, NtripClientMachine, NtripConfig,
+    NtripCredentials, NtripEvent, NtripHandshake, NtripState, NtripVersion, StrAuth,
+};
+
+fn config(version: NtripVersion) -> NtripConfig {
+    NtripConfig {
+        host: "caster.example.test".into(),
+        port: 2101,
+        mountpoint: "MOUNT".into(),
+        version,
+        credentials: None,
+        user_agent_product: "sidereon-test/0".into(),
+        gga_interval_s: None,
+    }
+}
+
+#[test]
+fn facade_exposes_ntrip_request_stream_and_gga_behavior() {
+    assert_eq!(
+        config(NtripVersion::Rev1).request_bytes().expect("request"),
+        b"GET /MOUNT HTTP/1.0\r\nUser-Agent: NTRIP sidereon-test/0\r\n\r\n"
+    );
+
+    let table = parse_sourcetable(
+        "STR;MOUNT;ID;RTCM;1004;2;GPS;NET;USA;40.1;-105.2;1;0;gen;none;B;N;9600;misc\r\n\
+         ENDSOURCETABLE\r\n",
+    )
+    .expect("sourcetable");
+    let stream = table.streams().next().expect("stream record");
+    assert_eq!(stream.mountpoint, "MOUNT");
+    assert_eq!(stream.authentication, StrAuth::Basic);
+
+    let mut decoder = ChunkedDecoder::new();
+    assert_eq!(decoder.push(b"4\r\nWi").expect("chunk prefix"), b"Wi");
+    assert_eq!(decoder.push(b"ki\r\n0\r\n\r\n").expect("chunk tail"), b"ki");
+    assert!(decoder.finished());
+
+    let mut machine = NtripClientMachine::new(config(NtripVersion::Rev2));
+    assert_eq!(machine.state(), NtripState::Idle);
+    machine.connection_request().expect("connection request");
+    let events = machine.push(b"HTTP/1.1 200 OK\r\nContent-Type: gnss/data\r\n\r\nabc");
+    assert_eq!(
+        events,
+        vec![
+            NtripEvent::Connected(NtripHandshake {
+                version: NtripVersion::Rev2,
+                chunked: false,
+                headers: vec![("Content-Type".into(), "gnss/data".into())],
+            }),
+            NtripEvent::Payload(b"abc".to_vec()),
+        ]
+    );
+    assert_eq!(machine.state(), NtripState::Streaming);
+
+    let sentence = format_gga(
+        &GgaPosition {
+            lat_deg: 40.0,
+            lon_deg: -105.0,
+            height_m: 1600.0,
+            ..GgaPosition::default()
+        },
+        3661.239,
+    )
+    .expect("GGA sentence");
+    assert_eq!(
+        sentence,
+        b"$GPGGA,010101.23,4000.0000000,N,10500.0000000,W,1,10,1.00,1600.0,M,,,,*2A\r\n"
+    );
+}
+
+#[test]
+fn facade_exposes_rev2_headers_and_chunked_machine() {
+    let mut config = config(NtripVersion::Rev2);
+    config.credentials = Some(NtripCredentials {
+        username: "user".into(),
+        password: "pass".into(),
+    });
+    assert_eq!(
+        config.request_headers().expect("request headers"),
+        (
+            "/MOUNT".into(),
+            vec![
+                ("Host".into(), "caster.example.test:2101".into()),
+                ("Ntrip-Version".into(), "Ntrip/2.0".into()),
+                ("User-Agent".into(), "NTRIP sidereon-test/0".into()),
+                ("Authorization".into(), "Basic dXNlcjpwYXNz".into()),
+                ("Connection".into(), "close".into()),
+            ],
+        )
+    );
+
+    let mut machine = NtripClientMachine::new(config);
+    machine.connection_request().expect("connection request");
+    let events = machine.push(
+        b"HTTP/1.1 200 OK\r\nContent-Type: gnss/data\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\n\r\n",
+    );
+    assert_eq!(
+        events,
+        vec![
+            NtripEvent::Connected(NtripHandshake {
+                version: NtripVersion::Rev2,
+                chunked: true,
+                headers: vec![
+                    ("Content-Type".into(), "gnss/data".into()),
+                    ("Transfer-Encoding".into(), "chunked".into()),
+                ],
+            }),
+            NtripEvent::Payload(b"abc".to_vec()),
+            NtripEvent::StreamEnded,
+        ]
+    );
+    assert_eq!(machine.state(), NtripState::Closed);
+}

--- a/crates/sidereon/tests/scenario_facade.rs
+++ b/crates/sidereon/tests/scenario_facade.rs
@@ -1,0 +1,166 @@
+use sidereon::scenario::{
+    scenario_source_transcript_fingerprint, simulate_scenario, simulate_scenario_with_media,
+    simulate_scenario_with_source, simulate_scenario_with_source_and_media, DeclaredScenarioSource,
+    Scenario, ScenarioConstellation, ScenarioEpochRange, ScenarioErrorBudget,
+    ScenarioExternalProduct, ScenarioExternalProductKind, ScenarioGeodeticPosition,
+    ScenarioMediaSources, ScenarioReceiver, ScenarioSignal, SyntheticKeplerOrbit,
+    SyntheticKeplerSource, SyntheticObservationSet, SCENARIO_SCHEMA_VERSION,
+};
+use sidereon::{GnssSatelliteId, GnssSystem};
+
+fn scenario() -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        seed: 7,
+        epochs: ScenarioEpochRange {
+            start_j2000_s: 0.0,
+            count: 1,
+            cadence_s: 1.0,
+        },
+        receiver: ScenarioReceiver::StaticGeodetic {
+            position: ScenarioGeodeticPosition {
+                lat_rad: 0.0,
+                lon_rad: 0.0,
+                height_m: 0.0,
+            },
+        },
+        constellation: ScenarioConstellation::SyntheticKeplerian {
+            satellites: vec![SyntheticKeplerOrbit {
+                satellite_id: GnssSatelliteId::new(GnssSystem::Gps, 1).expect("satellite"),
+                semi_major_axis_m: 26_560_000.0,
+                eccentricity: 0.0,
+                inclination_rad: 0.0,
+                raan_rad: 0.0,
+                arg_perigee_rad: 0.0,
+                mean_anomaly_rad: 0.0,
+                epoch_j2000_s: 0.0,
+                clock_bias_s: 0.0,
+                clock_drift_s_s: 0.0,
+            }],
+        },
+        signals: vec![ScenarioSignal::l1_ca(GnssSystem::Gps)],
+        error_budget: ScenarioErrorBudget::default(),
+    }
+}
+
+#[test]
+fn facade_exposes_deterministic_synthetic_observables_and_truth_ledger() {
+    let scenario = scenario();
+    let first: SyntheticObservationSet = simulate_scenario(&scenario).expect("first simulation");
+    let second = simulate_scenario_with_media(&scenario, &ScenarioMediaSources::default())
+        .expect("second simulation");
+
+    assert_eq!(first, second);
+    assert_eq!(first.observation_count(), 1);
+    assert_eq!(
+        first.determinism_fingerprint(),
+        second.determinism_fingerprint()
+    );
+    assert_eq!(
+        first
+            .truth_terms
+            .pseudorange_sum_m(0)
+            .expect("range terms")
+            .to_bits(),
+        first.observations.pseudorange_m[0].to_bits()
+    );
+    assert_eq!(
+        first
+            .truth_terms
+            .carrier_phase_sum_cycles(0)
+            .expect("phase terms")
+            .to_bits(),
+        first.observations.carrier_phase_cycles[0].to_bits()
+    );
+    assert_eq!(
+        first
+            .truth_terms
+            .doppler_sum_hz(0)
+            .expect("Doppler terms")
+            .to_bits(),
+        first.observations.doppler_hz[0].to_bits()
+    );
+
+    let source = SyntheticKeplerSource::new(
+        scenario
+            .satellites()
+            .iter()
+            .map(|sat| match &scenario.constellation {
+                ScenarioConstellation::SyntheticKeplerian { satellites } => satellites
+                    .iter()
+                    .find(|orbit| orbit.satellite_id == *sat)
+                    .copied()
+                    .expect("orbit"),
+                ScenarioConstellation::ExternalProducts { .. } => unreachable!(),
+            })
+            .collect(),
+    )
+    .expect("synthetic source");
+    let identity = ScenarioExternalProduct {
+        kind: ScenarioExternalProductKind::Sp3,
+        product_id: "synthetic".into(),
+        content_digest: "pending".into(),
+    };
+    let declared = DeclaredScenarioSource::new(&source, identity);
+    assert_eq!(declared.source().satellites().len(), 1);
+    assert!(ScenarioMediaSources::default().ionex.is_none());
+}
+
+#[test]
+fn facade_exposes_declared_ephemeris_source_variants() {
+    let synthetic = scenario();
+    let (orbits, satellite_ids) = match &synthetic.constellation {
+        ScenarioConstellation::SyntheticKeplerian { satellites } => (
+            satellites.clone(),
+            satellites.iter().map(|orbit| orbit.satellite_id).collect(),
+        ),
+        ScenarioConstellation::ExternalProducts { .. } => unreachable!(),
+    };
+    let source = SyntheticKeplerSource::new(orbits).expect("synthetic source");
+
+    let mut external = synthetic.clone();
+    let identity = ScenarioExternalProduct {
+        kind: ScenarioExternalProductKind::Sp3,
+        product_id: "synthetic".into(),
+        content_digest: "pending".into(),
+    };
+    external.constellation = ScenarioConstellation::ExternalProducts {
+        source: identity.clone(),
+        satellites: satellite_ids,
+    };
+
+    let declared = DeclaredScenarioSource::new(&source, identity.clone());
+    let digest = scenario_source_transcript_fingerprint(
+        &external,
+        &declared,
+        &ScenarioMediaSources::default(),
+    )
+    .expect("source fingerprint");
+    if let ScenarioConstellation::ExternalProducts { source, .. } = &mut external.constellation {
+        source.content_digest = digest;
+    }
+
+    let declared = DeclaredScenarioSource::new(
+        &source,
+        match &external.constellation {
+            ScenarioConstellation::ExternalProducts { source, .. } => source.clone(),
+            ScenarioConstellation::SyntheticKeplerian { .. } => unreachable!(),
+        },
+    );
+    let from_source = simulate_scenario_with_source(&external, &declared).expect("source run");
+    let from_source_and_media = simulate_scenario_with_source_and_media(
+        &external,
+        &declared,
+        &ScenarioMediaSources::default(),
+    )
+    .expect("source and media run");
+
+    assert_eq!(from_source, from_source_and_media);
+    assert_eq!(from_source.observation_count(), 1);
+    assert_eq!(
+        from_source.determinism_fingerprint(),
+        simulate_scenario(&synthetic)
+            .expect("synthetic run")
+            .determinism_fingerprint()
+    );
+}


### PR DESCRIPTION
A cross-interface audit of the five maintained surfaces at 1.1.1 found three capability groups that exist in public `sidereon-core` modules but have no `sidereon` facade route, so facade callers cannot reach them without depending on the engine crate directly.

- Estimation, detection, and tracking: alpha-beta and scalar Kalman filters, innovation/NIS gating, EWMA/MAD/CFAR detectors, `TrackFilter`, and RTS smoothing.
- Scenario simulation with its typed ground-truth ledger.
- Sans-I/O NTRIP protocol and state machine, including GGA formatting.

Re-exports and thin wrappers only; no modeling, and no engine changes. Tests cover each group through the facade surface.