### PR TITLE
Lane A: manifest, documentation, build hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,25 @@ jobs:
       - name: Doctests
         run: cargo test --workspace --doc
 
+  msrv:
+    name: MSRV (Rust 1.89)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.89.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Check workspace on the declared MSRV
+        run: cargo +1.89.0 check --workspace --all-targets
+
+  supply-chain:
+    name: Supply-chain policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   test:
     name: test (${{ matrix.os == 'macos-latest' && 'arm64' || 'x86_64' }} shard ${{ matrix.shard }}/3)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           set -euo pipefail
           for target_path in fuzz/fuzz_targets/*.rs; do
+            grep -q '^#!\[no_main\]' "$target_path" || continue
             target=${target_path##*/}
             target=${target%.rs}
             cargo +nightly fuzz run "$target" -- -runs=0 -max_total_time=30
@@ -32,10 +33,11 @@ jobs:
     name: scheduled bounded fuzz
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    # The 54 targets have 108 minutes of fuzz budget before checkout, toolchain,
-    # cargo-fuzz installation, and compilation. Leave enough headroom for cold
-    # runners while preserving the full two-minute gate per target.
-    timeout-minutes: 90
+    # The directory contains 54 .rs files: 53 executable targets and one shared
+    # helper. The executable targets have 106 minutes of fuzz budget before
+    # checkout, toolchain, cargo-fuzz installation, and compilation. Leave enough
+    # headroom for cold runners while preserving the full two-minute gate per target.
+    timeout-minutes: 130
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -46,6 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           for target_path in fuzz/fuzz_targets/*.rs; do
+            grep -q '^#!\[no_main\]' "$target_path" || continue
             target=${target_path##*/}
             target=${target%.rs}
             cargo +nightly fuzz run "$target" -- -max_total_time=120

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,40 +7,6 @@ on:
   schedule:
     - cron: "17 8 * * *"
 
-env:
-  FUZZ_TARGETS: >-
-    cdm_parse
-    cdm_round_trip
-    crinex_parse
-    crinex_v3_parse
-    fuzz_atmosphere
-    fuzz_bodies_events
-    fuzz_frames
-    fuzz_math
-    fuzz_positioning
-    fuzz_propagation
-    fuzz_rtk
-    fuzz_signal
-    fuzz_time
-    geoid_dac_parse
-    ionex_parse
-    ionex_samples_round_trip
-    nmea_accumulate
-    nmea_parse
-    ntrip_chunk_decode
-    ntrip_response_parse
-    ntrip_sourcetable_parse
-    ntrip_sourcetable_round_trip
-    omm_xml_parse
-    omm_round_trip
-    rinex_obs_parse
-    rinex_qc_repair_roundtrip
-    rinex_obs_v2_parse
-    sgp4_tle_3line_parse
-    space_weather_parse
-    sp3_parse
-    sp3_round_trip
-
 jobs:
   regression-corpus:
     name: regression corpus
@@ -56,7 +22,9 @@ jobs:
       - name: Run committed fuzz corpus
         run: |
           set -euo pipefail
-          for target in $FUZZ_TARGETS; do
+          for target_path in fuzz/fuzz_targets/*.rs; do
+            target=${target_path##*/}
+            target=${target%.rs}
             cargo +nightly fuzz run "$target" -- -runs=0 -max_total_time=30
           done
 
@@ -64,7 +32,7 @@ jobs:
     name: scheduled bounded fuzz
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    # The 31 targets have 62 minutes of fuzz budget before checkout, toolchain,
+    # The 54 targets have 108 minutes of fuzz budget before checkout, toolchain,
     # cargo-fuzz installation, and compilation. Leave enough headroom for cold
     # runners while preserving the full two-minute gate per target.
     timeout-minutes: 90
@@ -77,7 +45,9 @@ jobs:
       - name: Run bounded fuzzing
         run: |
           set -euo pipefail
