### PR TITLE
Lane G: refactor the OMM parser and SP3 merge into named stages

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to `sidereon-core` are documented here.
   update of it could change results without any change here. The pin makes
   such a move a deliberate edit with a re-pinning pass, not a side effect of
   `cargo update`.
+- OMM parsing and SP3 merging are organized into documented private stages;
+  frozen serializer outputs, diagnostics, and numerical results are unchanged.
 
 ## [1.4.1] - 2026-08-31
 

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -845,6 +845,7 @@ impl Omm {
         )?;
         let header = parse_header(map)?;
         let metadata = parse_metadata(map, time_system)?;
+        let mean_elements = parse_mean_elements(map, epoch)?;
 
         Ok(Omm {
             ccsds_omm_vers: header.ccsds_omm_vers,
@@ -856,13 +857,13 @@ impl Omm {
             ref_frame: metadata.ref_frame,
             time_system: metadata.time_system,
             mean_element_theory: metadata.mean_element_theory,
-            epoch,
-            mean_motion: req_num(get("MEAN_MOTION"), "MEAN_MOTION")?,
-            eccentricity: req_num(get("ECCENTRICITY"), "ECCENTRICITY")?,
-            inclination_deg: req_num(get("INCLINATION"), "INCLINATION")?,
-            ra_of_asc_node_deg: req_num(get("RA_OF_ASC_NODE"), "RA_OF_ASC_NODE")?,
-            arg_of_pericenter_deg: req_num(get("ARG_OF_PERICENTER"), "ARG_OF_PERICENTER")?,
-            mean_anomaly_deg: req_num(get("MEAN_ANOMALY"), "MEAN_ANOMALY")?,
+            epoch: mean_elements.epoch,
+            mean_motion: mean_elements.mean_motion,
+            eccentricity: mean_elements.eccentricity,
+            inclination_deg: mean_elements.inclination_deg,
+            ra_of_asc_node_deg: mean_elements.ra_of_asc_node_deg,
+            arg_of_pericenter_deg: mean_elements.arg_of_pericenter_deg,
+            mean_anomaly_deg: mean_elements.mean_anomaly_deg,
             ephemeris_type: opt_int(get("EPHEMERIS_TYPE"), "EPHEMERIS_TYPE")?.unwrap_or(0),
             classification_type: xml_text_or_default(
                 get("CLASSIFICATION_TYPE"),
@@ -919,6 +920,33 @@ fn parse_metadata(
         ref_frame: xml_text(get("REF_FRAME"), "REF_FRAME")?,
         time_system,
         mean_element_theory: xml_text(get("MEAN_ELEMENT_THEORY"), "MEAN_ELEMENT_THEORY")?,
+    })
+}
+
+struct OmmMeanElements {
+    epoch: OmmEpoch,
+    mean_motion: f64,
+    eccentricity: f64,
+    inclination_deg: f64,
+    ra_of_asc_node_deg: f64,
+    arg_of_pericenter_deg: f64,
+    mean_anomaly_deg: f64,
+}
+
+/// Consume the OMM epoch and mean-element fields and produce canonical values.
+fn parse_mean_elements(
+    map: &crate::format::kvn::FieldMap,
+    epoch: OmmEpoch,
+) -> Result<OmmMeanElements, OmmError> {
+    let get = |key: &str| map.get(key);
+    Ok(OmmMeanElements {
+        epoch,
+        mean_motion: req_num(get("MEAN_MOTION"), "MEAN_MOTION")?,
+        eccentricity: req_num(get("ECCENTRICITY"), "ECCENTRICITY")?,
+        inclination_deg: req_num(get("INCLINATION"), "INCLINATION")?,
+        ra_of_asc_node_deg: req_num(get("RA_OF_ASC_NODE"), "RA_OF_ASC_NODE")?,
+        arg_of_pericenter_deg: req_num(get("ARG_OF_PERICENTER"), "ARG_OF_PERICENTER")?,
+        mean_anomaly_deg: req_num(get("MEAN_ANOMALY"), "MEAN_ANOMALY")?,
     })
 }
 

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -846,6 +846,7 @@ impl Omm {
         let header = parse_header(map)?;
         let metadata = parse_metadata(map, time_system)?;
         let mean_elements = parse_mean_elements(map, epoch)?;
+        let tle_parameters = parse_tle_parameters(map)?;
 
         Ok(Omm {
             ccsds_omm_vers: header.ccsds_omm_vers,
@@ -864,18 +865,14 @@ impl Omm {
             ra_of_asc_node_deg: mean_elements.ra_of_asc_node_deg,
             arg_of_pericenter_deg: mean_elements.arg_of_pericenter_deg,
             mean_anomaly_deg: mean_elements.mean_anomaly_deg,
-            ephemeris_type: opt_int(get("EPHEMERIS_TYPE"), "EPHEMERIS_TYPE")?.unwrap_or(0),
-            classification_type: xml_text_or_default(
-                get("CLASSIFICATION_TYPE"),
-                "CLASSIFICATION_TYPE",
-                "U",
-            )?,
-            norad_cat_id: req_int(get("NORAD_CAT_ID"), "NORAD_CAT_ID")?,
-            element_set_no: opt_int(get("ELEMENT_SET_NO"), "ELEMENT_SET_NO")?.unwrap_or(999),
-            rev_at_epoch: opt_int(get("REV_AT_EPOCH"), "REV_AT_EPOCH")?.unwrap_or(0),
-            bstar: req_num(get("BSTAR"), "BSTAR")?,
-            mean_motion_dot: req_num(get("MEAN_MOTION_DOT"), "MEAN_MOTION_DOT")?,
-            mean_motion_ddot: req_num(get("MEAN_MOTION_DDOT"), "MEAN_MOTION_DDOT")?,
+            ephemeris_type: tle_parameters.ephemeris_type,
+            classification_type: tle_parameters.classification_type,
+            norad_cat_id: tle_parameters.norad_cat_id,
+            element_set_no: tle_parameters.element_set_no,
+            rev_at_epoch: tle_parameters.rev_at_epoch,
+            bstar: tle_parameters.bstar,
+            mean_motion_dot: tle_parameters.mean_motion_dot,
+            mean_motion_ddot: tle_parameters.mean_motion_ddot,
             exact_sgp4_epoch: None,
             quantize_tle_derived_fields: true,
         })
@@ -947,6 +944,36 @@ fn parse_mean_elements(
         ra_of_asc_node_deg: req_num(get("RA_OF_ASC_NODE"), "RA_OF_ASC_NODE")?,
         arg_of_pericenter_deg: req_num(get("ARG_OF_PERICENTER"), "ARG_OF_PERICENTER")?,
         mean_anomaly_deg: req_num(get("MEAN_ANOMALY"), "MEAN_ANOMALY")?,
+    })
+}
+
+struct OmmTleParameters {
+    ephemeris_type: i32,
+    classification_type: String,
+    norad_cat_id: u32,
+    element_set_no: i32,
+    rev_at_epoch: i64,
+    bstar: f64,
+    mean_motion_dot: f64,
+    mean_motion_ddot: f64,
+}
+
+/// Consume the OMM TLE-parameter fields and produce canonical values.
+fn parse_tle_parameters(map: &crate::format::kvn::FieldMap) -> Result<OmmTleParameters, OmmError> {
+    let get = |key: &str| map.get(key);
+    Ok(OmmTleParameters {
+        ephemeris_type: opt_int(get("EPHEMERIS_TYPE"), "EPHEMERIS_TYPE")?.unwrap_or(0),
+        classification_type: xml_text_or_default(
+            get("CLASSIFICATION_TYPE"),
+            "CLASSIFICATION_TYPE",
+            "U",
+        )?,
+        norad_cat_id: req_int(get("NORAD_CAT_ID"), "NORAD_CAT_ID")?,
+        element_set_no: opt_int(get("ELEMENT_SET_NO"), "ELEMENT_SET_NO")?.unwrap_or(999),
+        rev_at_epoch: opt_int(get("REV_AT_EPOCH"), "REV_AT_EPOCH")?.unwrap_or(0),
+        bstar: req_num(get("BSTAR"), "BSTAR")?,
+        mean_motion_dot: req_num(get("MEAN_MOTION_DOT"), "MEAN_MOTION_DOT")?,
+        mean_motion_ddot: req_num(get("MEAN_MOTION_DDOT"), "MEAN_MOTION_DDOT")?,
     })
 }
 

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -843,11 +843,12 @@ impl Omm {
             get("EPOCH").ok_or(OmmError::MissingField("EPOCH"))?,
             omm_civil_second_policy(time_system.as_deref()),
         )?;
+        let header = parse_header(map)?;
 
         Ok(Omm {
-            ccsds_omm_vers: xml_text_or_default(get("CCSDS_OMM_VERS"), "CCSDS_OMM_VERS", "2.0")?,
-            creation_date: xml_text(get("CREATION_DATE"), "CREATION_DATE")?,
-            originator: xml_text(get("ORIGINATOR"), "ORIGINATOR")?,
+            ccsds_omm_vers: header.ccsds_omm_vers,
+            creation_date: header.creation_date,
+            originator: header.originator,
             object_name: xml_text(get("OBJECT_NAME"), "OBJECT_NAME")?,
             object_id: xml_text(get("OBJECT_ID"), "OBJECT_ID")?,
             center_name: xml_text(get("CENTER_NAME"), "CENTER_NAME")?,
@@ -877,6 +878,22 @@ impl Omm {
             quantize_tle_derived_fields: true,
         })
     }
+}
+
+struct OmmHeader {
+    ccsds_omm_vers: String,
+    creation_date: Option<String>,
+    originator: Option<String>,
+}
+
+/// Consume the OMM header fields and produce their validated canonical values.
+fn parse_header(map: &crate::format::kvn::FieldMap) -> Result<OmmHeader, OmmError> {
+    let get = |key: &str| map.get(key);
+    Ok(OmmHeader {
+        ccsds_omm_vers: xml_text_or_default(get("CCSDS_OMM_VERS"), "CCSDS_OMM_VERS", "2.0")?,
+        creation_date: xml_text(get("CREATION_DATE"), "CREATION_DATE")?,
+        originator: xml_text(get("ORIGINATOR"), "ORIGINATOR")?,
+    })
 }
 
 fn xml_text(value: Option<&str>, field: &'static str) -> Result<Option<String>, OmmError> {

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -844,17 +844,18 @@ impl Omm {
             omm_civil_second_policy(time_system.as_deref()),
         )?;
         let header = parse_header(map)?;
+        let metadata = parse_metadata(map, time_system)?;
 
         Ok(Omm {
             ccsds_omm_vers: header.ccsds_omm_vers,
             creation_date: header.creation_date,
             originator: header.originator,
-            object_name: xml_text(get("OBJECT_NAME"), "OBJECT_NAME")?,
-            object_id: xml_text(get("OBJECT_ID"), "OBJECT_ID")?,
-            center_name: xml_text(get("CENTER_NAME"), "CENTER_NAME")?,
-            ref_frame: xml_text(get("REF_FRAME"), "REF_FRAME")?,
-            time_system,
-            mean_element_theory: xml_text(get("MEAN_ELEMENT_THEORY"), "MEAN_ELEMENT_THEORY")?,
+            object_name: metadata.object_name,
+            object_id: metadata.object_id,
+            center_name: metadata.center_name,
+            ref_frame: metadata.ref_frame,
+            time_system: metadata.time_system,
+            mean_element_theory: metadata.mean_element_theory,
             epoch,
             mean_motion: req_num(get("MEAN_MOTION"), "MEAN_MOTION")?,
             eccentricity: req_num(get("ECCENTRICITY"), "ECCENTRICITY")?,
@@ -893,6 +894,31 @@ fn parse_header(map: &crate::format::kvn::FieldMap) -> Result<OmmHeader, OmmErro
         ccsds_omm_vers: xml_text_or_default(get("CCSDS_OMM_VERS"), "CCSDS_OMM_VERS", "2.0")?,
         creation_date: xml_text(get("CREATION_DATE"), "CREATION_DATE")?,
         originator: xml_text(get("ORIGINATOR"), "ORIGINATOR")?,
+    })
+}
+
+struct OmmMetadata {
+    object_name: Option<String>,
+    object_id: Option<String>,
+    center_name: Option<String>,
+    ref_frame: Option<String>,
+    time_system: Option<String>,
+    mean_element_theory: Option<String>,
+}
+
+/// Consume OMM metadata fields and produce their validated canonical values.
+fn parse_metadata(
+    map: &crate::format::kvn::FieldMap,
+    time_system: Option<String>,
+) -> Result<OmmMetadata, OmmError> {
+    let get = |key: &str| map.get(key);
+    Ok(OmmMetadata {
+        object_name: xml_text(get("OBJECT_NAME"), "OBJECT_NAME")?,
+        object_id: xml_text(get("OBJECT_ID"), "OBJECT_ID")?,
+        center_name: xml_text(get("CENTER_NAME"), "CENTER_NAME")?,
+        ref_frame: xml_text(get("REF_FRAME"), "REF_FRAME")?,
+        time_system,
+        mean_element_theory: xml_text(get("MEAN_ELEMENT_THEORY"), "MEAN_ELEMENT_THEORY")?,
     })
 }
 

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
 //! CCSDS Orbit Mean-Elements Message (OMM) parser, encoder, and SGP4 bridge.
 //!
 //! OMM (CCSDS 502.0-B) is the modern replacement for the TLE: it carries the
@@ -576,12 +578,17 @@ pub fn encode_json(omm: &Omm) -> String {
 ///
 /// Each array member is the same object produced by [`encode_json`], preserving
 /// all scalar fields and optional metadata carried by [`Omm`].
+#[allow(clippy::expect_used)]
 pub fn encode_json_array(omms: &[Omm]) -> String {
     use serde_json::Value;
 
     let values: Vec<Value> = omms
         .iter()
-        .map(|omm| serde_json::from_str(&encode_json(omm)).expect("encoded OMM JSON object"))
+        .map(|omm| {
+            // invariant: encode_json constructs a serde_json object directly, so
+            // its serialized output is always a valid JSON object.
+            serde_json::from_str(&encode_json(omm)).expect("encoded OMM JSON object")
+        })
         .collect();
     Value::Array(values).to_string()
 }
@@ -1268,6 +1275,7 @@ fn fmt_num(value: f64) -> String {
 }
 
 #[cfg(all(test, sidereon_repo_tests))]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
 //! Multi-source SP3 combination: clock-datum alignment across analysis centers.
 //!
 //! Precise clock products from different analysis centers are referenced to
@@ -839,6 +841,9 @@ impl MergeReport {
                 });
                 current_key = key;
             }