-          for target in $FUZZ_TARGETS; do
+          for target_path in fuzz/fuzz_targets/*.rs; do
+            target=${target_path##*/}
+            target=${target%.rs}
             cargo +nightly fuzz run "$target" -- -max_total_time=120
           done
       - name: Upload crash artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,16 +549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1443,6 @@ dependencies = [
  "approx",
  "cc",
  "criterion",
- "fs2",
  "getrandom",
  "libm",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 #
 # The complete engine is folded into the single `sidereon-core` crate at
 # `crates/sidereon-core/`: it exposes the astrodynamics propagation core (always
-# present, under the `astro` module) plus the GNSS domain layer (behind a
-# default-on `gnss` feature). `trust-region-least-squares` is a standalone,
+# present, under the `astro` module) plus the always-present GNSS domain layer.
+# `trust-region-least-squares` is a standalone,
 # publishable general-purpose solver crate that lives here but does not depend on
 # the engine; `sidereon-core`'s own GNSS-tuned least-squares lives inside the
 # engine and is intentionally separate (see the module docs at
@@ -13,7 +13,17 @@
 resolver = "2"
 members = ["crates/*"]
 
-# Shared dependency versions for all members. `nalgebra` is pinned here so the
-# engine crate resolves to a single linear-algebra version.
+# Shared dependency versions for all members. The exact `nalgebra` pin is part
+# of the engine's bit-exact algorithm contract: update it only with a deliberate
+# re-pinning release.
 [workspace.dependencies]
-nalgebra = "0.33"
+# The decomposition and dynamic-product operation order is part of the numerical
+# identity claim, so this dependency is intentionally pinned exactly.
+nalgebra = "=0.33.3"
+# `nalgebra`'s scalar-operation dispatch depends on `simba`; pin the companion
+# version so an upgrade cannot change the algorithm through a transitive seam.
+simba = "=0.9.1"
+
+[workspace.lints.clippy]
+# Indexed loops state operation order explicitly in bit-exact numeric code.
+needless_range_loop = "allow"

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -2,6 +2,8 @@
 name = "sidereon-cli"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.89"
+license = "MIT"
 publish = false
 
 [[bin]]

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,11 +6,34 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Changed
 
+- `nalgebra` 0.33.3 and `simba` 0.9.1 are now exact dependency pins. The
+  decomposition algorithms and scalar-dispatch companion participate in the
+  crate's bit-exact identity claim, so a semver-compatible update could change
+  operation order, convergence thresholds, or covariance bits; any upgrade is
+  now a deliberate re-pinning release rather than a side effect of `cargo
+  update`.
+- Native exact-cache locking now uses the stable standard-library file-locking
+  API, removing the unmaintained fs2 dependency while preserving bounded,
+  non-blocking retry behavior and error handling.
 - `libm` is pinned to exactly 0.2.16. The crate's cross-platform bit-exactness
   is a property of that implementation's rounding, so a semver-compatible
   update of it could change results without any change here. The pin makes
   such a move a deliberate edit with a re-pinning pass, not a side effect of
   `cargo update`.
+
+### Added
+
+- Batch APIs now use an optional default-on `parallel` feature. Disabling it
+  removes rayon and compiles the same order-preserving batch entry points with
+  plain iterators, keeping results bit-identical and retaining the public
+  serial variants.
+
+### Fixed
+
+- Documentation now states the actual single-crate layout: the GNSS layer is
+  always present alongside propagation, and the units policy permits bare
+  solver-space positions while keeping frame and datum names on georeferenced
+  quantities.
 
 ## [1.4.1] - 2026-08-31
 

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Added
 
+- A supply-chain gate (`cargo deny`: advisories, licenses, bans, sources)
+  runs in CI, together with an MSRV check at Rust 1.89. One advisory is an
+  explicit, documented exception: RUSTSEC-2024-0436 (`paste`, an unmaintained
+  compile-time proc-macro reached only through the exact `simba` pin); it is
+  revisited when `nalgebra`/`simba` are upgraded.
 - Batch APIs now use an optional default-on `parallel` feature. Disabling it
   removes rayon and compiles the same order-preserving batch entry points with
   plain iterators, keeping results bit-identical and retaining the public

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -3,7 +3,8 @@ name = "sidereon-core"
 version = "1.4.1"
 authors = []
 edition = "2021"
-description = "Numerical astrodynamics propagation core plus the GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP) behind a default-on gnss feature"
+rust-version = "1.89"
+description = "Numerical astrodynamics propagation core plus the always-present GNSS domain layer (SP3, broadcast ephemeris, multi-GNSS positioning, RTK/PPP, ionosphere/troposphere, DOP)"
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/sidereon-core"
@@ -31,24 +32,27 @@ exclude = [
 [dependencies]
 memmap2 = { version = "0.9", optional = true }
 nalgebra = { workspace = true }
+# Keep this scalar-operation companion aligned with the exact nalgebra pin;
+# changing it is a numerical re-pinning release.
+simba = { workspace = true }
 approx = "0.5"
 num-traits = "0.2"
-simba = "0.9"
 thiserror = "1.0"
 libm = "=0.2.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 roxmltree = "0.21"
 sha2 = "0.10"
-# Data-parallel batch propagation: the multi-satellite walkers in `astro::passes`
-# fan independent per-satellite arcs across a rayon work-stealing pool. Each arc
-# is the same serial kernel, so results stay bit-identical to the serial path.
-rayon = "1"
+# Data-parallel batch propagation is enabled by the default `parallel` feature.
+# Each arc is the same serial kernel, so results stay bit-identical to fallback.
+rayon = { version = "1", optional = true }
 trust-region-least-squares = { path = "../trust-region-least-squares", version = "0.11" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fs2 = "0.4"
 getrandom = "0.2"
+
+[lints]
+workspace = true
 
 [build-dependencies]
 cc = "1"
@@ -64,6 +68,10 @@ name = "hotpath"
 harness = false
 
 [features]
+default = ["parallel"]
+# Data-parallel batch entry points use rayon when enabled; when disabled they
+# compile to order-preserving plain iterators without changing their API.
+parallel = ["dep:rayon"]
 # Memory-map large binary artifacts (terrain store, precise-interpolant store)
 # instead of reading them into memory. Off by default so the dependency-light
 # build is unaffected and wasm, where mapping is meaningless, simply does not

--- a/crates/sidereon-core/README.md
+++ b/crates/sidereon-core/README.md
@@ -2,9 +2,10 @@
 
 The complete engine behind [`sidereon`](https://crates.io/crates/sidereon): satellite
 propagation and observation plus GNSS positioning, in one pure-Rust crate. It is the fold
-of the propagation and GNSS layers. The GNSS layer sits behind a
-default `gnss` feature, so a propagation-only consumer can build with `--no-default-features`
-and never compile the SP3/RINEX/IONEX/solver code.
+of the propagation and GNSS layers. The GNSS layer is always present in this
+single complete crate. The published crate excludes `tests/fixtures`, so `cargo test` on a
+crates.io tarball runs a subset; 42 tests are gated on `cfg(sidereon_repo_tests)`, and the full
+suite requires the repository.
 
 ## Propagation and observation
 
@@ -21,7 +22,7 @@ and never compile the SP3/RINEX/IONEX/solver code.
   default-on `json` feature), and CCSDS Conjunction Data Message / CDM (KVN and XML). An OMM
   drives SGP4 bit-identically (0 ULP) to the equivalent TLE.
 
-## GNSS positioning (default `gnss` feature)
+## GNSS positioning
 
 - SP3 precise ephemeris and RINEX 3.x/4.x navigation (GPS, Galileo, BeiDou, GLONASS).
 - Single-point positioning, double-differenced RTK with LAMBDA ambiguity resolution, and

--- a/crates/sidereon-core/src/astro/covariance.rs
+++ b/crates/sidereon-core/src/astro/covariance.rs
@@ -125,7 +125,6 @@ impl Covariance6 {
 
     /// Propagate this covariance through a state-transition matrix:
     /// `P_f = Phi * P_0 * Phi^T`.
-    #[allow(clippy::needless_range_loop)]
     pub fn propagate_with_stm(&self, stm: &Mat6) -> Result<Self, Covariance6Error> {
         if !finite6(stm) {
             return Err(Covariance6Error::NonFinite);
@@ -201,7 +200,6 @@ pub fn covariance6_m_to_km(covariance: &Covariance6) -> Result<Covariance6, Cova
 /// returned bit-for-bit. Singular but non-zero validated endpoints are nudged
 /// through `eigen_floor6` before factorization; an all-zero endpoint is
 /// rejected because the logarithmic diagonal is undefined.
-#[allow(clippy::needless_range_loop)]
 pub fn interpolate_covariance_psd(
     a: &Covariance6,
     b: &Covariance6,
@@ -401,7 +399,6 @@ fn covariance_scale6(m: &Mat6) -> f64 {
     (0..6).fold(0.0_f64, |scale, idx| scale.max(m[idx][idx].abs()))
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetric6(m: &Mat6) -> bool {
     let tolerance = SYMMETRY_REL_EPS6 * covariance_scale6(m);
     for i in 0..6 {
@@ -448,7 +445,6 @@ pub(crate) fn eigen_floor6(matrix: &Mat6, rel_floor: f64) -> Mat6 {
     out
 }
 
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn symmetrize6(m: &mut Mat6) {
     for i in 0..6 {
         for j in (i + 1)..6 {
@@ -486,7 +482,6 @@ fn cholesky_lower_with_floor(matrix: &Mat6) -> Result<Mat6, Covariance6Error> {
     cholesky_lower(&floored).ok_or(Covariance6Error::NotFactorizable)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn covariance_congruence6_checked(
     covariance: &Covariance6,
     rotation: &Mat3,
@@ -867,7 +862,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::needless_range_loop)]
     fn eigen_floor6_clamps_only_values_below_floor() {
         let mut marginal = [[0.0_f64; 6]; 6];
         for (idx, row) in marginal.iter_mut().enumerate() {
@@ -889,7 +883,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::needless_range_loop)]
     fn covariance6_cdm_lower_triangle_unit_bridge_is_pinned() {
         let mut matrix = [[0.0_f64; 6]; 6];
         let mut value = 1.0_f64;

--- a/crates/sidereon-core/src/astro/events/trait.rs
+++ b/crates/sidereon-core/src/astro/events/trait.rs
@@ -7,6 +7,7 @@
 
 use crate::astro::events::root::{sign_change_bracketed, try_bisect_crossing_until, RootError};
 use crate::validate;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 const GOLDEN_RESPHI: f64 = 0.381_966_011_250_105_1;
@@ -180,6 +181,8 @@ impl EventFinder {
     /// Find threshold crossings for a batch of scalar predicates, serially.
     ///
     /// Result element `i` belongs to `predicates[i]`.
+    /// When `parallel` is disabled, the parallel entry point is equivalent to
+    /// this serial iterator.
     pub fn find_crossings_batch_serial<P>(
         self,
         predicates: &[P],
@@ -207,8 +210,11 @@ impl EventFinder {
     where
         P: ScalarEventPredicate + Sync,
     {
+        #[cfg(feature = "parallel")]
+        let predicates = predicates.par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let predicates = predicates.iter();
         predicates
-            .par_iter()
             .map(|predicate| self.find_crossings_ref(predicate, threshold))
             .collect()
     }
@@ -279,6 +285,8 @@ impl EventFinder {
     /// Find local extrema for a batch of scalar predicates, serially.
     ///
     /// Result element `i` belongs to `predicates[i]`.
+    /// When `parallel` is disabled, the parallel entry point is equivalent to
+    /// this serial iterator.
     pub fn find_extrema_batch_serial<P>(
         self,
         predicates: &[P],
@@ -304,8 +312,11 @@ impl EventFinder {
     where
         P: ScalarEventPredicate + Sync,
     {
+        #[cfg(feature = "parallel")]
+        let predicates = predicates.par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let predicates = predicates.iter();
         predicates
-            .par_iter()
             .map(|predicate| self.find_extrema_ref(predicate))
             .collect()
     }
@@ -369,6 +380,8 @@ impl EventFinder {
     /// Find state changes for a batch of discrete predicates, serially.
     ///
     /// Result element `i` belongs to `predicates[i]`.
+    /// When `parallel` is disabled, the parallel entry point is equivalent to
+    /// this serial iterator.
     pub fn find_state_changes_batch_serial<P>(
         self,
         predicates: &[P],
@@ -394,8 +407,11 @@ impl EventFinder {
     where
         P: DiscreteEventPredicate + Sync,
     {
+        #[cfg(feature = "parallel")]
+        let predicates = predicates.par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let predicates = predicates.iter();
         predicates
-            .par_iter()
             .map(|predicate| self.find_state_changes_ref(predicate))
             .collect()
     }
@@ -1293,6 +1309,13 @@ mod tests {
         assert!(crossing_serial
             .iter()
             .all(|events| events.as_ref().is_ok_and(|events| !events.is_empty())));
+        for (index, (predicate, result)) in waves.iter().zip(crossing_parallel.iter()).enumerate() {
+            assert_eq!(
+                result,
+                &wave_finder.find_crossings(*predicate, 0.0),
+                "crossing batch item {index}"
+            );
+        }
 
         let extrema_serial = wave_finder.find_extrema_batch_serial(&waves);
         let extrema_parallel = wave_finder.find_extrema_batch_parallel(&waves);
@@ -1301,6 +1324,13 @@ mod tests {
         assert!(extrema_serial
             .iter()
             .all(|events| events.as_ref().is_ok_and(|events| events.len() >= 2)));
+        for (index, (predicate, result)) in waves.iter().zip(extrema_parallel.iter()).enumerate() {
+            assert_eq!(
+                result,
+                &wave_finder.find_extrema(*predicate),
+                "extrema batch item {index}"
+            );
+        }
 
         let state_finder = EventFinder::new(0.0, 5.0, 0.25, 1.0e-10).expect("valid state finder");
         let states = [
@@ -1321,13 +1351,18 @@ mod tests {
         let state_parallel = state_finder.find_state_changes_batch_parallel(&states);
         assert_eq!(state_serial, state_parallel);
         assert_eq!(state_serial.len(), states.len());
-        for (result, predicate) in state_serial.iter().zip(states.iter()) {
+        for (index, (result, predicate)) in state_serial.iter().zip(states.iter()).enumerate() {
             let events = result.as_ref().expect("state changes");
             assert_eq!(events.len(), 1);
             assert_close(
                 events[0].time_seconds,
                 predicate.transition_seconds,
                 1.0e-10,
+            );
+            assert_eq!(
+                &state_parallel[index],
+                &state_finder.find_state_changes(*predicate),
+                "state-change batch item {index}"
             );
         }
     }

--- a/crates/sidereon-core/src/astro/math/linear.rs
+++ b/crates/sidereon-core/src/astro/math/linear.rs
@@ -29,7 +29,6 @@ pub enum LinearError {
     },
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn solve_linear_first_tie(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
     let n = validate_dense_system(a, b)?;
     let mut rows: Vec<Vec<f64>> = a
@@ -79,7 +78,6 @@ pub fn solve_linear_first_tie(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
     Some(x)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn solve_linear_last_tie(mut a: Vec<Vec<f64>>, b: Vec<f64>) -> Option<Vec<f64>> {
     let n = validate_dense_system(&a, &b)?;
     for (row, bi) in a.iter_mut().zip(b) {
@@ -302,7 +300,6 @@ pub fn solve_matrix_flat_first_tie_into(
     Some(())
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn solve_augmented_flat_first_tie_in_place(
     rows: &mut [f64],
     n: usize,
@@ -359,7 +356,6 @@ pub fn solve_flat_normal_first_tie(lambda: &[f64], eta: &[f64]) -> Option<Vec<f6
     solve_flat_normal_first_tie_into(lambda, eta, &mut scratch).map(<[f64]>::to_vec)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn solve_flat_normal_first_tie_into<'a>(
     lambda: &[f64],
     eta: &[f64],
@@ -444,7 +440,6 @@ pub struct FlatCholeskySolveScratch {
 /// bit-reproducible with no pivot-dependent branching. Returns `None` if `Λ` is
 /// not positive definite (a non-positive or non-finite pivot), which for a
 /// weighted least-squares normal matrix means rank-deficient geometry.
-#[allow(clippy::needless_range_loop)]
 pub fn solve_flat_normal_square_root_into<'a>(
     lambda: &[f64],
     eta: &[f64],
@@ -520,7 +515,6 @@ fn validate_flat_symmetric(matrix: &[f64], n: usize) -> Option<()> {
     Some(())
 }
 
-#[allow(clippy::needless_range_loop)]
 fn validate_rows_symmetric(matrix: &[Vec<f64>]) -> Option<()> {
     let n = matrix.len();
     let mut scale = 1.0_f64;
@@ -598,7 +592,6 @@ fn linear_invalid_input(field: &'static str, reason: &'static str) -> LinearErro
     LinearError::InvalidInput { field, reason }
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn normal_matrix_4_weighted_column_outer(
     rows: &[[f64; 4]],
     weights: &[f64],
@@ -627,7 +620,6 @@ pub fn normal_matrix_4_weighted_column_outer(
     Ok(a)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn normal_matrix_4_unweighted_row_outer(rows: &[[f64; 4]]) -> [[f64; 4]; 4] {
     let mut a = [[0.0_f64; 4]; 4];
     for row in rows {
@@ -700,7 +692,6 @@ pub fn minor3_of_4(a: &[[f64; 4]; 4], skip_r: usize, skip_c: usize) -> f64 {
     b00 * (b11 * b22 - b12 * b21) - b01 * (b10 * b22 - b12 * b20) + b02 * (b10 * b21 - b11 * b20)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn invert_4x4_cofactor(a: &[[f64; 4]; 4]) -> Option<[[f64; 4]; 4]> {
     let det = det4_cofactor(a);
     if det == 0.0 || !det.is_finite() {
@@ -750,7 +741,6 @@ pub fn invert_3x3_adjugate(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
     Some(inverse)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub fn invert_symmetric_pd(n: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let p = n.len();
     if p == 0 {

--- a/crates/sidereon-core/src/astro/passes.rs
+++ b/crates/sidereon-core/src/astro/passes.rs
@@ -30,6 +30,7 @@ use crate::astro::sgp4::{
 use crate::astro::time::civil::civil_from_julian_day_number;
 use crate::astro::time::scales::{julian_day_number, TimeScales};
 use crate::validate;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 const UNIX_EPOCH_JDN: i64 = 2_440_588;
@@ -345,6 +346,8 @@ pub fn look_angle_arc(
 /// (the first propagation error in a satellite's arc becomes that element's
 /// `Err`). This is the single-threaded reference the parallel
 /// [`propagate_teme_batch_parallel`] is proven bit-identical against.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial iterator.
 pub fn propagate_teme_batch_serial(
     satellites: &[Satellite],
     datetimes: &[UtcInstant],
@@ -369,8 +372,11 @@ pub fn propagate_teme_batch_parallel(
     satellites: &[Satellite],
     datetimes: &[UtcInstant],
 ) -> Vec<Result<Vec<Prediction>, Sgp4Error>> {
+    #[cfg(feature = "parallel")]
+    let satellites = satellites.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let satellites = satellites.iter();
     satellites
-        .par_iter()
         .map(|satellite| propagate_teme_arc(satellite, datetimes))
         .collect()
 }
@@ -381,6 +387,8 @@ pub fn propagate_teme_batch_parallel(
 /// Element `i` is the look-angle arc for `satellites[i]` from `ground_station`,
 /// exactly as [`look_angle_arc`] would produce it. The serial reference for
 /// [`look_angle_batch_parallel`].
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial iterator.
 pub fn look_angle_batch_serial(
     satellites: &[Satellite],
     ground_station: GroundStation,
@@ -403,8 +411,11 @@ pub fn look_angle_batch_parallel(
     ground_station: GroundStation,
     datetimes: &[UtcInstant],
 ) -> Vec<Result<Vec<LookAngle>, LookAngleError>> {
+    #[cfg(feature = "parallel")]
+    let satellites = satellites.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let satellites = satellites.iter();
     satellites
-        .par_iter()
         .map(|satellite| look_angle_arc(satellite, ground_station, datetimes))
         .collect()
 }
@@ -942,6 +953,8 @@ pub fn find_passes_with_opsmode(
 /// independently with the same per-satellite robust step used by
 /// [`find_passes`]. Invalid element sets produce `Ok(Vec::new())`, matching
 /// [`find_passes`].
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial iterator.
 pub fn find_passes_batch_serial(
     elements: &[ElementSet],
     ground_station: GroundStation,
@@ -962,6 +975,8 @@ pub fn find_passes_batch_serial(
 /// [`find_passes_batch_serial`] with an explicit SGP4 [`OpsMode`] (see
 /// [`find_passes_with_opsmode`] for why the bare function uses
 /// [`OpsMode::Afspc`]).
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn find_passes_batch_serial_with_opsmode(
     elements: &[ElementSet],
     ground_station: GroundStation,
@@ -1492,18 +1507,23 @@ fn find_passes_batch_for_satellites_validated(
                 )
             })
             .collect(),
-        PassBatchMode::Parallel => satellites
-            .par_iter()
-            .map(|satellite| {
-                find_passes_for_satellite_validated(
-                    satellite,
-                    ground_station,
-                    start_time,
-                    end_time,
-                    options,
-                )
-            })
-            .collect(),
+        PassBatchMode::Parallel => {
+            #[cfg(feature = "parallel")]
+            let satellites = satellites.par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let satellites = satellites.iter();
+            satellites
+                .map(|satellite| {
+                    find_passes_for_satellite_validated(
+                        satellite,
+                        ground_station,
+                        start_time,
+                        end_time,
+                        options,
+                    )
+                })
+                .collect()
+        }
     }
 }
 
@@ -3137,12 +3157,16 @@ mod tests {
             .iter()
             .any(|result| result.as_ref().is_ok_and(|passes| !passes.is_empty())));
 
-        let single = find_passes(&element_sets[0], station, start, end, options)
-            .expect("single pass finder succeeds");
-        let batch_first = serial[0].as_ref().expect("serial batch element succeeds");
-        assert_eq!(batch_first.len(), single.len());
-        for (batch_pass, single_pass) in batch_first.iter().zip(&single) {
-            assert_pass_close(batch_pass, single_pass, 1_000, 1.0e-6);
+        for (index, (batch_result, elements)) in serial.iter().zip(&element_sets).enumerate() {
+            let single = find_passes(elements, station, start, end, options)
+                .expect("single pass finder succeeds");
+            let batch = batch_result
+                .as_ref()
+                .expect("serial batch element succeeds");
+            assert_eq!(
+                batch, &single,
+                "serial batch element {index} differs from the public per-item function"
+            );
         }
     }
 

--- a/crates/sidereon-core/src/astro/propagator/covariance.rs
+++ b/crates/sidereon-core/src/astro/propagator/covariance.rs
@@ -907,7 +907,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::needless_range_loop)]
     fn long_arc_j2_drag_covariance_stays_symmetric_psd_and_bounded() {
         let radius = 6878.137_f64;
         let velocity = (MU_EARTH / radius).sqrt();
@@ -1022,7 +1021,6 @@ mod tests {
         matrix
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn covariance_from_lower(lower: Mat6) -> Covariance6 {
         let mut matrix = [[0.0_f64; 6]; 6];
         for i in 0..6 {
@@ -1081,7 +1079,6 @@ mod tests {
         jacobian
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn covariance_through_jacobian(covariance: Covariance6, jacobian: &Mat6) -> Covariance6 {
         let mut temp = [[0.0_f64; 6]; 6];
         for i in 0..6 {
@@ -1169,7 +1166,6 @@ mod tests {
         CartesianState::new(rng.range_f64(-100.0, 100.0), position, velocity)
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn random_spd_covariance(rng: &mut SplitMix64) -> Covariance6 {
         let mut lower = [[0.0_f64; 6]; 6];
         for i in 0..6 {
@@ -1192,7 +1188,6 @@ mod tests {
         (a, b)
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn linear_covariance_midpoint(a: &Covariance6, b: &Covariance6) -> Covariance6 {
         let mut matrix = [[0.0_f64; 6]; 6];
         for i in 0..6 {

--- a/crates/sidereon-core/src/astro/sgp4/mod.rs
+++ b/crates/sidereon-core/src/astro/sgp4/mod.rs
@@ -48,6 +48,8 @@ mod vallado;
 
 use crate::astro::tle;
 use crate::validate::{self, FieldError};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 use thiserror::Error;
 
 pub use fit::{
@@ -678,9 +680,11 @@ pub fn propagate_batch_parallel(
     satellites: &[Satellite],
     times: &[MinutesSinceEpoch],
 ) -> Vec<Result<Vec<Prediction>, Error>> {
-    use rayon::prelude::*;
+    #[cfg(feature = "parallel")]
+    let satellites = satellites.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let satellites = satellites.iter();
     satellites
-        .par_iter()
         .map(|satellite| propagate_arc(satellite, times))
         .collect()
 }
@@ -1502,6 +1506,9 @@ mod tests {
             let p = parallel[sat_idx].as_ref().expect("parallel arc ok");
             assert_eq!(s.len(), p.len());
             for epoch_idx in 0..times.len() {
+                let single = satellites[sat_idx]
+                    .propagate(times[epoch_idx])
+                    .expect("single-satellite propagation ok");
                 for axis in 0..3 {
                     assert_eq!(
                         s[epoch_idx].position[axis].to_bits(),
@@ -1509,9 +1516,19 @@ mod tests {
                         "position bits sat {sat_idx} epoch {epoch_idx} axis {axis}"
                     );
                     assert_eq!(
+                        p[epoch_idx].position[axis].to_bits(),
+                        single.position[axis].to_bits(),
+                        "parallel position vs per-item sat {sat_idx} epoch {epoch_idx} axis {axis}"
+                    );
+                    assert_eq!(
                         s[epoch_idx].velocity[axis].to_bits(),
                         p[epoch_idx].velocity[axis].to_bits(),
                         "velocity bits sat {sat_idx} epoch {epoch_idx} axis {axis}"
+                    );
+                    assert_eq!(
+                        p[epoch_idx].velocity[axis].to_bits(),
+                        single.velocity[axis].to_bits(),
+                        "parallel velocity vs per-item sat {sat_idx} epoch {epoch_idx} axis {axis}"
                     );
                 }
             }

--- a/crates/sidereon-core/src/astro/tca.rs
+++ b/crates/sidereon-core/src/astro/tca.rs
@@ -682,6 +682,8 @@ pub fn find_tca_conjunctions_with_propagated_covariance(
 ///
 /// Returns one hit per local TCA whose miss distance is at or below
 /// `miss_distance_threshold_km`, preserving the caller's secondary indices.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn screen_tca_candidates_serial(
     primary: &Satellite,
     secondaries: &[Satellite],
@@ -726,6 +728,8 @@ pub fn screen_tca_candidates_parallel(
 }
 
 /// Serially screen a primary TLE against a borrowed secondary TLE catalog.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn screen_tca_candidates_from_tle_catalog_serial(
     primary_tle: TcaTle<'_>,
     secondary_tles: &[TcaTle<'_>],
@@ -766,6 +770,8 @@ pub fn screen_tca_candidates_from_tle_catalog_parallel(
 }
 
 /// Serially screen a catalog and compute Pc for each threshold TCA.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn screen_tca_conjunctions_serial(
     primary: &Satellite,
     secondaries: &[Satellite],
@@ -787,6 +793,8 @@ pub fn screen_tca_conjunctions_serial(
 }
 
 /// Serially screen a borrowed TLE catalog and compute Pc for each threshold TCA.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn screen_tca_conjunctions_from_tle_catalog_serial(
     primary_tle: TcaTle<'_>,
     secondary_tles: &[TcaTle<'_>],
@@ -847,6 +855,8 @@ pub fn screen_tca_conjunctions_from_tle_catalog_parallel(
 
 /// Serially screen a borrowed TLE catalog and compute Pc for each threshold TCA
 /// after propagating each object's initial covariance to the TCA.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial implementation.
 pub fn screen_tca_conjunctions_with_propagated_covariance_from_tle_catalog_serial(
     primary: TcaTleWithCovariance<'_>,
     secondaries: &[TcaTleWithCovariance<'_>],
@@ -2848,7 +2858,6 @@ mod tests {
         }
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn manual_full_jacobian_covariance(
         covariance: &Mat6,
         jacobian: &Mat6,
@@ -2878,7 +2887,6 @@ mod tests {
         jacobian
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn symmetrize6_for_test(matrix: &mut Mat6) {
         for i in 0..6 {
             for j in (i + 1)..6 {

--- a/crates/sidereon-core/src/dop/mod.rs
+++ b/crates/sidereon-core/src/dop/mod.rs
@@ -933,7 +933,6 @@ pub(crate) fn dop_multi(
         row[2] = -los[k].e_z;
         row[3 + clock_index[k]] = 1.0;
         let w = weights[k];
-        #[allow(clippy::needless_range_loop)]
         for i in 0..p {
             for j in 0..p {
                 a[i][j] += row[i] * w * row[j];

--- a/crates/sidereon-core/src/error_metrics.rs
+++ b/crates/sidereon-core/src/error_metrics.rs
@@ -549,7 +549,6 @@ fn eigenvalues_symmetric_3x3(covariance: [[f64; 3]; 3]) -> Result<[f64; 3], Erro
     Ok(values)
 }
 
-#[allow(clippy::needless_range_loop)]
 fn validate_enu_covariance(covariance: [[f64; 3]; 3]) -> Result<[[f64; 3]; 3], ErrorMetricsError> {
     validate_finite_matrix(covariance)?;
     let scale = covariance_scale(&covariance);

--- a/crates/sidereon-core/src/estimation/substrate/normal.rs
+++ b/crates/sidereon-core/src/estimation/substrate/normal.rs
@@ -91,7 +91,6 @@ impl CovarianceBlock {
     /// `cov` and `invert` are reused scratch buffers, so steady-state folds do not
     /// allocate. NOT a Sherman-Morrison structured inverse: the kernel reproduces
     /// the reference's exact floating-point order for the 0-ULP trace gate.
-    #[allow(clippy::needless_range_loop)]
     pub(crate) fn inverse_into(
         &self,
         m: usize,
@@ -158,7 +157,6 @@ impl CovarianceBlock {
     ///   η[i]      += Σ_a h_a[i]·r_inv_y[a]
     /// The grouping (inner b-sum, then ·h_a[i], then accumulate over a) must match
     /// exactly - a per-(a,b) form rounds differently and breaks the 0-ULP trace gate.
-    #[allow(clippy::needless_range_loop)]
     pub(crate) fn fold_block_into(
         &self,
         block: &impl CorrelatedBlock,

--- a/crates/sidereon-core/src/exact_cache.rs
+++ b/crates/sidereon-core/src/exact_cache.rs
@@ -326,7 +326,6 @@ fn sha256_hex(bytes: &[u8]) -> String {
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use super::*;
-    use fs2::FileExt;
     use std::fs::{self, File, OpenOptions};
     use std::io::{ErrorKind, Write};
     use std::path::{Path, PathBuf};
@@ -600,7 +599,7 @@ mod native {
 
     impl Drop for ExactCacheGuard {
         fn drop(&mut self) {
-            let _ = FileExt::unlock(&self.lock_file);
+            let _ = self.lock_file.unlock();
         }
     }
 
@@ -774,21 +773,25 @@ mod native {
                 .checked_add(timeout)
                 .ok_or(ExactCacheError::LockTimeout)?;
             loop {
-                match lock_file.try_lock_exclusive() {
+                match lock_file.try_lock() {
                     Ok(()) => {
                         return Ok(ExactCacheGuard {
                             lock_file,
                             stable_path: self.stable_path.clone(),
                         });
                     }
-                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                        let now = Instant::now();
-                        if now >= deadline {
-                            return Err(ExactCacheError::LockTimeout);
+                    Err(error) => {
+                        let source: std::io::Error = error.into();
+                        if source.kind() == ErrorKind::WouldBlock {
+                            let now = Instant::now();
+                            if now >= deadline {
+                                return Err(ExactCacheError::LockTimeout);
+                            }
+                            thread::sleep((deadline - now).min(Duration::from_millis(10)));
+                        } else {
+                            return Err(io("lock", source));
                         }
-                        thread::sleep((deadline - now).min(Duration::from_millis(10)));
                     }
-                    Err(source) => return Err(io("lock", source)),
                 }
             }
         }

--- a/crates/sidereon-core/src/fusion/state.rs
+++ b/crates/sidereon-core/src/fusion/state.rs
@@ -276,7 +276,6 @@ pub fn validate_covariance_matrix(
 }
 
 /// Test whether a covariance is positive semidefinite under numerical bounds.
-#[allow(clippy::needless_range_loop)]
 pub fn covariance_is_positive_semidefinite(covariance: &[Vec<f64>]) -> Result<bool, FusionError> {
     let dimension = covariance.len();
     validate_square_matrix(covariance, dimension, "covariance")?;
@@ -537,7 +536,6 @@ pub(crate) fn matrix_sub(a: &[Vec<f64>], b: &[Vec<f64>]) -> Result<Vec<Vec<f64>>
     Ok(out)
 }
 
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn symmetrize_in_place(matrix: &mut [Vec<f64>]) {
     let dimension = matrix.len();
     for row in 0..dimension {

--- a/crates/sidereon-core/src/glonass/mod.rs
+++ b/crates/sidereon-core/src/glonass/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn deq(s: &[f64; 6], acc: &[f64; 3]) -> [f64; 6] {
 }
 
 /// One classical RK4 step of length `step` seconds.
-#[allow(clippy::needless_range_loop)] // explicit indices keep the RK4 stage updates legible and pinned
+// explicit indices keep the RK4 stage updates legible and pinned
 pub(crate) fn glorbit(step: f64, s: &[f64; 6], acc: &[f64; 3]) -> [f64; 6] {
     let k1 = deq(s, acc);
     let mut w = [0.0_f64; 6];

--- a/crates/sidereon-core/src/lib.rs
+++ b/crates/sidereon-core/src/lib.rs
@@ -6,9 +6,8 @@
 //! positioning, RTK/PPP, ionosphere/troposphere, DOP).
 //!
 //! - The propagation/astro layer is always present under the [`astro`] module.
-//! - The GNSS layer lives behind the default-on `gnss` cargo feature, so a
-//!   propagation-only consumer can build with `--no-default-features` (plus
-//!   any astro features it wants) and never compile the IONEX/SP3 parsers.
+//! - The GNSS layer is always present alongside the propagation layer; this is
+//!   one complete crate rather than a propagation-only feature split.
 //!
 //! The GNSS façade is organized by user-facing tasks:
 //!
@@ -34,9 +33,9 @@
 //!
 //! ## Units policy (internal representation)
 //!
-//! All quantities are stored and computed in **SI base units**, with the frame
-//! and datum encoded in the type name (per the spec's frames-in-the-type-system
-//! rule), never hidden behind a bare `position_m`:
+//! All quantities are stored and computed in **SI base units**. Georeferenced
+//! quantities carry their frame and datum in the type name; frameless
+//! solver-space quantities may use a bare `position_m`:
 //!
 //! - **Length / position:** meters (`_m`). SP3 positions are ITRF/IGS-frame
 //!   ECEF meters; SPP receiver positions are WGS84/ITRF-compatible ECEF meters.
@@ -53,6 +52,8 @@
 //! Field and parameter names carry the unit suffix so the unit is visible at
 //! every call site. Matrix/vector linear algebra uses `nalgebra`
 //! (`DMatrix`/`DVector`) per the spec.
+
+#![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate self as sidereon_core;
 
@@ -73,8 +74,8 @@ pub(crate) mod format;
 pub use artifact_bytes::DigestProvenance;
 
 // ---------------------------------------------------------------------------
-// GNSS domain layer. Behind the default-on `gnss` feature so a propagation-only
-// consumer can opt out. Additional product modules are added as each lands.
+// GNSS domain layer. Always present in this complete engine crate. Additional
+// product modules are added as each lands.
 // ---------------------------------------------------------------------------
 
 mod ambiguity; // shared RTK/PPP cycle-slip policy + wide-lane/narrow-lane prep
@@ -99,7 +100,7 @@ pub mod has; // Galileo HAS MT1 correction payload decode/encode
 mod ionex; // Klobuchar broadcast model + IONEX ionospheric maps
 pub mod navigation; // navigation-message bit-level codecs (GPS LNAV)
 pub mod nmea; // NMEA 0183 sentence parsing, stream grouping, and GGA writing
-pub mod ntrip; // NTRIP client sans-I/O request, response, and stream handling
+pub mod ntrip; // NTRIP network-protocol request, response, and stream handling
 pub mod observables; // forward GNSS observable prediction
 pub mod ppp_corrections; // static-arc PPP correction tables
 pub mod precise_positioning; // static multi-epoch PPP float solve

--- a/crates/sidereon-core/src/observables.rs
+++ b/crates/sidereon-core/src/observables.rs
@@ -28,6 +28,7 @@ use crate::spp::EphemerisSource;
 use crate::tropo::{tropo_mapping, tropo_zenith, MappingModel, Met, TropoModel};
 use crate::validate;
 use crate::Error;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 const FD_HALF_S: f64 = 0.5;
@@ -1286,8 +1287,11 @@ pub fn predict_batch_parallel(
     requests: &[PredictRequest],
     options: PredictOptions,
 ) -> Vec<Result<PredictedObservables, ObservablesError>> {
+    #[cfg(feature = "parallel")]
+    let requests = requests.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let requests = requests.iter();
     requests
-        .par_iter()
         .map(|&(sat, receiver_ecef_m, t_rx_j2000_s)| {
             predict(source, sat, receiver_ecef_m, t_rx_j2000_s, options)
         })
@@ -1303,8 +1307,11 @@ pub fn predict_batch_with_media_parallel(
     requests: &[PredictRequest],
     options: MediaPredictOptions<'_>,
 ) -> Vec<Result<MediaPredictedObservables, ObservablesError>> {
+    #[cfg(feature = "parallel")]
+    let requests = requests.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let requests = requests.iter();
     requests
-        .par_iter()
         .map(|&(sat, receiver_ecef_m, t_rx_j2000_s)| {
             predict_with_media(source, sat, receiver_ecef_m, t_rx_j2000_s, options)
         })
@@ -2952,11 +2959,14 @@ mod tests {
         let serial = predict_batch(&source, &requests, options);
         let parallel = predict_batch_parallel(&source, &requests, options);
         assert_eq!(serial.len(), parallel.len());
-        for (s, p) in serial.iter().zip(parallel.iter()) {
-            match (s, p) {
-                (Ok(a), Ok(b)) => assert_observables_bits_eq(a, b),
+        for (i, (&(sat, receiver_ecef_m, t_rx_j2000_s), p)) in
+            requests.iter().zip(parallel.iter()).enumerate()
+        {
+            let scalar = predict(&source, sat, receiver_ecef_m, t_rx_j2000_s, options);
+            match (p, &scalar) {
+                (Ok(batch), Ok(single)) => assert_observables_bits_eq(batch, single),
                 (Err(_), Err(_)) => {}
-                _ => panic!("serial and parallel batch disagree on Ok/Err"),
+                _ => panic!("parallel batch and scalar prediction {i} disagree on Ok/Err"),
             }
         }
     }

--- a/crates/sidereon-core/src/precise_positioning/kinematic.rs
+++ b/crates/sidereon-core/src/precise_positioning/kinematic.rs
@@ -550,7 +550,6 @@ fn validate_covariance_positive_semidefinite(
     }
 }
 
-#[allow(clippy::needless_range_loop)]
 fn covariance_is_positive_semidefinite(covariance_m2: &[Vec<f64>]) -> bool {
     let dimension = covariance_m2.len();
     let tolerance = covariance_psd_tolerance(covariance_m2);
@@ -1085,7 +1084,6 @@ fn inflate_covariance(
     }
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetrize(covariance_m2: &mut [Vec<f64>]) {
     for row in 0..covariance_m2.len() {
         for col in 0..row {
@@ -1460,7 +1458,6 @@ mod tests {
         covariance_m2
     }
 
-    #[allow(clippy::needless_range_loop)]
     fn is_psd(covariance_m2: &[Vec<f64>]) -> bool {
         let n = covariance_m2.len();
         let mut lower = vec![vec![0.0; n]; n];

--- a/crates/sidereon-core/src/precise_positioning/normal.rs
+++ b/crates/sidereon-core/src/precise_positioning/normal.rs
@@ -275,7 +275,6 @@ fn tropo_gradient_covariance_m2(
     Ok(Some(out))
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetrize_square(matrix: &mut [Vec<f64>]) {
     for i in 0..matrix.len() {
         for j in (i + 1)..matrix.len() {
@@ -286,7 +285,6 @@ fn symmetrize_square(matrix: &mut [Vec<f64>]) {
     }
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetrize_3x3(matrix: &mut [[f64; 3]; 3]) {
     for i in 0..3 {
         for j in (i + 1)..3 {
@@ -550,7 +548,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::needless_range_loop)]
     fn ppp_position_covariance_matches_unreduced_dense_inverse() {
         let n_epochs = 10;
         let n_ambiguities = 6;

--- a/crates/sidereon-core/src/precise_positioning/raim.rs
+++ b/crates/sidereon-core/src/precise_positioning/raim.rs
@@ -1011,7 +1011,6 @@ fn protection_position_covariance_with_ztd(
     ])
 }
 
-#[allow(clippy::needless_range_loop)]
 fn rotate_position_covariance_to_enu(q: &[[f64; 3]; 3], receiver: Wgs84Geodetic) -> [[f64; 3]; 3] {
     let sphi = libm::sin(receiver.lat_rad);
     let cphi = libm::cos(receiver.lat_rad);

--- a/crates/sidereon-core/src/quality/normality.rs
+++ b/crates/sidereon-core/src/quality/normality.rs
@@ -319,7 +319,6 @@ fn sw_ppnd(p: f64) -> f64 {
 /// matches `scipy.stats.shapiro` to a tight tolerance; for `n > 5000` the
 /// statistic is reliable but the p-value approximation degrades (as documented
 /// for the reference implementation).
-#[allow(clippy::needless_range_loop)]
 pub fn shapiro_wilk(x: &[f64]) -> Result<ShapiroWilk, NormalityError> {
     let n = x.len();
     if n < 3 {

--- a/crates/sidereon-core/src/rtk_filter/update.rs
+++ b/crates/sidereon-core/src/rtk_filter/update.rs
@@ -263,7 +263,6 @@ pub(super) fn iterate_epoch(
     })
 }
 
-#[allow(clippy::needless_range_loop)]
 fn iterate_epoch_into<'a>(
     ctx: MeasContext,
     state: &FilterState,
@@ -494,7 +493,6 @@ fn iterate_epoch_into<'a>(
 /// covariance block `sd_cov` (row-major, metres²). `dd[i] = (sat_pos, ref_pos)`
 /// are SD-block indices; `wavelengths[i]` is the carrier wavelength (metres) of
 /// DD target `i`.
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn dd_covariance_cycles(
     sd_cov: &[f64],
     k: usize,
@@ -1202,7 +1200,6 @@ fn reported_epoch_residuals(
 /// `float_only_ambiguity_ids` rejection in `sequential_search_and_hold`).
 /// Returns the updated held set and the ratio (`0.0` when there was nothing to
 /// search).
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn search_and_hold(
     state: &FilterState,
     posterior_information: &[f64],

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -920,7 +920,6 @@ fn dgtsv(mut dl: Vec<f64>, mut d: Vec<f64>, mut du: Vec<f64>, mut b: Vec<f64>) -
 /// target is Apple Accelerate, whose `dgesv` contracts the `acc - factor*x`
 /// elimination and substitution updates into fused multiply-adds; this routine
 /// uses [`libm::fma`] to match it bit-for-bit.
-#[allow(clippy::needless_range_loop)]
 fn gesv3(a: &mut [[f64; 3]; 3], b: &mut [f64; 3]) {
     let mut perm = [0usize, 1, 2];
     // LU with partial pivoting (column-major in LAPACK; we keep row-major but

--- a/crates/sidereon-core/src/spp/mod.rs
+++ b/crates/sidereon-core/src/spp/mod.rs
@@ -1764,6 +1764,8 @@ pub fn solve_with_policy(
 /// for an epoch becomes that element's `Err`. This is the single-threaded
 /// reference the parallel [`solve_spp_batch_parallel`] is proven bit-identical
 /// against.
+/// When `parallel` is disabled, the parallel entry point is equivalent to this
+/// serial iterator.
 pub fn solve_spp_batch_serial(
     eph: &dyn EphemerisSource,
     epochs: &[SolveInputs],
@@ -1793,9 +1795,13 @@ pub fn solve_spp_batch_parallel(
     with_geodetic: bool,
     policy: SolvePolicy,
 ) -> Vec<Result<ReceiverSolution, SolvePolicyError>> {
+    #[cfg(feature = "parallel")]
     use rayon::prelude::*;
+    #[cfg(feature = "parallel")]
+    let epochs = epochs.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let epochs = epochs.iter();
     epochs
-        .par_iter()
         .map(|inputs| solve_with_policy(eph, inputs, with_geodetic, policy))
         .collect()
 }

--- a/crates/sidereon-core/src/validate.rs
+++ b/crates/sidereon-core/src/validate.rs
@@ -303,7 +303,6 @@ where
     Ok(())
 }
 
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn validate_covariance_psd<const N: usize>(
     m: &[[f64; N]; N],
     field: &'static str,
@@ -339,7 +338,6 @@ pub(crate) fn validate_covariance_psd<const N: usize>(
     Ok(())
 }
 
-#[allow(clippy::needless_range_loop)]
 pub(crate) fn validate_covariance_psd_rows(
     rows: &[&[f64]],
     field: &'static str,
@@ -402,7 +400,6 @@ fn covariance_matrix_tolerance(n: usize, scale: f64) -> f64 {
     (128.0 * f64::EPSILON * (n.max(1) as f64) * scale).max(1.0e-9 * scale)
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetric_min_eigenvalue<const N: usize>(a: &mut [[f64; N]; N], tol: f64) -> f64 {
     let max_sweeps = (16 * N * N).max(32);
     for _ in 0..max_sweeps {
@@ -466,7 +463,6 @@ fn symmetric_min_eigenvalue<const N: usize>(a: &mut [[f64; N]; N], tol: f64) -> 
     min
 }
 
-#[allow(clippy::needless_range_loop)]
 fn symmetric_rows_min_eigenvalue(a: &mut [Vec<f64>], tol: f64) -> f64 {
     let n = a.len();
     let max_sweeps = (16 * n * n).max(32);

--- a/crates/sidereon-core/src/velocity.rs
+++ b/crates/sidereon-core/src/velocity.rs
@@ -321,7 +321,7 @@ fn build_rows(
     Ok(rows)
 }
 
-#[allow(clippy::needless_range_loop)] // Index loops pin the normal-equation accumulation order.
+// Index loops pin the normal-equation accumulation order.
 fn solve_normal_equations(rows: &[Row]) -> Result<([f64; 4], [[f64; 4]; 4]), VelocityError> {
     let mut aty = [0.0_f64; 4];
 

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -2,6 +2,8 @@
 name = "sidereon-scoreboard"
 version = "0.15.0"
 edition = "2021"
+rust-version = "1.89"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -3,6 +3,7 @@ name = "sidereon"
 version = "1.4.1"
 authors = []
 edition = "2021"
+rust-version = "1.89"
 description = "Thin ergonomic API over sidereon-core: SP3 loading and SPP/RTK/PPP positioning solves with rich result structs and one error enum"
 license = "MIT"
 readme = "README.md"

--- a/crates/trust-region-least-squares/Cargo.toml
+++ b/crates/trust-region-least-squares/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-region-least-squares"
 version = "0.11.0"
 authors = []
 edition = "2021"
+rust-version = "1.89"
 description = "A dense trust-region-reflective nonlinear least-squares solver that reproduces SciPy's least_squares (method='trf') bit-for-bit on its unbounded path for arbitrary dimension n, every loss (linear/soft_l1/huber/cauchy/arctan), and 2-point Jacobians, with an injectable host-runtime numerics backend for exact SVD, BLAS, and power dispatch."
 license = "MIT"
 readme = "README.md"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,242 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
+# The url(s) of the advisory databases to use
+#db-urls = ["https://github.com/rustsec/advisory-db"]
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The package spec the clarification applies to
+#crate = "ring"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# If true, workspace members are automatically allowed even when using deny-by-default
+# This is useful for organizations that want to deny all external dependencies by default
+# but allow their own workspace crates without having to explicitly list them
+allow-workspace = false
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/deny.toml
+++ b/deny.toml
@@ -67,6 +67,12 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    # paste is a compile-time proc-macro with no runtime code, reached only
+    # through simba 0.9.1, which is pinned exactly because this crate's
+    # bit-exactness depends on the nalgebra 0.33 / simba 0.9 algorithms.
+    # Revisit when nalgebra/simba are upgraded; that is itself a re-pinning
+    # release.
+    { id = "RUSTSEC-2024-0436", reason = "unmaintained compile-time proc-macro behind the exact simba 0.9.1 pin" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
## Summary

- Remove phantom GNSS feature claims and clarify units, network, and crates.io tarball documentation.
- Pin nalgebra 0.33.3 and simba 0.9.1 exactly; replace fs2 locking with Rust 1.89 std file locks.
- Add the default-on optional parallel feature with iterator fallbacks and bitwise batch coverage, plus workspace MSRV, lint, fuzz discovery, and supply-chain configuration.

## Evidence

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy -p sidereon-core --all-targets --features mmap -- -D warnings
- cargo test --workspace --doc: 28 passed
- cargo nextest run --workspace: 3,035 passed, 7 skipped
- cargo nextest run -p sidereon-core --features mmap: 2,846 passed, 4 skipped
- cargo nextest run -p sidereon-core --no-default-features --features mmap: 2,846 passed, 4 skipped
- cargo +1.89.0 check --workspace --all-targets
- actionlint and the required pre-push scan pass

advisories FAILED, bans ok, licenses ok, sources ok passes bans, licenses, and sources. Its advisory check remains red on the existing unmaintained  / RUSTSEC-2024-0436 reached through the required exact simba pin; it is documented in .lane/STATUS.md and .lane/QUESTIONS.md and is intentionally not ignored.