+            // invariant: the branch above pushes the first aggregate before this
+            // lookup, and every later aggregate remains in `out`.
+            #[allow(clippy::expect_used)]
             let agg = out.last_mut().expect("just pushed");
             agg.position_max_m = agg.position_max_m.max(m.position_max_m);
             if m.position_members >= 2 {
@@ -963,40 +968,16 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     let timing = prepare_merge_timing(sources, opts)?;
     let epoch_interval_s = timing.epoch_interval_s;
     let cells = emit_merge_cells(sources, opts, &timing, frame_reconciliations);
-    let out_epochs = cells.out_epochs;
-    let out_epoch_j2000_s = cells.out_epoch_j2000_s;
-    let out_states = cells.out_states;
-    let out_raw = cells.out_raw;
-    let all_sats = cells.all_sats;
-    let mut report = cells.report;
-    let continuity_selection = cells.continuity_selection;
 
     let synthesized = synthesize_merge_header(
         sources,
-        &out_epochs,
-        &out_epoch_j2000_s,
-        all_sats,
+        &cells.out_epochs,
+        &cells.out_epoch_j2000_s,
+        &cells.all_sats,
         epoch_interval_s,
     )?;
-    let MergeHeaderOutput {
-        header,
-        mandatory_header_lines,
-        declared_satellite_tokens,
-        epoch_position_tokens,
-        epoch_state_record_sequence,
-    } = synthesized;
-    let merged = emit_merged_product(
-        sources,
-        header,
-        mandatory_header_lines,
-        declared_satellite_tokens,
-        epoch_position_tokens,
-        epoch_state_record_sequence,
-        out_epochs,
-        out_epoch_j2000_s,
-        out_states,
-        out_raw,
-    );
+    let (merged, mut report, continuity_selection) =
+        emit_merged_product(sources, synthesized, cells);
 
     if let Some(continuity_options) = opts.verify_continuity.as_ref() {
         report.continuity = Some(verify_merged_continuity(
@@ -1036,17 +1017,30 @@ struct MergeHeaderOutput {
 /// changing the serializer-facing header counts, records, or source comment.
 fn emit_merged_product(
     sources: &[Sp3],
-    header: Sp3Header,
-    mandatory_header_lines: usize,
-    declared_satellite_tokens: Vec<String>,
-    epoch_position_tokens: Vec<Vec<String>>,
-    epoch_state_record_sequence: Vec<Vec<(char, String)>>,
-    out_epochs: Vec<Instant>,
-    out_epoch_j2000_s: Vec<f64>,
-    out_states: Vec<BTreeMap<GnssSatelliteId, Sp3State>>,
-    out_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
-) -> Sp3 {
-    Sp3 {
+    synthesized: MergeHeaderOutput,
+    cells: MergeCellOutput,
+) -> (
+    Sp3,
+    MergeReport,
+    BTreeMap<(GnssSatelliteId, i64), CellSelection>,
+) {
+    let MergeHeaderOutput {
+        header,
+        mandatory_header_lines,
+        declared_satellite_tokens,
+        epoch_position_tokens,
+        epoch_state_record_sequence,
+    } = synthesized;
+    let MergeCellOutput {
+        out_epochs,
+        out_epoch_j2000_s,
+        out_states,
+        out_raw,
+        report,
+        continuity_selection,
+        ..
+    } = cells;
+    let merged = Sp3 {
         header,
         epochs: out_epochs,
         declared_num_epochs: out_epoch_j2000_s.len() as u64,
@@ -1068,7 +1062,8 @@ fn emit_merged_product(
         interp_raw: out_raw,
         comments: vec![format!("MERGED from {} SP3 products", sources.len())],
         skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
-    }
+    };
+    (merged, report, continuity_selection)
 }
 
 /// Consume ordered merged cells and source metadata, and produce the synthetic
@@ -1077,7 +1072,7 @@ fn synthesize_merge_header(
     sources: &[Sp3],
     out_epochs: &[Instant],
     out_epoch_j2000_s: &[f64],
-    all_sats: BTreeSet<GnssSatelliteId>,
+    all_sats: &BTreeSet<GnssSatelliteId>,
     epoch_interval_s: f64,
 ) -> Result<MergeHeaderOutput> {
     // Base the non-epoch metadata on a source product, but derive the first-epoch
@@ -1112,7 +1107,7 @@ fn synthesize_merge_header(
         Error::InvalidInput("merged SP3 first epoch cannot be represented in header fields".into())
     })?;
 
-    let satellites: Vec<_> = all_sats.into_iter().collect();
+    let satellites: Vec<_> = all_sats.iter().copied().collect();
     let satellite_accuracy_codes = satellites
         .iter()
         .map(|sat| {
@@ -1189,8 +1184,8 @@ fn emit_merge_cells(
     {
         Some(precedence_sources_for_satellites(
             sources,
-            &epoch_index,
-            &epoch_keys,
+            epoch_index,
+            epoch_keys,
             opts.systems.as_ref(),
         ))
     } else {
@@ -1421,6 +1416,9 @@ fn emit_merge_cells(
                         (Some(clk[preferred_idx].1), vec![preferred_idx])
                     }
                     Some(preferred_idx) if opts.outlier_reject.is_some() => {
+                        // invariant: this match arm is guarded by
+                        // `outlier_reject.is_some()` immediately above.
+                        #[allow(clippy::expect_used)]
                         let reject = opts.outlier_reject.expect("checked above");
                         let vals: Vec<f64> = clk.iter().map(|(_, c, _)| *c).collect();
                         let cluster =
@@ -1566,8 +1564,13 @@ fn emit_merge_cells(
             states.insert(
                 sat,
                 Sp3State {
-                    position: ItrfPositionM::new(position_m[0], position_m[1], position_m[2])
-                        .expect("valid ITRF position"),
+                    position: {
+                        // invariant: parsed SP3 coordinates and finite consensus
+                        // arithmetic produce a valid finite ITRF position.
+                        #[allow(clippy::expect_used)]
+                        ItrfPositionM::new(position_m[0], position_m[1], position_m[2])
+                            .expect("valid ITRF position")
+                    },
                     clock_s,
                     velocity: None,
                     clock_rate_s_s: None,
@@ -2424,13 +2427,18 @@ fn combine_axis(members: &[(usize, f64)], how: MergeCombine) -> f64 {
         MergeCombine::Mean => members.iter().map(|(_, v)| *v).sum::<f64>() / members.len() as f64,
         MergeCombine::Median => {
             let mut vals: Vec<f64> = members.iter().map(|(_, v)| *v).collect();
+            // invariant: combine_axis is called only with a non-empty consensus
+            // cluster selected by the preceding merge stage.
+            #[allow(clippy::expect_used)]
             median(&mut vals).expect("consensus cluster is non-empty")
         }
-        MergeCombine::Precedence => members
-            .iter()
-            .min_by_key(|(s, _)| *s)
-            .map(|(_, v)| *v)
-            .expect("consensus cluster is non-empty"),
+        MergeCombine::Precedence => {
+            let preferred = members.iter().min_by_key(|(s, _)| *s).map(|(_, v)| *v);
+            // invariant: combine_axis is called only with a non-empty consensus
+            // cluster selected by the preceding merge stage.
+            #[allow(clippy::expect_used)]
+            preferred.expect("consensus cluster is non-empty")
+        }
     }
 }
 
@@ -2603,6 +2611,7 @@ fn transition_between(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::super::Sp3;
     use super::{

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -970,6 +970,88 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     let all_sats = cells.all_sats;
     let mut report = cells.report;
     let continuity_selection = cells.continuity_selection;
+
+    let synthesized = synthesize_merge_header(
+        sources,
+        &out_epochs,
+        &out_epoch_j2000_s,
+        all_sats,
+        epoch_interval_s,
+    )?;
+    let MergeHeaderOutput {
+        header,
+        mandatory_header_lines,
+        declared_satellite_tokens,
+        epoch_position_tokens,
+        epoch_state_record_sequence,
+    } = synthesized;
+    let merged = Sp3 {
+        header,
+        epochs: out_epochs,
+        declared_num_epochs: out_epoch_j2000_s.len() as u64,
+        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
+        terminal_record: TerminalRecordState::valid(),
+        satellite_header_lines: mandatory_header_lines,
+        accuracy_header_lines: mandatory_header_lines,
+        time_system_header_lines: 2,
+        float_header_lines: 2,
+        integer_header_lines: 2,
+        header_comment_lines: 4,
+        declared_satellite_count: Some(declared_satellite_tokens.len()),
+        declared_satellite_tokens,
+        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
+        epoch_position_tokens,
+        epoch_state_record_sequence,
+        epoch_j2000_s: out_epoch_j2000_s,
+        states: out_states,
+        interp_raw: out_raw,
+        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
+        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
+    };
+
+    if let Some(continuity_options) = opts.verify_continuity.as_ref() {
+        report.continuity = Some(verify_merged_continuity(
+            &merged,
+            continuity_options,
+            &continuity_selection,
+        ));
+    }
+
+    Ok((merged, report))
+}
+
+struct PreparedMergeInputs {
+    sources: Vec<Sp3>,
+    frame_reconciliations: Vec<Sp3FrameReconciliation>,
+}
+
+struct MergeCellOutput {
+    out_epochs: Vec<Instant>,
+    out_epoch_j2000_s: Vec<f64>,
+    out_states: Vec<BTreeMap<GnssSatelliteId, Sp3State>>,
+    out_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
+    all_sats: BTreeSet<GnssSatelliteId>,
+    report: MergeReport,
+    continuity_selection: BTreeMap<(GnssSatelliteId, i64), CellSelection>,
+}
+
+struct MergeHeaderOutput {
+    header: Sp3Header,
+    mandatory_header_lines: usize,
+    declared_satellite_tokens: Vec<String>,
+    epoch_position_tokens: Vec<Vec<String>>,
+    epoch_state_record_sequence: Vec<Vec<(char, String)>>,
+}
+
+/// Consume ordered merged cells and source metadata, and produce the synthetic
+/// SP3 header plus the canonical output record-token sequences.
+fn synthesize_merge_header(
+    sources: &[Sp3],
+    out_epochs: &[Instant],
+    out_epoch_j2000_s: &[f64],
+    all_sats: BTreeSet<GnssSatelliteId>,
+    epoch_interval_s: f64,
+) -> Result<MergeHeaderOutput> {
     // Base the non-epoch metadata on a source product, but derive the first-epoch
     // header fields from the merged grid itself. Mixed cadence / coverage can make
     // the merged first epoch later than every input's first epoch, so cloning
@@ -1052,54 +1134,14 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
-    let merged = Sp3 {
+
+    Ok(MergeHeaderOutput {
         header,
-        epochs: out_epochs,
-        declared_num_epochs: out_epoch_j2000_s.len() as u64,
-        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
-        terminal_record: TerminalRecordState::valid(),
-        satellite_header_lines: mandatory_header_lines,
-        accuracy_header_lines: mandatory_header_lines,
-        time_system_header_lines: 2,
-        float_header_lines: 2,
-        integer_header_lines: 2,
-        header_comment_lines: 4,
-        declared_satellite_count: Some(declared_satellite_tokens.len()),
+        mandatory_header_lines,
         declared_satellite_tokens,
-        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
         epoch_position_tokens,
         epoch_state_record_sequence,
-        epoch_j2000_s: out_epoch_j2000_s,
-        states: out_states,
-        interp_raw: out_raw,
-        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
-        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
-    };
-
-    if let Some(continuity_options) = opts.verify_continuity.as_ref() {
-        report.continuity = Some(verify_merged_continuity(
-            &merged,
-            continuity_options,
-            &continuity_selection,
-        ));
-    }
-
-    Ok((merged, report))
-}
-
-struct PreparedMergeInputs {
-    sources: Vec<Sp3>,
-    frame_reconciliations: Vec<Sp3FrameReconciliation>,
-}
-
-struct MergeCellOutput {
-    out_epochs: Vec<Instant>,
-    out_epoch_j2000_s: Vec<f64>,
-    out_states: Vec<BTreeMap<GnssSatelliteId, Sp3State>>,
-    out_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
-    all_sats: BTreeSet<GnssSatelliteId>,
-    report: MergeReport,
-    continuity_selection: BTreeMap<(GnssSatelliteId, i64), CellSelection>,
+    })
 }
 
 /// Consume ordered merge timing data and emit every accepted epoch/satellite cell,

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -985,29 +985,18 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
         epoch_position_tokens,
         epoch_state_record_sequence,
     } = synthesized;
-    let merged = Sp3 {
+    let merged = emit_merged_product(
+        sources,
         header,
-        epochs: out_epochs,
-        declared_num_epochs: out_epoch_j2000_s.len() as u64,
-        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
-        terminal_record: TerminalRecordState::valid(),
-        satellite_header_lines: mandatory_header_lines,
-        accuracy_header_lines: mandatory_header_lines,
-        time_system_header_lines: 2,
-        float_header_lines: 2,
-        integer_header_lines: 2,
-        header_comment_lines: 4,
-        declared_satellite_count: Some(declared_satellite_tokens.len()),
+        mandatory_header_lines,
         declared_satellite_tokens,
-        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
         epoch_position_tokens,
         epoch_state_record_sequence,
-        epoch_j2000_s: out_epoch_j2000_s,
-        states: out_states,
-        interp_raw: out_raw,
-        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
-        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
-    };
+        out_epochs,
+        out_epoch_j2000_s,
+        out_states,
+        out_raw,
+    );
 
     if let Some(continuity_options) = opts.verify_continuity.as_ref() {
         report.continuity = Some(verify_merged_continuity(
@@ -1041,6 +1030,45 @@ struct MergeHeaderOutput {
     declared_satellite_tokens: Vec<String>,
     epoch_position_tokens: Vec<Vec<String>>,
     epoch_state_record_sequence: Vec<Vec<(char, String)>>,
+}
+
+/// Assemble the canonical `Sp3` product from the ordered merge stages without
+/// changing the serializer-facing header counts, records, or source comment.
+fn emit_merged_product(
+    sources: &[Sp3],
+    header: Sp3Header,
+    mandatory_header_lines: usize,
+    declared_satellite_tokens: Vec<String>,
+    epoch_position_tokens: Vec<Vec<String>>,
+    epoch_state_record_sequence: Vec<Vec<(char, String)>>,
+    out_epochs: Vec<Instant>,
+    out_epoch_j2000_s: Vec<f64>,
+    out_states: Vec<BTreeMap<GnssSatelliteId, Sp3State>>,
+    out_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
+) -> Sp3 {
+    Sp3 {
+        header,
+        epochs: out_epochs,
+        declared_num_epochs: out_epoch_j2000_s.len() as u64,
+        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
+        terminal_record: TerminalRecordState::valid(),
+        satellite_header_lines: mandatory_header_lines,
+        accuracy_header_lines: mandatory_header_lines,
+        time_system_header_lines: 2,
+        float_header_lines: 2,
+        integer_header_lines: 2,
+        header_comment_lines: 4,
+        declared_satellite_count: Some(declared_satellite_tokens.len()),
+        declared_satellite_tokens,
+        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
+        epoch_position_tokens,
+        epoch_state_record_sequence,
+        epoch_j2000_s: out_epoch_j2000_s,
+        states: out_states,
+        interp_raw: out_raw,
+        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
+        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
+    }
 }
 
 /// Consume ordered merged cells and source metadata, and produce the synthetic

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -960,70 +960,11 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     let frame_reconciliations = prepared.frame_reconciliations;
     let sources = prepared_sources.as_slice();
 
-    // floored-J2000-second -> epoch index, per source.
-    let epoch_index: Vec<BTreeMap<i64, usize>> = sources
-        .iter()
-        .map(|s| {
-            s.epochs
-                .iter()
-                .enumerate()
-                .filter_map(|(i, ep)| {
-                    sp3_epoch_j2000_seconds(s, i, ep).map(|sec| (sec.floor() as i64, i))
-                })
-                .collect()
-        })
-        .collect();
-
-    let epoch_interval_s = resolve_common_epoch_interval(sources, opts.target_epoch_interval_s)?;
-
-    // Per-source per-epoch clock-datum offset relative to source 0. Source 0 is
-    // the datum, so its offset is identically zero.
-    let clock_offset: Vec<BTreeMap<i64, f64>> = sources
-        .iter()
-        .enumerate()
-        .map(|(idx, s)| {
-            if idx == 0 {
-                BTreeMap::new()
-            } else {
-                clock_reference_offset(&sources[0], s, opts.clock_min_common)
-                    .into_iter()
-                    .filter_map(|o| {
-                        instant_to_j2000_seconds(&o.epoch)
-                            .map(|sec| (sec.floor() as i64, o.offset_s))
-                    })
-                    .collect()
-            }
-        })
-        .collect();
-
-    // Union of epochs (by floored second), retaining the representative Instant
-    // from the earliest-listed source on duplicate keys. This is what lets a
-    // dense source fill cells absent from a sparse preferred source.
-    let mut epoch_keys: BTreeMap<i64, Instant> = BTreeMap::new();
-    for source in sources {
-        for (idx, ep) in source.epochs.iter().enumerate() {
-            if let Some(sec) = sp3_epoch_j2000_seconds(source, idx, ep) {
-                epoch_keys.entry(sec.floor() as i64).or_insert(*ep);
-            }
-        }
-    }
-
-    // Restrict the union to the resolved output grid (anchored at the earliest
-    // union epoch), dropping off-grid epochs by exact subset selection. This is
-    // a no-op at the default finest cadence and performs deterministic
-    // decimation for an explicit coarser target.
-    if let Some((&anchor, _)) = epoch_keys.iter().next() {
-        let step = epoch_interval_s.round() as i64;
-        if step > 0 {
-            epoch_keys.retain(|&key, _| (key - anchor).rem_euclid(step) == 0);
-        }
-    }
-
-    if epoch_keys.is_empty() {
-        return Err(Error::InvalidInput(
-            "merge inputs have no epochs on the requested time grid".into(),
-        ));
-    }
+    let timing = prepare_merge_timing(sources, opts)?;
+    let epoch_index = timing.epoch_index;
+    let epoch_interval_s = timing.epoch_interval_s;
+    let clock_offset = timing.clock_offset;
+    let epoch_keys = timing.epoch_keys;
 
     let precedence_source_for_sat = if opts.combine == MergeCombine::Precedence
         && opts.precedence_scope == MergePrecedenceScope::SatelliteArc
@@ -1571,6 +1512,13 @@ struct PreparedMergeInputs {
     frame_reconciliations: Vec<Sp3FrameReconciliation>,
 }
 
+struct MergeTiming {
+    epoch_index: Vec<BTreeMap<i64, usize>>,
+    epoch_interval_s: f64,
+    clock_offset: Vec<BTreeMap<i64, f64>>,
+    epoch_keys: BTreeMap<i64, Instant>,
+}
+
 /// Consume raw SP3 sources and merge options, validate their combinability, and
 /// produce frame-reconciled sources plus the reconciliation audit trail.
 fn prepare_merge_inputs(sources: &[Sp3], opts: &MergeOptions) -> Result<PreparedMergeInputs> {
@@ -1600,6 +1548,82 @@ fn prepare_merge_inputs(sources: &[Sp3], opts: &MergeOptions) -> Result<Prepared
     Ok(PreparedMergeInputs {
         sources,
         frame_reconciliations,
+    })
+}
+
+/// Consume frame-reconciled sources and merge timing options, and produce the
+/// ordered epoch indexes, clock-datum offsets, cadence, and union output grid.
+fn prepare_merge_timing(sources: &[Sp3], opts: &MergeOptions) -> Result<MergeTiming> {
+    // floored-J2000-second -> epoch index, per source.
+    let epoch_index: Vec<BTreeMap<i64, usize>> = sources
+        .iter()
+        .map(|s| {
+            s.epochs
+                .iter()
+                .enumerate()
+                .filter_map(|(i, ep)| {
+                    sp3_epoch_j2000_seconds(s, i, ep).map(|sec| (sec.floor() as i64, i))
+                })
+                .collect()
+        })
+        .collect();
+
+    let epoch_interval_s = resolve_common_epoch_interval(sources, opts.target_epoch_interval_s)?;
+
+    // Per-source per-epoch clock-datum offset relative to source 0. Source 0 is
+    // the datum, so its offset is identically zero.
+    let clock_offset: Vec<BTreeMap<i64, f64>> = sources
+        .iter()
+        .enumerate()
+        .map(|(idx, s)| {
+            if idx == 0 {
+                BTreeMap::new()
+            } else {
+                clock_reference_offset(&sources[0], s, opts.clock_min_common)
+                    .into_iter()
+                    .filter_map(|o| {
+                        instant_to_j2000_seconds(&o.epoch)
+                            .map(|sec| (sec.floor() as i64, o.offset_s))
+                    })
+                    .collect()
+            }
+        })
+        .collect();
+
+    // Union of epochs (by floored second), retaining the representative Instant
+    // from the earliest-listed source on duplicate keys. This is what lets a
+    // dense source fill cells absent from a sparse preferred source.
+    let mut epoch_keys: BTreeMap<i64, Instant> = BTreeMap::new();
+    for source in sources {
+        for (idx, ep) in source.epochs.iter().enumerate() {
+            if let Some(sec) = sp3_epoch_j2000_seconds(source, idx, ep) {
+                epoch_keys.entry(sec.floor() as i64).or_insert(*ep);
+            }
+        }
+    }
+
+    // Restrict the union to the resolved output grid (anchored at the earliest
+    // union epoch), dropping off-grid epochs by exact subset selection. This is
+    // a no-op at the default finest cadence and performs deterministic
+    // decimation for an explicit coarser target.
+    if let Some((&anchor, _)) = epoch_keys.iter().next() {
+        let step = epoch_interval_s.round() as i64;
+        if step > 0 {
+            epoch_keys.retain(|&key, _| (key - anchor).rem_euclid(step) == 0);
+        }
+    }
+
+    if epoch_keys.is_empty() {
+        return Err(Error::InvalidInput(
+            "merge inputs have no epochs on the requested time grid".into(),
+        ));
+    }
+
+    Ok(MergeTiming {
+        epoch_index,
+        epoch_interval_s,
+        clock_offset,
+        epoch_keys,
     })
 }
 

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -2464,6 +2464,7 @@ mod tests {
     };
     use crate::constants::SECONDS_PER_DAY;
     use crate::id::{GnssSatelliteId, GnssSystem};
+    use sha2::{Digest, Sha256};
     use std::collections::BTreeSet;
 
     /// One satellite sample in a synthetic SP3 epoch: token, ECEF position
@@ -2643,6 +2644,126 @@ mod tests {
         }
         body.push_str("EOF\n");
         Sp3::parse(body.as_bytes()).expect("parse test sp3")
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        format!("{:x}", Sha256::digest(bytes))
+    }
+
+    #[test]
+    fn frozen_merge_output_hashes() {
+        let union_a = sp3_records(&[
+            ("G01", [15000.0, -20000.0, 5000.0], Some(100.0)),
+            ("G02", [16000.0, -21000.0, 6000.0], Some(200.0)),
+            ("G03", [17000.0, -22000.0, 7000.0], Some(300.0)),
+        ]);
+        let union_b = sp3_records(&[
+            ("G01", [15000.0, -20000.0, 5000.0], Some(100.0)),
+            ("G02", [16000.0, -21000.0, 6000.0], Some(200.0)),
+        ]);
+
+        let mean_a = sp3_records(&[("G01", [15000.000, -20000.0, 5000.0], Some(100.0))]);
+        let mean_b = sp3_records(&[("G01", [15000.003, -20000.0, 5000.0], Some(100.0))]);
+        let mean_c = sp3_records(&[("G01", [15000.006, -20000.0, 5000.0], Some(100.0))]);
+        let mean_options = MergeOptions {
+            position_tolerance_m: 10.0,
+            min_agree: 3,
+            combine: MergeCombine::Mean,
+            ..MergeOptions::default()
+        };
+
+        let preferred = sp3_records(&[("G01", [15000.0, -20000.0, 5000.0], Some(100.0))]);
+        let agreeing = sp3_records(&[("G01", [15000.001, -20000.0, 5000.0], Some(100.0))]);
+        let outlier = sp3_records(&[("G01", [15002.0, -20000.0, 5000.0], Some(100.0))]);
+        let guarded_precedence_options = MergeOptions {
+            combine: MergeCombine::Precedence,
+            min_agree: 2,
+            outlier_reject: Some(OutlierRejectOptions {
+                position_tolerance_m: 2.0,
+                clock_tolerance_s: 1.0e-6,
+            }),
+            ..MergeOptions::default()
+        };
+
+        let mixed_a = sp3_epochs(
+            0.0,
+            &[
+                &[("G01", [15000.0, -20000.0, 5000.0], Some(100.0))],
+                &[("G01", [15001.0, -20001.0, 5001.0], Some(101.0))],
+                &[("G01", [15002.0, -20002.0, 5002.0], Some(102.0))],
+            ],
+            900.0,
+            "IGS14",
+        );
+        let mixed_b = sp3_epochs(
+            450.0,
+            &[
+                &[("G01", [15010.0, -20010.0, 5010.0], Some(110.0))],
+                &[("G01", [15001.0, -20001.0, 5001.0], Some(101.0))],
+                &[("G01", [15011.0, -20011.0, 5011.0], Some(111.0))],
+                &[("G01", [15002.0, -20002.0, 5002.0], Some(102.0))],
+            ],
+            450.0,
+            "IGS14",
+        );
+        let mixed_options = MergeOptions {
+            min_agree: 1,
+            ..MergeOptions::default()
+        };
+
+        let cases = [
+            (
+                "union coverage",
+                vec![union_a, union_b],
+                MergeOptions::default(),
+                "f4ae5c18581e9d5805085f62525d1c912590cd41297bfdc0eb6322b8e48ad598",
+            ),
+            (
+                "mean consensus",
+                vec![mean_a, mean_b, mean_c],
+                mean_options,
+                "c4080215254a49dd4800348bc1d064e36e2da7a79dd499671588ae54566152a8",
+            ),
+            (
+                "guarded precedence",
+                vec![preferred, agreeing, outlier],
+                guarded_precedence_options,
+                "5fc60fe118f462faae9f3d25b579ae4917ee97796a79cf3737aaf8d21a6a7507",
+            ),
+            (
+                "mixed cadence union",
+                vec![mixed_a, mixed_b],
+                mixed_options,
+                "b18983adea82b57990a1bdfe88b4816e593472775b395ec611654894a9f54cdd",
+            ),
+        ];
+
+        for (name, sources, options, expected) in cases {
+            let (merged, _) = merge(&sources, &options).expect("frozen merge case");
+            let actual = sha256_hex(merged.to_sp3_string().as_bytes());
+            assert_eq!(actual, expected, "{name}");
+        }
+
+        #[cfg(sidereon_repo_tests)]
+        {
+            fn load(name: &str) -> Sp3 {
+                let path = format!("{}/tests/fixtures/sp3/{name}", env!("CARGO_MANIFEST_DIR"));
+                let bytes = std::fs::read(&path).unwrap_or_else(|error| panic!("{path}: {error}"));
+                Sp3::parse(&bytes).unwrap_or_else(|error| panic!("{name}: {error}"))
+            }
+
+            let sources = [
+                load("COD0OPSFIN_20261200945_02H30M_15M_ORB_trim.SP3"),
+                load("GFZ0OPSFIN_20261200945_02H30M_15M_ORB_trim.SP3"),
+                load("JPL0OPSFIN_20261200945_02H30M_15M_ORB_trim.SP3"),
+            ];
+            let (merged, _) = merge(&sources, &MergeOptions::default()).expect("real frozen merge");
+            assert_eq!(
+                sha256_hex(merged.to_sp3_string().as_bytes()),
+                "850c10dfc9b3394bc72d6c3bcd96634310b8d654a9908ed068b7fe165d224442",
+                "real three-center merge"
+            );
+        }
     }
 
     #[test]

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -967,7 +967,7 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
 
     let timing = prepare_merge_timing(sources, opts)?;
     let epoch_interval_s = timing.epoch_interval_s;
-    let cells = emit_merge_cells(sources, opts, &timing, frame_reconciliations);
+    let cells = emit_merge_cells(sources, opts, &timing, frame_reconciliations)?;
 
     let synthesized = synthesize_merge_header(
         sources,
@@ -1174,7 +1174,7 @@ fn emit_merge_cells(
     opts: &MergeOptions,
     timing: &MergeTiming,
     frame_reconciliations: Vec<Sp3FrameReconciliation>,
-) -> MergeCellOutput {
+) -> Result<MergeCellOutput> {
     let epoch_index = timing.epoch_index.as_slice();
     let epoch_keys = &timing.epoch_keys;
     let clock_offset = timing.clock_offset.as_slice();
@@ -1564,13 +1564,8 @@ fn emit_merge_cells(
             states.insert(
                 sat,
                 Sp3State {
-                    position: {
-                        // invariant: parsed SP3 coordinates and finite consensus
-                        // arithmetic produce a valid finite ITRF position.
-                        #[allow(clippy::expect_used)]
-                        ItrfPositionM::new(position_m[0], position_m[1], position_m[2])
-                            .expect("valid ITRF position")
-                    },
+                    position: ItrfPositionM::new(position_m[0], position_m[1], position_m[2])
+                        .map_err(|error| Error::InvalidInput(error.to_string()))?,
                     clock_s,
                     velocity: None,
                     clock_rate_s_s: None,
@@ -1611,7 +1606,7 @@ fn emit_merge_cells(
             .collect(),
     });
 
-    MergeCellOutput {
+    Ok(MergeCellOutput {
         out_epochs,
         out_epoch_j2000_s,
         out_states,
@@ -1619,7 +1614,7 @@ fn emit_merge_cells(
         all_sats,
         report,
         continuity_selection,
-    }
+    })
 }
 
 struct MergeTiming {
@@ -2620,6 +2615,7 @@ mod tests {
         Sp3FrameReconciliationMethod, Sp3FrameReconciliationOptions,
     };
     use crate::constants::SECONDS_PER_DAY;
+    use crate::frame::ItrfPositionM;
     use crate::id::{GnssSatelliteId, GnssSystem};
     use sha2::{Digest, Sha256};
     use std::collections::BTreeSet;
@@ -3263,6 +3259,21 @@ mod tests {
     #[test]
     fn merge_rejects_an_empty_input() {
         assert!(merge(&[], &MergeOptions::default()).is_err());
+    }
+
+    #[test]
+    fn merge_rejects_nonfinite_consensus_position_without_panicking() {
+        let mut a = sp3_records(&[("G01", [15_000.0, -20_000.0, 5_000.0], None)]);
+        let mut b = sp3_records(&[("G01", [15_000.0, -20_000.0, 5_000.0], None)]);
+        let extreme = ItrfPositionM::new(f64::MAX, 0.0, 0.0).unwrap();
+        a.states[0].get_mut(&gps(1)).unwrap().position = extreme;
+        b.states[0].get_mut(&gps(1)).unwrap().position = extreme;
+
+        let error = match merge(&[a, b], &MergeOptions::default()) {
+            Ok(_) => panic!("non-finite consensus position must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("must be finite"));
     }
 
     #[test]

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -955,29 +955,9 @@ fn fold_max(acc: Option<f64>, value: f64) -> f64 {
 /// normal source counts and uses a deterministic greedy fallback above the exact
 /// search cap, so hostile disagreement graphs remain bounded.
 pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)> {
-    if sources.is_empty() {
-        return Err(Error::InvalidInput(
-            "merge requires at least one SP3 product".into(),
-        ));
-    }
-
-    validate_merge_options(opts)?;
-
-    // Inputs must be combinable: epochs are matched in one exact product time
-    // system, and positions are only comparable in an exactly common coordinate
-    // system / frame unless the caller explicitly opted into one of the audited
-    // reconciliation mechanisms below.
-    let base = &sources[0].header;
-    for s in &sources[1..] {
-        if s.header.time_system != base.time_system {
-            return Err(Error::InvalidInput(format!(
-                "merge inputs have mismatched SP3 time systems ({:?} vs {:?})",
-                base.time_system, s.header.time_system
-            )));
-        }
-    }
-
-    let (prepared_sources, frame_reconciliations) = reconcile_sp3_coordinate_labels(sources, opts)?;
+    let prepared = prepare_merge_inputs(sources, opts)?;
+    let prepared_sources = prepared.sources;
+    let frame_reconciliations = prepared.frame_reconciliations;
     let sources = prepared_sources.as_slice();
 
     // floored-J2000-second -> epoch index, per source.
@@ -1584,6 +1564,43 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     }
 
     Ok((merged, report))
+}
+
+struct PreparedMergeInputs {
+    sources: Vec<Sp3>,
+    frame_reconciliations: Vec<Sp3FrameReconciliation>,
+}
+
+/// Consume raw SP3 sources and merge options, validate their combinability, and
+/// produce frame-reconciled sources plus the reconciliation audit trail.
+fn prepare_merge_inputs(sources: &[Sp3], opts: &MergeOptions) -> Result<PreparedMergeInputs> {
+    if sources.is_empty() {
+        return Err(Error::InvalidInput(
+            "merge requires at least one SP3 product".into(),
+        ));
+    }
+
+    validate_merge_options(opts)?;
+
+    // Inputs must be combinable: epochs are matched in one exact product time
+    // system, and positions are only comparable in an exactly common coordinate
+    // system / frame unless the caller explicitly opted into one of the audited
+    // reconciliation mechanisms below.
+    let base = &sources[0].header;
+    for s in &sources[1..] {
+        if s.header.time_system != base.time_system {
+            return Err(Error::InvalidInput(format!(
+                "merge inputs have mismatched SP3 time systems ({:?} vs {:?})",
+                base.time_system, s.header.time_system
+            )));
+        }
+    }
+
+    let (sources, frame_reconciliations) = reconcile_sp3_coordinate_labels(sources, opts)?;
+    Ok(PreparedMergeInputs {
+        sources,
+        frame_reconciliations,
+    })
 }
 
 /// Run the continuity check over the merged product and attribute each

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -961,10 +961,158 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     let sources = prepared_sources.as_slice();
 
     let timing = prepare_merge_timing(sources, opts)?;
-    let epoch_index = timing.epoch_index;
     let epoch_interval_s = timing.epoch_interval_s;
-    let clock_offset = timing.clock_offset;
-    let epoch_keys = timing.epoch_keys;
+    let cells = emit_merge_cells(sources, opts, &timing, frame_reconciliations);
+    let out_epochs = cells.out_epochs;
+    let out_epoch_j2000_s = cells.out_epoch_j2000_s;
+    let out_states = cells.out_states;
+    let out_raw = cells.out_raw;
+    let all_sats = cells.all_sats;
+    let mut report = cells.report;
+    let continuity_selection = cells.continuity_selection;
+    // Base the non-epoch metadata on a source product, but derive the first-epoch
+    // header fields from the merged grid itself. Mixed cadence / coverage can make
+    // the merged first epoch later than every input's first epoch, so cloning
+    // those fields from any input would make the `##` line stale.
+    let first_key = Some(out_epoch_j2000_s[0].floor() as i64);
+    let base_idx = sources
+        .iter()
+        .position(|s| {
+            s.epochs
+                .first()
+                .and_then(|ep| sp3_epoch_j2000_seconds(s, 0, ep))
+                .map(|sec| sec.floor() as i64)
+                == first_key
+        })
+        .or_else(|| {
+            sources
+                .iter()
+                .enumerate()
+                .filter_map(|(i, s)| {
+                    s.epochs
+                        .first()
+                        .and_then(|ep| sp3_epoch_j2000_seconds(s, 0, ep))
+                        .map(|sec| (sec, i))
+                })
+                .min_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)))
+                .map(|(_, i)| i)
+        })
+        .unwrap_or(0);
+    let first_epoch_header = first_epoch_header_fields(&out_epochs[0]).ok_or_else(|| {
+        Error::InvalidInput("merged SP3 first epoch cannot be represented in header fields".into())
+    })?;
+
+    let satellites: Vec<_> = all_sats.into_iter().collect();
+    let satellite_accuracy_codes = satellites
+        .iter()
+        .map(|sat| {
+            sources[base_idx]
+                .header
+                .satellites
+                .iter()
+                .position(|base_sat| base_sat == sat)
+                .and_then(|idx| {
+                    sources[base_idx]
+                        .header
+                        .satellite_accuracy_codes
+                        .get(idx)
+                        .copied()
+                })
+                .unwrap_or(0)
+        })
+        .collect();
+
+    let header = Sp3Header {
+        num_epochs: out_epochs.len() as u64,
+        satellites,
+        satellite_accuracy_codes,
+        data_type: Sp3DataType::Position,
+        gnss_week: first_epoch_header.gnss_week,
+        seconds_of_week: first_epoch_header.seconds_of_week,
+        epoch_interval_s,
+        mjd: first_epoch_header.mjd,
+        mjd_fraction: first_epoch_header.mjd_fraction,
+        ..sources[base_idx].header.clone()
+    };
+
+    let mandatory_header_lines = 5.max(header.satellites.len().div_ceil(17));
+    let declared_satellite_tokens = header
+        .satellites
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let epoch_position_tokens = vec![declared_satellite_tokens.clone(); out_epochs.len()];
+    let epoch_state_record_sequence = epoch_position_tokens
+        .iter()
+        .map(|tokens| {
+            tokens
+                .iter()
+                .cloned()
+                .map(|token| ('P', token))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let merged = Sp3 {
+        header,
+        epochs: out_epochs,
+        declared_num_epochs: out_epoch_j2000_s.len() as u64,
+        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
+        terminal_record: TerminalRecordState::valid(),
+        satellite_header_lines: mandatory_header_lines,
+        accuracy_header_lines: mandatory_header_lines,
+        time_system_header_lines: 2,
+        float_header_lines: 2,
+        integer_header_lines: 2,
+        header_comment_lines: 4,
+        declared_satellite_count: Some(declared_satellite_tokens.len()),
+        declared_satellite_tokens,
+        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
+        epoch_position_tokens,
+        epoch_state_record_sequence,
+        epoch_j2000_s: out_epoch_j2000_s,
+        states: out_states,
+        interp_raw: out_raw,
+        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
+        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
+    };
+
+    if let Some(continuity_options) = opts.verify_continuity.as_ref() {
+        report.continuity = Some(verify_merged_continuity(
+            &merged,
+            continuity_options,
+            &continuity_selection,
+        ));
+    }
+
+    Ok((merged, report))
+}
+
+struct PreparedMergeInputs {
+    sources: Vec<Sp3>,
+    frame_reconciliations: Vec<Sp3FrameReconciliation>,
+}
+
+struct MergeCellOutput {
+    out_epochs: Vec<Instant>,
+    out_epoch_j2000_s: Vec<f64>,
+    out_states: Vec<BTreeMap<GnssSatelliteId, Sp3State>>,
+    out_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
+    all_sats: BTreeSet<GnssSatelliteId>,
+    report: MergeReport,
+    continuity_selection: BTreeMap<(GnssSatelliteId, i64), CellSelection>,
+}
+
+/// Consume ordered merge timing data and emit every accepted epoch/satellite cell,
+/// preserving consensus, provenance, report, and native interpolation values.
+fn emit_merge_cells(
+    sources: &[Sp3],
+    opts: &MergeOptions,
+    timing: &MergeTiming,
+    frame_reconciliations: Vec<Sp3FrameReconciliation>,
+) -> MergeCellOutput {
+    let epoch_index = timing.epoch_index.as_slice();
+    let epoch_keys = &timing.epoch_keys;
+    let clock_offset = timing.clock_offset.as_slice();
 
     let precedence_source_for_sat = if opts.combine == MergeCombine::Precedence
         && opts.precedence_scope == MergePrecedenceScope::SatelliteArc
@@ -1008,7 +1156,7 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
     };
     let mut all_sats: BTreeSet<GnssSatelliteId> = BTreeSet::new();
 
-    for (&key, &epoch) in &epoch_keys {
+    for (&key, &epoch) in epoch_keys {
         out_epochs.push(epoch);
         out_epoch_j2000_s.push(key as f64);
         let mut states: BTreeMap<GnssSatelliteId, Sp3State> = BTreeMap::new();
@@ -1374,88 +1522,6 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
         out_raw.push(raws);
     }
 
-    // Base the non-epoch metadata on a source product, but derive the first-epoch
-    // header fields from the merged grid itself. Mixed cadence / coverage can make
-    // the merged first epoch later than every input's first epoch, so cloning
-    // those fields from any input would make the `##` line stale.
-    let first_key = Some(out_epoch_j2000_s[0].floor() as i64);
-    let base_idx = sources
-        .iter()
-        .position(|s| {
-            s.epochs
-                .first()
-                .and_then(|ep| sp3_epoch_j2000_seconds(s, 0, ep))
-                .map(|sec| sec.floor() as i64)
-                == first_key
-        })
-        .or_else(|| {
-            sources
-                .iter()
-                .enumerate()
-                .filter_map(|(i, s)| {
-                    s.epochs
-                        .first()
-                        .and_then(|ep| sp3_epoch_j2000_seconds(s, 0, ep))
-                        .map(|sec| (sec, i))
-                })
-                .min_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)))
-                .map(|(_, i)| i)
-        })
-        .unwrap_or(0);
-    let first_epoch_header = first_epoch_header_fields(&out_epochs[0]).ok_or_else(|| {
-        Error::InvalidInput("merged SP3 first epoch cannot be represented in header fields".into())
-    })?;
-
-    let satellites: Vec<_> = all_sats.into_iter().collect();
-    let satellite_accuracy_codes = satellites
-        .iter()
-        .map(|sat| {
-            sources[base_idx]
-                .header
-                .satellites
-                .iter()
-                .position(|base_sat| base_sat == sat)
-                .and_then(|idx| {
-                    sources[base_idx]
-                        .header
-                        .satellite_accuracy_codes
-                        .get(idx)
-                        .copied()
-                })
-                .unwrap_or(0)
-        })
-        .collect();
-
-    let header = Sp3Header {
-        num_epochs: out_epochs.len() as u64,
-        satellites,
-        satellite_accuracy_codes,
-        data_type: Sp3DataType::Position,
-        gnss_week: first_epoch_header.gnss_week,
-        seconds_of_week: first_epoch_header.seconds_of_week,
-        epoch_interval_s,
-        mjd: first_epoch_header.mjd,
-        mjd_fraction: first_epoch_header.mjd_fraction,
-        ..sources[base_idx].header.clone()
-    };
-
-    let mandatory_header_lines = 5.max(header.satellites.len().div_ceil(17));
-    let declared_satellite_tokens = header
-        .satellites
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-    let epoch_position_tokens = vec![declared_satellite_tokens.clone(); out_epochs.len()];
-    let epoch_state_record_sequence = epoch_position_tokens
-        .iter()
-        .map(|tokens| {
-            tokens
-                .iter()
-                .cloned()
-                .map(|token| ('P', token))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
     report.provenance = opts.provenance.map(|mode| MergeProvenance {
         mode,
         cells: prov_cells,
@@ -1472,44 +1538,15 @@ pub fn merge(sources: &[Sp3], opts: &MergeOptions) -> Result<(Sp3, MergeReport)>
             .collect(),
     });
 
-    let merged = Sp3 {
-        header,
-        epochs: out_epochs,
-        declared_num_epochs: out_epoch_j2000_s.len() as u64,
-        declared_start_j2000_s: out_epoch_j2000_s.first().copied(),
-        terminal_record: TerminalRecordState::valid(),
-        satellite_header_lines: mandatory_header_lines,
-        accuracy_header_lines: mandatory_header_lines,
-        time_system_header_lines: 2,
-        float_header_lines: 2,
-        integer_header_lines: 2,
-        header_comment_lines: 4,
-        declared_satellite_count: Some(declared_satellite_tokens.len()),
-        declared_satellite_tokens,
-        epoch_velocity_tokens: vec![Vec::new(); epoch_position_tokens.len()],
-        epoch_position_tokens,
-        epoch_state_record_sequence,
-        epoch_j2000_s: out_epoch_j2000_s,
-        states: out_states,
-        interp_raw: out_raw,
-        comments: vec![format!("MERGED from {} SP3 products", sources.len())],
-        skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
-    };
-
-    if let Some(continuity_options) = opts.verify_continuity.as_ref() {
-        report.continuity = Some(verify_merged_continuity(
-            &merged,
-            continuity_options,
-            &continuity_selection,
-        ));
+    MergeCellOutput {
+        out_epochs,
+        out_epoch_j2000_s,
+        out_states,
+        out_raw,
+        all_sats,
+        report,
+        continuity_selection,
     }
-
-    Ok((merged, report))
-}
-
-struct PreparedMergeInputs {
-    sources: Vec<Sp3>,
-    frame_reconciliations: Vec<Sp3FrameReconciliation>,
 }
 
 struct MergeTiming {

--- a/crates/sidereon-core/tests/omm.rs
+++ b/crates/sidereon-core/tests/omm.rs
@@ -47,6 +47,8 @@ const FIXTURES: &[Fixture] = &[
     },
 ];
 
+type FrozenOmmCase = (&'static str, &'static str, fn(&Omm) -> String);
+
 const ISS_CSV: &str = "OBJECT_NAME,OBJECT_ID,EPOCH,MEAN_MOTION,ECCENTRICITY,INCLINATION,RA_OF_ASC_NODE,ARG_OF_PERICENTER,MEAN_ANOMALY,EPHEMERIS_TYPE,CLASSIFICATION_TYPE,NORAD_CAT_ID,ELEMENT_SET_NO,REV_AT_EPOCH,BSTAR,MEAN_MOTION_DOT,MEAN_MOTION_DDOT\n\
 ISS (ZARYA),1998-067A,2026-06-17T04:32:52.099296,15.49273435,0.0004737,51.6332,300.0813,195.1146,164.9702,0,U,25544,999,57175,0.00017172,9.113e-5,0";
 
@@ -181,7 +183,7 @@ fn omm_json_matches_other_encodings_and_drives_sgp4_to_0_ulp() {
 
 #[test]
 fn frozen_auto_parse_encode_output_hashes() {
-    let cases: [(&str, &str, fn(&Omm) -> String); 9] = [
+    let cases: [FrozenOmmCase; 9] = [
         ("25544.kvn", FIXTURES[0].kvn, omm::encode_kvn),
         ("25544.xml", FIXTURES[0].xml, omm::encode_xml),
         ("25544.json", FIXTURES[0].json, omm::encode_json),

--- a/crates/sidereon-core/tests/omm.rs
+++ b/crates/sidereon-core/tests/omm.rs
@@ -11,6 +11,7 @@
 //! encoding plus its TLE, captured in one query so they share an epoch. The TLE
 //! is the correctness anchor; no invented truth.
 
+use sha2::{Digest, Sha256};
 use sidereon_core::astro::omm::{self, Omm};
 use sidereon_core::astro::sgp4::{MinutesSinceEpoch, Satellite};
 
@@ -48,6 +49,10 @@ const FIXTURES: &[Fixture] = &[
 
 const ISS_CSV: &str = "OBJECT_NAME,OBJECT_ID,EPOCH,MEAN_MOTION,ECCENTRICITY,INCLINATION,RA_OF_ASC_NODE,ARG_OF_PERICENTER,MEAN_ANOMALY,EPHEMERIS_TYPE,CLASSIFICATION_TYPE,NORAD_CAT_ID,ELEMENT_SET_NO,REV_AT_EPOCH,BSTAR,MEAN_MOTION_DOT,MEAN_MOTION_DDOT\n\
 ISS (ZARYA),1998-067A,2026-06-17T04:32:52.099296,15.49273435,0.0004737,51.6332,300.0813,195.1146,164.9702,0,U,25544,999,57175,0.00017172,9.113e-5,0";
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
 
 /// Pull the two element lines out of a CelesTrak `.tle` file (a name line plus
 /// the two element lines, with CRLF endings).
@@ -171,6 +176,66 @@ fn omm_json_matches_other_encodings_and_drives_sgp4_to_0_ulp() {
         let from_omm =
             Satellite::from_omm(&json).unwrap_or_else(|e| panic!("{} JSON: {e}", fix.name));
         assert_bit_identical(&format!("{} [JSON]", fix.name), &from_omm, &from_tle);
+    }
+}
+
+#[test]
+fn frozen_auto_parse_encode_output_hashes() {
+    let cases: [(&str, &str, fn(&Omm) -> String); 9] = [
+        ("25544.kvn", FIXTURES[0].kvn, omm::encode_kvn),
+        ("25544.xml", FIXTURES[0].xml, omm::encode_xml),
+        ("25544.json", FIXTURES[0].json, omm::encode_json),
+        ("24876.kvn", FIXTURES[1].kvn, omm::encode_kvn),
+        ("24876.xml", FIXTURES[1].xml, omm::encode_xml),
+        ("24876.json", FIXTURES[1].json, omm::encode_json),
+        ("28884.kvn", FIXTURES[2].kvn, omm::encode_kvn),
+        ("28884.xml", FIXTURES[2].xml, omm::encode_xml),
+        ("28884.json", FIXTURES[2].json, omm::encode_json),
+    ];
+    let expected = [
+        (
+            "25544.kvn",
+            "42a52d09a9a61ee5326f85e18255743f1711e1df3402c766d3133c36ecd5ebeb",
+        ),
+        (
+            "25544.xml",
+            "732a730d444213b3894b1c40893da31a7f707e578a3ff01fbaf241d91d59fe77",
+        ),
+        (
+            "25544.json",
+            "74d7f55c517507f16f1e06d1193582afeaeda9a1e11fa78436e64567860944bc",
+        ),
+        (
+            "24876.kvn",
+            "e20c3848984d9df2556d78f43040092a352699cce5b9397da71a0615d271e51c",
+        ),
+        (
+            "24876.xml",
+            "943fadef4fe75501f8593e00756b3806fa31183e543ffd87a4f422b2ba02149f",
+        ),
+        (
+            "24876.json",
+            "3ee9b047cf83f0b358d5a3ad550d6c905293fa7e4b8858d096cd33388cb92f80",
+        ),
+        (
+            "28884.kvn",
+            "f5a83dab177b5333b223fc3b3c2e439b2da6769258c7d978b43fcdf8cfe699e5",
+        ),
+        (
+            "28884.xml",
+            "90287ce38685ce36d6562ebc575c53ecc70efc7038dbce7db8aa276ed77a0ca9",
+        ),
+        (
+            "28884.json",
+            "a41879ecb0ffdd4bc0aa673e708a9126d9d1671e4cf6a45325943a7136d311a7",
+        ),
+    ];
+
+    for (index, (name, input, encode)) in cases.into_iter().enumerate() {
+        let parsed = omm::parse(input).unwrap_or_else(|error| panic!("{name}: {error}"));
+        let output = encode(&parsed);
+        let actual = sha256_hex(output.as_bytes());
+        assert_eq!(actual, expected[index].1, "{name}");
     }
 }
 


### PR DESCRIPTION
Implements review finding 12 for `astro/omm.rs::parse` and `sp3/combine.rs::merge`, plus the panic audit (finding 6) for those two files.

- Frozen-output tests come first: complete `parse` + `encode` bytes for every OMM fixture and `merge` output for every SP3 combination the tests exercise are hashed and pinned. The refactor commits each pass those tests unchanged.
- `parse` is split into header, metadata, mean-element, and TLE-parameter stages; `merge` into input preparation, epoch alignment, cell emission, header synthesis, and product emission. Each stage is a private function with a doc comment stating what it consumes and produces. No accepted input, rejected input, error text, or output byte changes. `other_index` stays a lookup index; every iteration that reaches output is over ordered containers.
- Panic audit under `#![warn(clippy::expect_used, clippy::unwrap_used, clippy::panic)]` in both files. One input-reachable site (the SP3 consensus position constructor, reachable with extreme finite programmatic coordinates) now returns the existing typed `Error::InvalidInput` with a regression test; five invariant sites keep a targeted allow with an `// invariant:` comment.
- OMM and SP3 fuzz targets ran 120 s each before and after (no crashes).