### PR TITLE
Documentation pass: 2,106 public items across 74 modules

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -34,6 +34,13 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Added
 
+- Reference documentation for 2,106 public items across 74 modules, written
+  from the code that produces and consumes each item: units, frames, bit
+  widths and scale factors for raw protocol fields, the header record or
+  function each value comes from, when an `Option` is `None`, and the
+  condition under which each error variant is returned. 522 items in 41
+  modules remain undocumented; `#![warn(missing_docs)]` stays off until they
+  are covered.
 - A supply-chain gate (`cargo deny`: advisories, licenses, bans, sources)
   runs in CI, together with an MSRV check at Rust 1.89. One advisory is an
   explicit, documented exception: RUSTSEC-2024-0436 (`paste`, an unmaintained

--- a/crates/sidereon-core/src/antex.rs
+++ b/crates/sidereon-core/src/antex.rs
@@ -17,6 +17,9 @@ use std::fmt;
 /// Parsed ANTEX antenna calibration product.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Antex {
+    /// Latest completed antenna block for each trimmed `TYPE / SERIAL NO` id.
+    /// A later block with the same id replaces this entry; all blocks remain
+    /// available through [`Antex::antenna_intervals`].
     pub antennas: BTreeMap<String, Antenna>,
     antenna_intervals: BTreeMap<String, Vec<Antenna>>,
     /// Count of malformed records skipped during a forgiving parse (a corrupt PCV
@@ -32,80 +35,147 @@ pub struct Antex {
 /// Receiver or satellite antenna block.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Antenna {
+    /// Trimmed body of the `TYPE / SERIAL NO` record, also used as the key in
+    /// the parsed antenna views and as the identifier in lookup errors.
     pub id: String,
+    /// Classification assigned from the trimmed serial by the
+    /// `is_satellite_serial` helper.
     pub kind: AntennaKind,
+    /// Trimmed first 20-byte field of the `TYPE / SERIAL NO` record.
     pub antenna_type: String,
+    /// Trimmed 20..40-byte field of the `TYPE / SERIAL NO` record. It drives
+    /// receiver/satellite classification and satellite PRN lookup.
     pub serial: String,
+    /// First parseable value from `DAZI`, in degrees; parsing initializes this
+    /// field to `0.0` when no such value is present.
     pub dazi_deg: f64,
+    /// First value from `ZEN1 / ZEN2 / DZEN`, in degrees; it anchors recovered
+    /// PCV sample zeniths and is the lower bound checked by [`Antenna::pcv`].
     pub zenith_start_deg: f64,
+    /// Second value from `ZEN1 / ZEN2 / DZEN`, in degrees; it is the inclusive
+    /// upper bound checked by [`Antenna::pcv`].
     pub zenith_end_deg: f64,
+    /// Third value from `ZEN1 / ZEN2 / DZEN`, in degrees, used to place
+    /// successive PCV values; a zero value assigns every sample the start.
     pub zenith_step_deg: f64,
+    /// Nonblank trimmed `SINEX CODE` content, or `None` when that record is
+    /// absent or blank.
     pub sinex_code: Option<String>,
+    /// Timestamp from `VALID FROM`, used as an inclusive lower bound by
+    /// [`Antenna::valid_at`].
     pub valid_from: Option<AntexDateTime>,
+    /// Timestamp from `VALID UNTIL`, used as an inclusive upper bound by
+    /// [`Antenna::valid_at`].
     pub valid_until: Option<AntexDateTime>,
+    /// Completed frequency blocks indexed by their trimmed labels; a repeated
+    /// label replaces the earlier block in this antenna.
     pub frequencies: BTreeMap<String, Frequency>,
 }
 
 /// ANTEX antenna block role.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AntennaKind {
+    /// Assigned when the trimmed serial does not match the three-byte satellite
+    /// PRN pattern accepted by the `is_satellite_serial` helper.
     Receiver,
+    /// Assigned for a serial consisting of one uppercase ASCII letter and two
+    /// ASCII digits; satellite lookup requires this classification.
     Satellite,
 }
 
 /// Frequency-specific PCO/PCV calibration block.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Frequency {
+    /// Trimmed label from the `START OF FREQUENCY` record and the key used by
+    /// antenna frequency lookup.
     pub frequency: String,
+    /// Finite `NORTH / EAST / UP` PCO values converted from ANTEX millimeters
+    /// to meters and kept in north/east/up order.
     pub pco_m: [f64; 3],
+    /// PCV samples recovered in row/token order, with values expressed in
+    /// meters; lookup partitions them by [`PcvGrid`] for interpolation.
     pub pcv_samples: Vec<PcvSample>,
 }
 
 /// One phase-center-variation grid value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PcvSample {
+    /// Whether the source row was headed by `NOAZI` or by a numeric azimuth.
     pub grid: PcvGrid,
+    /// `None` for `NOAZI` samples; otherwise the unnormalized parsed angle
+    /// from the source row head, in degrees.
     pub azimuth_deg: Option<f64>,
+    /// Zenith coordinate computed from the antenna grid start, step, and this
+    /// value's row position.
     pub zenith_deg: f64,
+    /// PCV token converted from ANTEX millimeters to meters; malformed tokens
+    /// are skipped instead of producing a sample.
     pub value_m: f64,
 }
 
 /// PCV grid type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PcvGrid {
+    /// A `NOAZI` row used for zenith-only interpolation or fallback.
     NoAzimuth,
+    /// A numeric-azimuth row whose samples are grouped by azimuth for lookup.
     Azimuth,
 }
 
 /// Civil UTC-like timestamp fields from `VALID FROM` / `VALID UNTIL`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AntexDateTime {
+    /// Validated civil calendar year, restricted by the shared validator to
+    /// `0..=9999`.
     pub year: i32,
+    /// Validated one-based civil month in `1..=12`.
     pub month: u8,
+    /// Day accepted for the stored civil year and month.
     pub day: u8,
+    /// UTC-like civil clock hour in `0..=23`.
     pub hour: u8,
+    /// UTC-like civil minute in `0..=59`.
     pub minute: u8,
+    /// Stored whole-second component; UTC-like validation permits ordinary
+    /// values through `59` and a valid leap-second label `60`.
     pub second: u8,
 }
 
 /// ANTEX parse or lookup error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AntexError {
+    /// A date/time component failed integer-range, calendar, clock, or
+    /// UTC-like leap-second validation.
     InvalidDateTime,
+    /// A public PCV input was rejected by shared validation.
     InvalidInput {
+        /// Static label of the rejected PCV argument; the current path uses
+        /// `"zenith_deg"`.
         field: &'static str,
+        /// Validator reason, such as `"not finite"` or `"out of range"`.
         reason: &'static str,
     },
+    /// The trimmed requested frequency label was absent from an antenna's
+    /// frequency map.
     UnknownFrequency {
+        /// Id of the antenna whose frequency map was queried.
         antenna_id: String,
+        /// Original caller-supplied frequency argument, before lookup trims it.
         frequency: String,
     },
+    /// A frequency block ended without a finite three-value `NORTH / EAST / UP`
+    /// record having been parsed.
     MissingPco {
+        /// Id of the antenna containing the incomplete frequency block.
         antenna_id: String,
+        /// Trimmed label from that block's `START OF FREQUENCY` record.
         frequency: String,
     },
+    /// The selected PCV interpolation input contained no samples.
     EmptyPcvGrid {
+        /// Id of the antenna requested by the PCV lookup.
         antenna_id: String,
+        /// Stored frequency label used by the PCV lookup.
         frequency: String,
     },
 }
@@ -340,6 +410,10 @@ fn invalid_input(field: &'static str, reason: &'static str) -> AntexError {
 }
 
 impl AntexDateTime {
+    /// Construct a timestamp after UTC-like civil-time validation.
+    ///
+    /// Invalid calendar or clock values, including an unsupported leap-second
+    /// label, return [`AntexError::InvalidDateTime`].
     pub fn new(
         year: i32,
         month: u8,

--- a/crates/sidereon-core/src/astro/almanac/ecliptic.rs
+++ b/crates/sidereon-core/src/astro/almanac/ecliptic.rs
@@ -5,7 +5,9 @@ use crate::astro::time::scales::TimeScales;
 /// Geocentric apparent ecliptic longitude and latitude of a body, degrees, of date.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct EclipticLonLat {
+    /// Ecliptic longitude in degrees on `[0, 360)`. [`geocentric_ecliptic`] obtains it by wrapping the `atan2` angle after rotating the normalized true-of-date equatorial position by true obliquity; phase, season, and planetary-event calculations consume it as their ecliptic angle.
     pub longitude_deg: f64,
+    /// Ecliptic latitude in degrees on `[-90, 90]`, obtained from the obliquity-rotated normalized position with a clamped `asin` in [`geocentric_ecliptic`]. The eclipse finder reads the Moon's value at new and full phases and skips candidates outside the corresponding node limit before classification.
     pub latitude_deg: f64,
 }
 

--- a/crates/sidereon-core/src/astro/angles.rs
+++ b/crates/sidereon-core/src/astro/angles.rs
@@ -18,8 +18,16 @@ const RIGHT_ANGLE_DEG: f64 = 90.0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum AngleError {
     #[error("invalid angle input {field}: {reason}")]
+    /// An angle helper rejected a non-finite, out-of-range, or degenerate input.
     InvalidInput {
+        /// Static label identifying the rejected angle-helper argument.
+        /// Vector and coordinate helpers use `a`/`b`; position-angle helpers use `from`/`to`;
+        /// satellite geometry uses `sat_pos`, `sun_pos`, `moon_pos`, and `observer_pos`; beta
+        /// helpers use `orbit_normal`/`sun`, or `r`/`v` for state inputs.
         field: &'static str,
+        /// Validation reason included in the formatted error.
+        /// The validators emit `not finite`, `zero vector`, `out of range`, or
+        /// `latitude out of range`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/anomaly.rs
+++ b/crates/sidereon-core/src/astro/anomaly.rs
@@ -13,27 +13,56 @@ const TOL_ABS: f64 = 1.0e-12;
 const TOL_REL: f64 = 1.0e-14;
 const MAX_ITER: usize = 50;
 
+/// Errors returned by the anomaly conversions, [`solve_kepler`], and
+/// [`propagate_kepler`].
 #[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
 pub enum AnomalyError {
+    /// A checked floating-point input was not finite.
     #[error("non-finite input {field}")]
-    NonFinite { field: &'static str },
+    NonFinite {
+        /// Names the input that was NaN or infinite.
+        field: &'static str,
+    },
+    /// The supplied eccentricity was negative.
     #[error("eccentricity must be non-negative")]
     NegativeEccentricity,
+    /// Propagation received a non-positive gravitational parameter.
     #[error("mu must be positive")]
     NonPositiveMu,
+    /// Propagation received a non-positive semi-latus rectum.
     #[error("semi-latus rectum must be positive")]
     NonPositiveSemiLatus,
+    /// A true anomaly was at or beyond the admissible open-orbit limit.
     #[error("true anomaly {nu} is beyond the open-orbit asymptote {limit}")]
-    BeyondAsymptote { nu: f64, limit: f64 },
+    BeyondAsymptote {
+        /// The original, unwrapped true anomaly that failed the domain check.
+        nu: f64,
+        /// The parabolic or hyperbolic open-orbit limit used by the check.
+        limit: f64,
+    },
+    /// The supplied classical elements are inconsistent with their conic or orbit type.
     #[error("inconsistent element {field}")]
-    InconsistentElements { field: &'static str },
+    InconsistentElements {
+        /// Names the invalid semi-major-axis, eccentricity, or inclination field.
+        field: &'static str,
+    },
+    /// The iterative elliptic or hyperbolic solve exhausted its iteration limit.
     #[error("Kepler solve did not converge in {iterations} iters (residual {residual})")]
-    NonConvergent { iterations: usize, residual: f64 },
+    NonConvergent {
+        /// The number of iterations attempted, which is `MAX_ITER` on this error.
+        iterations: usize,
+        /// The residual from the final iteration.
+        residual: f64,
+    },
 }
 
+/// Middle-anomaly result and iteration count returned by [`solve_kepler`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KeplerSolution {
+    /// Eccentric anomaly `E`, hyperbolic anomaly `H`, or Barker anomaly `D`.
+    /// Elliptic results are normalized to `[0, 2*pi)`.
     pub anomaly: f64,
+    /// The converged 1-based iteration count, or zero for the direct parabolic inversion.
     pub iterations: usize,
 }
 
@@ -44,6 +73,18 @@ enum Regime {
     Hyperbolic,
 }
 
+/// Solve Kepler's equation for the conic regime selected by `ecc`.
+///
+/// Mean, eccentric, hyperbolic, and Barker anomalies are in radians; `ecc` is
+/// dimensionless. Elliptic mean anomaly is reduced to `[0, 2*pi)` before the
+/// iterative solve, while the parabolic branch uses Barker's direct inversion.
+///
+/// # Errors
+///
+/// Returns [`AnomalyError::NonFinite`] for a non-finite input,
+/// [`AnomalyError::NegativeEccentricity`] for negative `ecc`, or
+/// [`AnomalyError::NonConvergent`] when an elliptic or hyperbolic iteration
+/// does not reach its residual tolerance.
 pub fn solve_kepler(mean_anom: f64, ecc: f64) -> Result<KeplerSolution, AnomalyError> {
     check_finite(mean_anom, "mean_anom")?;
     validate_ecc(ecc)?;
@@ -68,10 +109,29 @@ pub fn solve_kepler(mean_anom: f64, ecc: f64) -> Result<KeplerSolution, AnomalyE
     }
 }
 
+/// Convert mean anomaly to the middle anomaly for the selected conic regime.
+///
+/// The returned value is the `anomaly` field from [`solve_kepler`]: `E` for an
+/// elliptic orbit, `H` for a hyperbolic orbit, or Barker's `D` at the
+/// parabolic boundary. Angles are in radians and eccentricity is dimensionless.
+///
+/// # Errors
+///
+/// Propagates validation and convergence errors from [`solve_kepler`].
 pub fn mean_to_eccentric(mean_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     Ok(solve_kepler(mean_anom, ecc)?.anomaly)
 }
 
+/// Convert eccentric, hyperbolic, or Barker anomaly to mean anomaly.
+///
+/// The elliptic branch computes `E - ecc*sin(E)` and normalizes the result to
+/// `[0, 2*pi)`. The parabolic branch computes `D + D^3/3`, and the hyperbolic
+/// branch computes `ecc*sinh(H) - H`.
+///
+/// # Errors
+///
+/// Returns [`AnomalyError::NonFinite`] if `ecc_anom` or `ecc` is not finite,
+/// or [`AnomalyError::NegativeEccentricity`] if `ecc` is negative.
 pub fn eccentric_to_mean(ecc_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     check_finite(ecc_anom, "ecc_anom")?;
     validate_ecc(ecc)?;
@@ -86,6 +146,16 @@ pub fn eccentric_to_mean(ecc_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     }
 }
 
+/// Convert eccentric, Barker, or hyperbolic anomaly to true anomaly.
+///
+/// The elliptic and hyperbolic branches use the corresponding sine and cosine
+/// relations, while the parabolic branch uses `nu = 2*atan(D)`. The returned
+/// true anomaly is normalized to `[0, 2*pi)`.
+///
+/// # Errors
+///
+/// Returns [`AnomalyError::NonFinite`] if `ecc_anom` or `ecc` is not finite,
+/// or [`AnomalyError::NegativeEccentricity`] if `ecc` is negative.
 pub fn eccentric_to_true(ecc_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     check_finite(ecc_anom, "ecc_anom")?;
     validate_ecc(ecc)?;
@@ -106,6 +176,18 @@ pub fn eccentric_to_true(ecc_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     }
 }
 
+/// Convert true anomaly to eccentric, Barker, or hyperbolic anomaly.
+///
+/// Elliptic input is converted with the half-angle relation and normalized to
+/// `[0, 2*pi)`. The parabolic result is `D = tan(nu/2)`, and the hyperbolic
+/// result is obtained with `asinh` after wrapping `nu` to `(-pi, pi]`.
+///
+/// # Errors
+///
+/// Returns [`AnomalyError::NonFinite`] if `true_anom` or `ecc` is not finite,
+/// [`AnomalyError::NegativeEccentricity`] if `ecc` is negative, or
+/// [`AnomalyError::BeyondAsymptote`] when an open-orbit input is at or beyond
+/// its parabolic or hyperbolic limit.
 pub fn true_to_eccentric(true_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     check_finite(true_anom, "true_anom")?;
     validate_ecc(ecc)?;
@@ -135,16 +217,48 @@ pub fn true_to_eccentric(true_anom: f64, ecc: f64) -> Result<f64, AnomalyError> 
     }
 }
 
+/// Convert mean anomaly directly to normalized true anomaly.
+///
+/// This composes [`mean_to_eccentric`] with [`eccentric_to_true`], selecting
+/// `E`, `H`, or `D` from `ecc` before returning the true anomaly in
+/// `[0, 2*pi)`.
+///
+/// # Errors
+///
+/// Returns the first validation, convergence, or open-orbit-domain error from
+/// the two conversions.
 pub fn mean_to_true(mean_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     let ecc_anom = mean_to_eccentric(mean_anom, ecc)?;
     eccentric_to_true(ecc_anom, ecc)
 }
 
+/// Convert true anomaly directly to mean anomaly.
+///
+/// This composes [`true_to_eccentric`] with [`eccentric_to_mean`]. Open-orbit
+/// domain checks therefore occur before the mean anomaly is evaluated.
+///
+/// # Errors
+///
+/// Returns the first validation or open-orbit-domain error from the two
+/// conversions.
 pub fn true_to_mean(true_anom: f64, ecc: f64) -> Result<f64, AnomalyError> {
     let ecc_anom = true_to_eccentric(true_anom, ecc)?;
     eccentric_to_mean(ecc_anom, ecc)
 }
 
+/// Propagate classical elements for a two-body Keplerian orbit by `dt`.
+///
+/// The input is copied before propagation. Circular inclined and circular
+/// equatorial elements advance `arglat` and `truelon`, respectively; eccentric
+/// orbit types advance `nu` through mean anomaly using `mu` and the relevant
+/// `a` or `p`. All other fields are preserved.
+///
+/// # Errors
+///
+/// Returns [`AnomalyError::NonFinite`], [`AnomalyError::NonPositiveMu`],
+/// [`AnomalyError::NonPositiveSemiLatus`], or
+/// [`AnomalyError::InconsistentElements`] when the inputs fail validation, or
+/// an anomaly-conversion error when the propagated anomaly cannot be computed.
 pub fn propagate_kepler(
     elements: &ClassicalElements,
     mu: f64,

--- a/crates/sidereon-core/src/astro/bodies/observe.rs
+++ b/crates/sidereon-core/src/astro/bodies/observe.rs
@@ -179,15 +179,27 @@ impl Default for ObserveOptions {
 #[derive(Debug, Clone, Copy)]
 pub enum Target<'a> {
     /// SPK-covered body by NAIF id.
-    Spk { kernel: &'a Spk, naif_id: i32 },
+    Spk {
+        /// Kernel used for the target, Earth, and Sun state queries.
+        kernel: &'a Spk,
+        /// NAIF identifier of the target body queried relative to the SSB.
+        naif_id: i32,
+    },
     /// Analytic low-precision Sun, no kernel required.
     Sun,
     /// Analytic low-precision Moon, no kernel required.
     Moon,
     /// Caller-supplied SSB-centered ICRS/J2000 state plus a kernel for Earth/Sun.
     BarycentricState {
+        /// Kernel used for the Earth barycentric state and solar-deflection Sun state.
         kernel: &'a Spk,
+        /// Target position at the observation epoch, in SSB-centered ICRS/J2000 kilometers.
+        ///
+        /// The light-time reducer advances this position with `velocity_km_s`.
         position_km: [f64; 3],
+        /// Target velocity in SSB-centered ICRS/J2000 kilometers per second.
+        ///
+        /// The light-time reducer treats this velocity as constant during its iteration.
         velocity_km_s: [f64; 3],
     },
 }
@@ -209,7 +221,10 @@ pub enum ObserveError {
     Angle(#[from] AngleError),
     /// SPK state used a reference frame this reduction does not support.
     #[error("unsupported SPK reference frame {frame}")]
-    UnsupportedSpkFrame { frame: i32 },
+    UnsupportedSpkFrame {
+        /// NAIF reference-frame identifier returned by the SPK state.
+        frame: i32,
+    },
     /// A public input or computed intermediate was not finite.
     #[error("non-finite observation input or intermediate")]
     NonFinite,

--- a/crates/sidereon-core/src/astro/cdm.rs
+++ b/crates/sidereon-core/src/astro/cdm.rs
@@ -72,16 +72,27 @@ const SEGMENT_TAG: &str = "segment";
 /// type.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CdmKvn {
+    /// Raw CREATION_DATE text from the message. The readers do not validate it as a calendar value, and the host is responsible for interpreting and formatting the instant.
     pub creation_date: Option<String>,
+    /// ORIGINATOR text copied from the message and emitted when present.
     pub originator: Option<String>,
+    /// MESSAGE_ID text copied without format validation and emitted in the corresponding header field when present.
     pub message_id: Option<String>,
+    /// Raw TCA text; this module leaves date/time resolution and formatting to the host.
     pub tca: Option<String>,
+    /// Finite MISS_DISTANCE value in meters. KVN units are stripped and XML units are ignored on input; encoders label the value in meters.
     pub miss_distance_m: Option<f64>,
+    /// Finite RELATIVE_SPEED value in meters per second. KVN units are stripped and XML units are ignored on input; encoders label the value in meters per second.
     pub relative_speed_m_s: Option<f64>,
+    /// Optional finite COLLISION_PROBABILITY value, emitted without a units attribute.
     pub collision_probability: Option<f64>,
+    /// COLLISION_PROBABILITY_METHOD text, emitted when present and XML-escaped in XML output.
     pub collision_probability_method: Option<String>,
+    /// Optional hard-body radius in meters. KVN reads and writes it through the NASA CARA `COMMENT HBR` convention; XML reads an `HBR` element, but the XML encoder omits it.
     pub hard_body_radius_m: Option<f64>,
+    /// The object parsed from the first KVN OBJECT block or first XML segment.
     pub object1: CdmObject,
+    /// The object parsed from the second KVN OBJECT block or second XML segment.
     pub object2: CdmObject,
 }
 
@@ -91,25 +102,45 @@ pub struct CdmKvn {
 /// `None` and are not emitted on encode.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CdmObject {
+    /// Optional OBJECT_DESIGNATOR text copied from either serialization and emitted under the same key when present.
     pub object_designator: Option<String>,
+    /// Optional CATALOG_NAME text copied from either serialization and emitted under the same key when present.
     pub catalog_name: Option<String>,
+    /// Optional OBJECT_NAME text copied from either serialization; XML output escapes it.
     pub object_name: Option<String>,
+    /// Optional INTERNATIONAL_DESIGNATOR text copied from either serialization and emitted under the same key when present.
     pub international_designator: Option<String>,
+    /// OBJECT_TYPE is carried as text rather than parsed into an enum, then emitted when present.
     pub object_type: Option<String>,
+    /// Optional OPERATOR_CONTACT_POSITION text emitted in the canonical metadata order when present.
     pub operator_contact_position: Option<String>,
+    /// Optional OPERATOR_ORGANIZATION text copied by both readers and emitted when present.
     pub operator_organization: Option<String>,
+    /// Optional OPERATOR_PHONE text emitted in the canonical metadata order when present.
     pub operator_phone: Option<String>,
+    /// Optional OPERATOR_EMAIL text emitted in the canonical metadata order when present.
     pub operator_email: Option<String>,
+    /// Optional EPHEMERIS_NAME text copied by both readers and emitted when present.
     pub ephemeris_name: Option<String>,
+    /// Optional COVARIANCE_METHOD text copied by both readers and emitted when present.
     pub covariance_method: Option<String>,
+    /// MANEUVERABLE is carried as text, preserving values such as YES or NO, and emitted when present.
     pub maneuverable: Option<String>,
+    /// Optional ORBIT_CENTER text emitted in the canonical metadata order when present.
     pub orbit_center: Option<String>,
+    /// Optional REF_FRAME text copied without frame conversion and emitted when present.
     pub ref_frame: Option<String>,
+    /// Optional GRAVITY_MODEL text, including any model detail supplied by the message, emitted under the same key.
     pub gravity_model: Option<String>,
+    /// Optional ATMOSPHERIC_MODEL text emitted in the canonical metadata order when present.
     pub atmospheric_model: Option<String>,
+    /// Optional N_BODY_PERTURBATIONS text preserving the listed perturbing bodies and emitted when present.
     pub n_body_perturbations: Option<String>,
+    /// SOLAR_RAD_PRESSURE is carried as text rather than interpreted as a boolean, then emitted when present.
     pub solar_rad_pressure: Option<String>,
+    /// EARTH_TIDES is carried as text rather than interpreted as a boolean, then emitted when present.
     pub earth_tides: Option<String>,
+    /// INTRACK_THRUST is carried as text, preserving values such as NO, and emitted when present.
     pub intrack_thrust: Option<String>,
     /// Position `(x, y, z)` then velocity `(x_dot, y_dot, z_dot)`.
     pub state: ((f64, f64, f64), (f64, f64, f64)),

--- a/crates/sidereon-core/src/astro/conjunction.rs
+++ b/crates/sidereon-core/src/astro/conjunction.rs
@@ -44,12 +44,25 @@ const FOSTER_NUMERICAL_ANGULAR_STEPS: usize = 40;
 /// relative velocity, and `z_hat` is the encounter-plane normal.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct EncounterFrame {
+    /// Unit ECI vector for the in-plane cross-track axis. It is derived from
+    /// the relative-position component orthogonal to relative velocity, or
+    /// from a selected world-axis trial vector when the objects are on a
+    /// collision course.
     pub x_hat: [f64; 3],
+    /// Unit ECI vector in the direction of the relative velocity `v2 - v1`.
     pub y_hat: [f64; 3],
+    /// ECI normal to the encounter plane, computed as `y_hat` crossed with
+    /// `x_hat`.
     pub z_hat: [f64; 3],
+    /// Relative ECI position `r2 - r1`, in kilometers.
     pub relative_position_km: [f64; 3],
+    /// Relative ECI velocity `v2 - v1`, in kilometers per second.
     pub relative_velocity_km_s: [f64; 3],
+    /// Norm in kilometers of the relative-position component orthogonal to
+    /// `y_hat`; this is the miss distance used by [`CollisionPc`].
     pub miss_km: f64,
+    /// Norm in kilometers per second of `v2 - v1`. Values below
+    /// `ZERO_REL_SPEED_EPS_KM_S` make the encounter frame unavailable.
     pub relative_speed_km_s: f64,
 }
 
@@ -68,18 +81,39 @@ pub enum PcMethod {
 /// and 3x3 position covariance (km^2).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ConjunctionState {
+    /// Object position in kilometers in the common inertial frame supplied to
+    /// the solver. The TCA wrapper supplies the converted primary relative
+    /// position and `[0.0; 3]` for the secondary.
     pub position_km: [f64; 3],
+    /// Object velocity in kilometers per second in the common inertial frame
+    /// supplied to the solver. The TCA wrapper supplies the converted primary
+    /// relative velocity and `[0.0; 3]` for the secondary.
     pub velocity_km_s: [f64; 3],
+    /// Object position covariance in square kilometers in the same frame as
+    /// `position_km`; the solver adds both object matrices element-wise before
+    /// projecting them into the encounter plane.
     pub covariance_km2: [[f64; 3]; 3],
 }
 
 /// Collision-probability result and the encounter-plane summary it came from.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CollisionPc {
+    /// Collision probability from the selected integration method. A negative
+    /// computed value is returned as zero after finite-value validation.
     pub pc: f64,
+    /// Encounter-frame miss distance in kilometers, copied from
+    /// [`EncounterFrame::miss_km`].
     pub miss_km: f64,
+    /// Relative-state speed in kilometers per second, copied from
+    /// [`EncounterFrame::relative_speed_km_s`].
     pub relative_speed_km_s: f64,
+    /// Standard deviation in kilometers along the first principal axis of the
+    /// projected encounter-plane Gaussian; it is the square root of the larger
+    /// covariance eigenvalue.
     pub sigma_x_km: f64,
+    /// Standard deviation in kilometers along the second principal axis of the
+    /// projected encounter-plane Gaussian; it is the square root of the smaller
+    /// covariance eigenvalue.
     pub sigma_z_km: f64,
 }
 
@@ -87,9 +121,17 @@ pub struct CollisionPc {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConjunctionError {
     /// A numeric input or derived probability was non-finite.
-    NonFinite { field: &'static str },
+    NonFinite {
+        /// Static label of the input or derived output that failed finite
+        /// validation.
+        field: &'static str,
+    },
     /// A strictly positive input was zero or negative.
-    NotPositive { field: &'static str },
+    NotPositive {
+        /// Static label of the value that failed a positivity or covariance
+        /// validity check.
+        field: &'static str,
+    },
     /// The encounter frame is undefined because relative velocity is zero.
     UndefinedFrame,
 }

--- a/crates/sidereon-core/src/astro/constants.rs
+++ b/crates/sidereon-core/src/astro/constants.rs
@@ -148,6 +148,13 @@ pub mod astro {
 
 /// Model-specific constants that intentionally differ from WGS84.
 pub mod models {
+    /// PZ-90.11 constants consumed by the GLONASS equation of motion and the
+    /// Doppler ECEF transport term.
+    ///
+    /// The GLONASS module re-exports the gravitational constant, J2, Earth
+    /// radius, and rotation rate for its central-gravity, oblateness, and
+    /// rotating-frame terms; [`crate::astro::doppler::range_rate_and_ratio`]
+    /// uses the rotation rate for the same frame transport convention.
     pub mod pz90 {
         /// Geocentric gravitational constant (m^3/s^2), PZ-90.11.
         pub const GM_M3_S2: f64 = 3.986_004_4e14;
@@ -159,11 +166,21 @@ pub mod models {
         pub const A_M: f64 = 6_378_136.0;
     }
 
+    /// IERS-specific constant used by the Dehant solid-Earth tide calculation.
+    ///
+    /// [`crate::tides::solid_earth_tide`] uses the radius in the IERS
+    /// `DEHANTTIDEINEL.F` degree-2 and degree-3 scale factors whose ECEF
+    /// displacement is checked against the routine's reference rows.
     pub mod iers {
         /// Earth radius used by the Dehant solid Earth tide formulation (m).
         pub const SOLID_TIDE_EARTH_RADIUS_M: f64 = 6_378_136.6;
     }
 
+    /// PROJ-pinned WGS84 constants used by the ECEF-to-geodetic parity path.
+    ///
+    /// [`crate::astro::frames::transforms::geodetic_from_ecef_proj`] uses the
+    /// pinned axes, eccentricities, half-pi, and radian-to-degree multiplier;
+    /// its outputs are checked against pyproj 3.6.1 / PROJ 9.3.0 bit fixtures.
     pub mod proj {
         /// PROJ-pinned WGS84 semi-major axis (m).
         pub const WGS84_A_M: f64 = f64::from_bits(0x4158_54a6_4000_0000);
@@ -179,6 +196,12 @@ pub mod models {
         pub const HALF_PI: f64 = f64::from_bits(0x3ff9_21fb_5444_2d18);
     }
 
+    /// Per-constellation constants used by broadcast orbit and clock presets.
+    ///
+    /// [`crate::broadcast::ConstellationConstants`] takes its GPS/QZSS,
+    /// Galileo, and BeiDou gravitational, Earth-rotation, and relativistic
+    /// clock values from this module; the broadcast recipe tests require those
+    /// preset values to match at 0 ULP.
     pub mod broadcast {
         /// GPS broadcast gravitational constant (m^3/s^2), IS-GPS-200.
         pub const GPS_GM_M3_S2: f64 = 3.986_005_0e14;

--- a/crates/sidereon-core/src/astro/data/iau2000a.rs
+++ b/crates/sidereon-core/src/astro/data/iau2000a.rs
@@ -15,6 +15,9 @@
 // Units: 0.1 microarcsecond (and 0.1 microarcsecond per Julian century
 //        for time-dependent terms).
 
+/// Five integer multipliers for the 678 lunisolar nutation arguments.
+/// Row `r` is dotted with the five fundamental arguments and is paired with
+/// row `r` of [`LUNISOLAR_LONGITUDE_COEFFICIENTS`] and [`LUNISOLAR_OBLIQUITY_COEFFICIENTS`].
 pub static NALS_T: [[i32; 5]; 678] = [
     [0, 0, 0, 0, 1],
     [0, 0, 2, -2, 2],
@@ -696,6 +699,9 @@ pub static NALS_T: [[i32; 5]; 678] = [
     [2, 0, 2, 4, 1],
 ];
 
+/// Fourteen integer multipliers for the 687 planetary nutation arguments.
+/// Row `r` is dotted with the fourteen planetary arguments and is paired with
+/// row `r` of [`NUTATION_COEFFICIENTS_LONGITUDE`] and [`NUTATION_COEFFICIENTS_OBLIQUITY`].
 pub static NAPL_T: [[i32; 14]; 687] = [
     [0, 0, 0, 0, 0, 0, 0, 8, -16, 4, 5, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, -8, 16, -4, -5, 0, 0, 2],
@@ -1386,6 +1392,10 @@ pub static NAPL_T: [[i32; 14]; 687] = [
     [0, 0, 2, 2, 2, 0, 0, 2, 0, -2, 0, 0, 0, 0],
 ];
 
+/// Lunisolar longitude coefficients in 0.1 microarcseconds.
+/// For each row, the three columns multiply `sin(argument)`, `sin(argument) * t`, and
+/// `cos(argument)` respectively in the IAU 2000A longitude sum; the completed sum is
+/// converted to radians by the nutation evaluator.
 pub static LUNISOLAR_LONGITUDE_COEFFICIENTS: [[f64; 3]; 678] = [
     [-172064161.0, -174666.0, 33386.0],
     [-13170906.0, -1675.0, -13696.0],
@@ -2067,6 +2077,10 @@ pub static LUNISOLAR_LONGITUDE_COEFFICIENTS: [[f64; 3]; 678] = [
     [-3.0, 0.0, 0.0],
 ];
 
+/// Lunisolar obliquity coefficients in 0.1 microarcseconds.
+/// For each row, the three columns multiply `cos(argument)`, `cos(argument) * t`, and
+/// `sin(argument)` respectively in the IAU 2000A obliquity sum; the completed sum is
+/// converted to radians by the nutation evaluator.
 pub static LUNISOLAR_OBLIQUITY_COEFFICIENTS: [[f64; 3]; 678] = [
     [92052331.0, 9086.0, 15377.0],
     [5730336.0, -3015.0, -4587.0],
@@ -2748,6 +2762,9 @@ pub static LUNISOLAR_OBLIQUITY_COEFFICIENTS: [[f64; 3]; 678] = [
     [2.0, 0.0, 0.0],
 ];
 
+/// Planetary longitude coefficients in 0.1 microarcseconds.
+/// For each row, the two columns multiply `sin(argument)` and `cos(argument)` respectively
+/// in the IAU 2000A longitude sum, which is then converted to radians.
 pub static NUTATION_COEFFICIENTS_LONGITUDE: [[f64; 2]; 687] = [
     [1440.0, 0.0],
     [56.0, -117.0],
@@ -3438,6 +3455,9 @@ pub static NUTATION_COEFFICIENTS_LONGITUDE: [[f64; 2]; 687] = [
     [3.0, 0.0],
 ];
 
+/// Planetary obliquity coefficients in 0.1 microarcseconds.
+/// For each row, the two columns multiply `sin(argument)` and `cos(argument)` respectively
+/// in the IAU 2000A obliquity sum, which is then converted to radians.
 pub static NUTATION_COEFFICIENTS_OBLIQUITY: [[f64; 2]; 687] = [
     [0.0, 0.0],
     [-42.0, -40.0],

--- a/crates/sidereon-core/src/astro/error.rs
+++ b/crates/sidereon-core/src/astro/error.rs
@@ -1,19 +1,32 @@
 use thiserror::Error;
 
+/// Failure categories returned by the numerical propagators and force models.
+/// [`crate::astro::integrators::Integrator::propagate`] and
+/// [`crate::astro::forces::ForceModel::acceleration`] use this enum for input,
+/// numerical, step-budget, and delegated force-model failures.
 #[derive(Error, Debug, Clone)]
 pub enum PropagationError {
+    /// An integration or force-model input failed validation; the payload
+    /// contains the field/reason text or a model-specific validation message.
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
+    /// A propagation calculation produced a non-finite result or encountered
+    /// an unusable numerical intermediate; the payload identifies the context.
     #[error("Numerical failure: {0}")]
     NumericalFailure(String),
 
+    /// The integrator reached [`crate::astro::propagator::api::IntegratorOptions::max_steps`]
+    /// before reaching its target epoch.
     #[error("Maximum number of steps exceeded")]
     MaxStepsExceeded,
 
+    /// When formatted, prefixes its payload with `Event failure: `.
     #[error("Event failure: {0}")]
     EventFailure(String),
 
+    /// A force-model dependency or frame evaluation failed; the payload
+    /// preserves contextual text added by the calling force implementation.
     #[error("Force model failure: {0}")]
     ForceModelFailure(String),
 }

--- a/crates/sidereon-core/src/astro/events/eclipse.rs
+++ b/crates/sidereon-core/src/astro/events/eclipse.rs
@@ -45,8 +45,14 @@ pub enum EclipseStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum EclipseError {
     #[error("invalid eclipse input {field}: {reason}")]
+    /// A satellite or Sun position failed validation before eclipse geometry
+    /// was evaluated.
     InvalidInput {
+        /// Name of the position argument that failed validation: `"sat_pos"`
+        /// or `"sun_pos"`.
         field: &'static str,
+        /// Validation failure: `"not finite"`, `"zero vector"`, or
+        /// `"out of range"`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/forces/composite.rs
+++ b/crates/sidereon-core/src/astro/forces/composite.rs
@@ -5,15 +5,39 @@ use crate::astro::state::CartesianState;
 use nalgebra::Vector3;
 
 #[derive(Default)]
+/// An additive force model that combines the accelerations returned by its
+/// component [`ForceModel`] implementations.
+///
+/// `ForceModelKind::build` uses it for two-body-plus-J2 and configured composite
+/// propagation, while `StatePropagator::build_force` uses it to layer drag over
+/// gravity. The summed vector is consumed by
+/// [`crate::astro::propagator::dynamics::OrbitalDynamics`] as the km/s²
+/// velocity derivative.
 pub struct CompositeForceModel {
+    /// Force components in the order in which they are evaluated.
+    ///
+    /// [`Self::add`] appends each model, and
+    /// [`ForceModel::acceleration`] visits every entry, adds its returned
+    /// vector to a zero vector, and returns zero when the list is empty. An
+    /// error from a component is returned before later components are run.
     pub models: Vec<Box<dyn ForceModel>>,
 }
 
 impl CompositeForceModel {
+    /// Creates an empty composite with no force components.
+    ///
+    /// This calls the derived default, so [`ForceModel::acceleration`] returns
+    /// a zero vector until a model is added.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Appends a boxed force model to the end of [`Self::models`].
+    ///
+    /// The model is evaluated after models already present, so the acceleration
+    /// sum and any component error follow insertion order. Numerical builders
+    /// use this ordering to place gravity before J2 or other perturbations and
+    /// before an added drag model.
     pub fn add(&mut self, model: Box<dyn ForceModel>) {
         self.models.push(model);
     }

--- a/crates/sidereon-core/src/astro/forces/j2.rs
+++ b/crates/sidereon-core/src/astro/forces/j2.rs
@@ -5,9 +5,31 @@ use crate::astro::propagator::api::PropagationContext;
 use crate::astro::state::CartesianState;
 use nalgebra::Vector3;
 
+/// Degree-2 zonal-harmonic perturbation model for Cartesian propagation.
+///
+/// The [`crate::astro::forces::ForceModel`] implementation uses `state.position_km`
+/// to return the perturbation acceleration in km/s². Its scale is
+/// `1.5 * j2 * (mu / r²) * (re / r)²`; the x and y components use
+/// `(coordinate / r) * (5 * z² / r² - 1)`, while the z component uses
+/// `(z / r) * (5 * z² / r² - 3)`. [`crate::astro::propagator::numerical::ForceModelKind::TwoBodyJ2`]
+/// builds this model alongside [`crate::astro::forces::TwoBodyGravity`], and a
+/// position whose norm squared is exactly zero returns
+/// [`crate::astro::error::PropagationError::NumericalFailure`].
 pub struct J2Gravity {
+    /// Gravitational parameter in km³/s². `Default::default` sets this to
+    /// [`crate::astro::constants::MU_EARTH`], `ForceModelKind::build` copies
+    /// `TwoBodyJ2::mu_km3_s2` here, and `acceleration` uses it in the `mu / r²`
+    /// factor.
     pub mu: f64,
+    /// Gravity-model reference equatorial radius in km. `Default::default` sets
+    /// this to [`crate::astro::constants::RE_EARTH`], `ForceModelKind::build`
+    /// copies `TwoBodyJ2::re_km` here, and `acceleration` uses its squared
+    /// ratio to the position magnitude.
     pub re: f64,
+    /// Dimensionless degree-2 zonal harmonic coefficient. `Default::default`
+    /// sets this to [`crate::astro::constants::J2_EARTH`], `ForceModelKind::build`
+    /// copies `TwoBodyJ2::j2` here, and `acceleration` uses it to scale the
+    /// perturbation.
     pub j2: f64,
 }
 

--- a/crates/sidereon-core/src/astro/forces/trait.rs
+++ b/crates/sidereon-core/src/astro/forces/trait.rs
@@ -3,7 +3,23 @@ use crate::astro::propagator::api::PropagationContext;
 use crate::astro::state::CartesianState;
 use nalgebra::Vector3;
 
+/// Thread-safe source of spacecraft acceleration for numerical orbit propagation.
+///
+/// [`StatePropagator`](crate::astro::propagator::StatePropagator) builds concrete
+/// force implementations behind this interface. A
+/// [`CompositeForceModel`](crate::astro::forces::CompositeForceModel) evaluates
+/// several implementations and adds their returned accelerations.
 pub trait ForceModel: Send + Sync {
+    /// Evaluate this model at a propagation state and epoch.
+    ///
+    /// The state contains an absolute TDB epoch, position in kilometers, and
+    /// velocity in kilometers per second. Implementations return acceleration
+    /// in kilometers per second squared in the propagator's inertial frame;
+    /// [`OrbitalDynamics`](crate::astro::propagator::OrbitalDynamics) writes the
+    /// result directly into [`StateDerivative`](crate::astro::state::StateDerivative)'s
+    /// `dvel_km_s2` field. Models that need body-fixed coordinates obtain them
+    /// from `ctx`; singularities, invalid parameters, and model or frame
+    /// failures are returned as [`PropagationError`].
     fn acceleration(
         &self,
         state: &CartesianState,

--- a/crates/sidereon-core/src/astro/frames/precession.rs
+++ b/crates/sidereon-core/src/astro/frames/precession.rs
@@ -19,7 +19,11 @@ pub enum PrecessionError {
     /// A precession input was non-finite or otherwise invalid.
     #[error("invalid precession {field}: {reason}")]
     InvalidInput {
+        /// Static label identifying the failed validation target: `jd_tdb` for a non-finite
+        /// input or `precession_matrix` for a non-finite computed component.
         field: &'static str,
+        /// Static validation detail: `must be finite` for a non-finite TDB Julian date or
+        /// `components must be finite` for a non-finite matrix component.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/frames/transforms.rs
+++ b/crates/sidereon-core/src/astro/frames/transforms.rs
@@ -43,7 +43,9 @@ pub enum FrameTransformError {
     /// A transform input was non-finite or otherwise invalid.
     #[error("invalid frame transform {field}: {reason}")]
     InvalidInput {
+        /// Static input label selected by the validation or time-conversion failure.
         field: &'static str,
+        /// Static explanation paired with `field` for the failure.
         reason: &'static str,
     },
 }
@@ -131,14 +133,24 @@ pub type Vec3 = (f64, f64, f64);
 /// TEME-frame position and velocity (km, km/s): the input to
 /// [`teme_to_gcrs_compute`].
 pub struct TemeStateKm {
+    /// TEME position `(x, y, z)` in kilometers, rotated by the shared
+    /// TEME/GCRS matrix; the Skyfield-compatible path converts through AU.
     pub position_km: [f64; 3],
+    /// TEME velocity `(vx, vy, vz)` in kilometers per second, rotated by the
+    /// shared TEME/GCRS matrix; the Skyfield-compatible path uses AU/day.
     pub velocity_km_s: [f64; 3],
 }
 
 /// Geodetic ground-station position (WGS84) for topocentric look angles.
 pub struct GeodeticStationKm {
+    /// WGS84 geodetic latitude in degrees, constrained to `[-90, 90]` and
+    /// used for the ellipsoidal station position and ENU north/up axes.
     pub latitude_deg: f64,
+    /// WGS84 geodetic longitude in degrees, constrained to `[-180, 180]` and
+    /// used for the station ECEF longitude and ENU east/north axes.
     pub longitude_deg: f64,
+    /// Signed WGS84 ellipsoidal height in kilometers; it must be finite but
+    /// is otherwise added directly to the ellipsoid radii.
     pub altitude_km: f64,
 }
 
@@ -150,7 +162,11 @@ pub struct GeodeticStationKm {
 /// `*_with_polar_motion` entry points below.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PolarMotion {
+    /// IERS x-pole coordinate in radians, used as the `R_y(xp)` angle in the
+    /// polar-motion matrix.
     pub xp_rad: f64,
+    /// IERS y-pole coordinate in radians, used as the `R_x(yp)` angle in the
+    /// polar-motion matrix.
     pub yp_rad: f64,
 }
 

--- a/crates/sidereon-core/src/astro/integrators/dp54.rs
+++ b/crates/sidereon-core/src/astro/integrators/dp54.rs
@@ -13,6 +13,14 @@ use crate::astro::propagator::result::{
 use crate::astro::state::{CartesianState, StateDerivative};
 use nalgebra::Vector3;
 
+/// Adaptive Dormand-Prince 5(4) integrator for Cartesian-state propagation.
+///
+/// [`Integrator::propagate`] uses the embedded [`DP54Tableau`] pair to compute
+/// fifth-order position and velocity updates with a fourth-order error
+/// estimate, reuses the endpoint derivative through FSAL, and adjusts signed
+/// steps with a PI controller configured for order 5. It validates adaptive
+/// tolerances and finite TDB epochs, supports forward and backward spans, and
+/// can return [`DenseOutput`] segments for accepted steps when requested.
 pub struct DP54;
 
 impl Integrator for DP54 {

--- a/crates/sidereon-core/src/astro/integrators/tableau.rs
+++ b/crates/sidereon-core/src/astro/integrators/tableau.rs
@@ -1,7 +1,40 @@
+/// Coefficients for the Dormand-Prince embedded fifth- and fourth-order step
+/// used by [`DP54`](crate::astro::integrators::DP54).
+///
+/// [`Default::default`] fills the seven stage-time fractions, lower-triangular
+/// stage coefficients, and paired solution weights used by the adaptive step
+/// calculation.
 pub struct DP54Tableau {
+    /// Dimensionless fractions of the signed step duration used for
+    /// intermediate stage epochs by [`DP54`](crate::astro::integrators::DP54).
+    ///
+    /// [`Default::default`] sets the seven values to
+    /// `[0, 1/5, 3/10, 4/5, 8/9, 1, 1]`; the step calculation multiplies an
+    /// entry by `h` and adds it to the current epoch.
     pub c: [f64; 7],
+    /// Lower-triangular stage-coupling coefficients used by
+    /// [`DP54`](crate::astro::integrators::DP54).
+    ///
+    /// For stage `i` from 1 through 5, the step calculation uses the first `i`
+    /// values of row `i` to combine previously computed position and velocity
+    /// derivatives before multiplying by `h`. [`Default::default`] supplies
+    /// rows of lengths 1 through 6 after the empty first row.
     pub a: Vec<Vec<f64>>,
+    /// Weights for the fifth-order position and velocity increments computed
+    /// by [`DP54`](crate::astro::integrators::DP54).
+    ///
+    /// The step calculation applies the first six values to the stage
+    /// derivatives, multiplies the sums by `h`, and adds them to the input
+    /// state. The default seventh value is zero because the FSAL derivative is
+    /// reserved for the embedded error calculation.
     pub b5: [f64; 7],
+    /// Weights for the embedded fourth-order position and velocity increments
+    /// used by [`DP54`](crate::astro::integrators::DP54).
+    ///
+    /// The step calculation applies all seven values, including the derivative
+    /// evaluated at the proposed endpoint, and subtracts the resulting
+    /// increments from the fifth-order increments to form adaptive error
+    /// estimates. [`Default::default`] sets the seventh value to `1/40`.
     pub b4: [f64; 7],
 }
 

--- a/crates/sidereon-core/src/astro/math/linear.rs
+++ b/crates/sidereon-core/src/astro/math/linear.rs
@@ -8,12 +8,21 @@ use crate::astro::tolerances::PIVOT_EPSILON;
 use crate::validate;
 
 #[derive(Debug, Default, Clone)]
+/// Reusable buffers for the flat first-tie linear kernels.
+///
+/// [`invert_flat_first_tie_into`] and [`solve_matrix_flat_first_tie_into`]
+/// refill `rows` with an augmented row-major system and reuse `x` for its
+/// length-`n` solution, so callers can retain this value between solves.
 pub struct FlatLinearScratch {
     rows: Vec<f64>,
     x: Vec<f64>,
 }
 
 #[derive(Debug, Default, Clone)]
+/// Reusable buffers for [`solve_flat_normal_first_tie_into`].
+///
+/// The into variant copies the row-major normal matrix and right-hand side into
+/// `a` and `b`, then returns the finite solution held in `x`.
 pub struct FlatNormalSolveScratch {
     a: Vec<f64>,
     b: Vec<f64>,
@@ -21,14 +30,28 @@ pub struct FlatNormalSolveScratch {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+/// Validation failure reported while building a fixed-size weighted normal matrix.
+///
+/// [`normal_matrix_4_weighted_column_outer`] uses this error for weight-length
+/// mismatches, failed finite-input checks, and a non-finite accumulated result.
 pub enum LinearError {
     #[error("invalid linear algebra {field}: {reason}")]
+    /// The named input or output failed validation, with the static reason
+    /// supplied by the check that detected it.
     InvalidInput {
+        /// Validation label such as `weights`, `rows`, or `normal matrix`.
         field: &'static str,
+        /// Static diagnostic paired with [`field`](Self::InvalidInput::field).
         reason: &'static str,
     },
 }
 
+/// Solve a finite dense row-major system `A x = b` with partial pivoting.
+///
+/// At each column, the largest absolute pivot is selected by scanning downward
+/// with strict `>` comparison, so an equal-magnitude pivot keeps the first row.
+/// The function returns `None` for an empty, ragged, or non-finite system, a
+/// non-finite or `<= PIVOT_EPSILON` pivot, or a non-finite back-substituted result.
 pub fn solve_linear_first_tie(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
     let n = validate_dense_system(a, b)?;
     let mut rows: Vec<Vec<f64>> = a
@@ -78,6 +101,12 @@ pub fn solve_linear_first_tie(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
     Some(x)
 }
 
+/// Solve an owned finite dense row-major system `A x = b` with partial pivoting.
+///
+/// The largest absolute pivot is selected with `total_cmp`; equal magnitudes
+/// therefore select the last row encountered. The function returns `None` for
+/// an empty, ragged, or non-finite system, a non-finite or `<= PIVOT_EPSILON`
+/// pivot, or a non-finite back-substituted result.
 pub fn solve_linear_last_tie(mut a: Vec<Vec<f64>>, b: Vec<f64>) -> Option<Vec<f64>> {
     let n = validate_dense_system(&a, &b)?;
     for (row, bi) in a.iter_mut().zip(b) {
@@ -110,6 +139,11 @@ pub fn solve_linear_last_tie(mut a: Vec<Vec<f64>>, b: Vec<f64>) -> Option<Vec<f6
     Some(x)
 }
 
+/// Invert a finite dense matrix by solving once per unit-vector column with
+/// [`solve_linear_first_tie`].
+///
+/// The solved columns are transposed into the returned row-major inverse. An
+/// empty matrix or any failed column solve returns `None`.
 pub fn invert_matrix_first_tie(a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let n = a.len();
     if n == 0 {
@@ -128,6 +162,11 @@ pub fn invert_matrix_first_tie(a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     )
 }
 
+/// Invert a finite dense matrix by solving once per unit-vector column with
+/// [`solve_linear_last_tie`].
+///
+/// The solved columns are transposed into the returned row-major inverse. An
+/// empty, malformed, or singular input returns `None`.
 pub fn invert_matrix_last_tie(a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let n = a.len();
     let mut columns = Vec::with_capacity(n);
@@ -140,6 +179,11 @@ pub fn invert_matrix_last_tie(a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     transpose(&columns)
 }
 
+/// Solve `A X = B` column by column with [`solve_linear_last_tie`].
+///
+/// `B` and the returned `X` are row-major matrices; the function transposes
+/// `B` to obtain right-hand-side columns and transposes the solved columns back.
+/// Invalid dimensions, non-finite entries, or a failed column solve return `None`.
 pub fn solve_matrix_last_tie(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let columns = transpose(b)?;
     let mut solved_columns = Vec::with_capacity(columns.len());
@@ -149,6 +193,14 @@ pub fn solve_matrix_last_tie(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f
     transpose(&solved_columns)
 }
 
+/// Accumulate weighted normal equations from `(row_h, row_y, row_weight)` items.
+///
+/// Each item is scaled as `h = row_h * row_weight` and `y = row_y * row_weight`,
+/// then accumulated as `AᵀA` and `Aᵀy` in fixed row-major index order. Callers
+/// pass an inverse sigma or a square root of an inverse-variance weight, so the
+/// resulting matrix and right-hand side represent the corresponding weighted
+/// equations. `None` denotes zero dimension, a wrong row length, non-finite input,
+/// or a non-finite accumulated result.
 pub fn normal_equations_weighted<'a, I>(rows: I, n: usize) -> Option<(Vec<Vec<f64>>, Vec<f64>)>
 where
     I: IntoIterator<Item = (&'a [f64], f64, f64)>,
@@ -181,6 +233,10 @@ where
     Some((ata, aty))
 }
 
+/// Subtract two finite nonempty matrices entry by entry.
+///
+/// Both operands must have the same row and column counts. A dimension,
+/// finiteness, or result check failure returns `None`.
 pub fn matrix_sub(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let (rows, cols) = validate_same_shape(a, b)?;
     let out: Vec<Vec<f64>> = a
@@ -196,6 +252,11 @@ pub fn matrix_sub(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     Some(out)
 }
 
+/// Multiply two finite rectangular matrices.
+///
+/// The second operand is transposed first; each output entry is then accumulated
+/// by a left-to-right `acc + x * y` fold. Empty, ragged, incompatible,
+/// non-finite, or non-finite-result inputs return `None`.
 pub fn matmul(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let b_t = transpose(b)?;
     let rows = a.len();
@@ -223,6 +284,11 @@ pub fn matmul(a: &[Vec<f64>], b: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     Some(out)
 }
 
+/// Transpose a finite rectangular matrix.
+///
+/// The first row establishes the column count, and output entries are emitted
+/// by iterating columns before rows. Empty, zero-column, ragged, or non-finite
+/// input returns `None`.
 pub fn transpose(matrix: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let cols = matrix.first()?.len();
     if cols == 0 {
@@ -241,6 +307,13 @@ pub fn transpose(matrix: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     )
 }
 
+/// Write the inverse of a finite row-major flat `n × n` matrix into `out`.
+///
+/// Each unit-vector right-hand side is solved with
+/// [`solve_augmented_flat_first_tie_in_place`], and the resulting columns are
+/// stored in row-major order. `scratch` retains the augmented rows and solution
+/// buffers between calls; invalid dimensions, non-finite data, or a failed solve
+/// return `None`.
 pub fn invert_flat_first_tie_into(
     a: &[f64],
     n: usize,
@@ -268,6 +341,12 @@ pub fn invert_flat_first_tie_into(
     Some(())
 }
 
+/// Solve a row-major flat system `A X = B` into `out` with first-tie pivoting.
+///
+/// `A` is `n × n`, while `B` and `out` are `n × cols`; each right-hand-side
+/// column is solved through [`solve_augmented_flat_first_tie_in_place`]. The
+/// buffers in `scratch` are reused, and invalid dimensions, non-finite data, or
+/// a failed solve return `None`.
 pub fn solve_matrix_flat_first_tie_into(
     a: &[f64],
     n: usize,
@@ -300,6 +379,12 @@ pub fn solve_matrix_flat_first_tie_into(
     Some(())
 }
 
+/// Solve an augmented row-major `n × (n + 1)` system in place.
+///
+/// The coefficient columns use first-tie partial pivoting, then back-substitution
+/// writes the length-`n` solution into `x`. `rows` is modified during elimination;
+/// invalid lengths, non-finite data, a non-finite or `<= PIVOT_EPSILON` pivot, or a
+/// non-finite solution return `None`.
 pub fn solve_augmented_flat_first_tie_in_place(
     rows: &mut [f64],
     n: usize,
@@ -351,11 +436,21 @@ pub fn solve_augmented_flat_first_tie_in_place(
     Some(())
 }
 
+/// Solve a flat row-major normal system and return an owned solution.
+///
+/// This convenience wrapper allocates [`FlatNormalSolveScratch`], delegates to
+/// [`solve_flat_normal_first_tie_into`], and copies the returned solution.
 pub fn solve_flat_normal_first_tie(lambda: &[f64], eta: &[f64]) -> Option<Vec<f64>> {
     let mut scratch = FlatNormalSolveScratch::default();
     solve_flat_normal_first_tie_into(lambda, eta, &mut scratch).map(<[f64]>::to_vec)
 }
 
+/// Solve a flat row-major normal system with reusable first-tie scratch storage.
+///
+/// `lambda` must contain finite `n × n` data and `eta` finite length-`n` data.
+/// The inputs are copied into `scratch`, strict `>` pivot scanning keeps the
+/// first equal-magnitude pivot, and the returned slice is `scratch.x`. Zero or
+/// mismatched dimensions, non-finite data, or a singular pivot return `None`.
 pub fn solve_flat_normal_first_tie_into<'a>(
     lambda: &[f64],
     eta: &[f64],
@@ -592,6 +687,12 @@ fn linear_invalid_input(field: &'static str, reason: &'static str) -> LinearErro
     LinearError::InvalidInput { field, reason }
 }
 
+/// Accumulate the weighted normal matrix of four-component rows.
+///
+/// The result uses the fixed-order sum `Σ rows[k][i] * weights[k] * rows[k][j]`
+/// for every `i, j`. There must be one finite weight per finite row; a mismatch,
+/// failed validation, or non-finite accumulated entry returns
+/// [`LinearError::InvalidInput`].
 pub fn normal_matrix_4_weighted_column_outer(
     rows: &[[f64; 4]],
     weights: &[f64],
@@ -620,6 +721,10 @@ pub fn normal_matrix_4_weighted_column_outer(
     Ok(a)
 }
 
+/// Accumulate the unweighted normal matrix from four-component rows.
+///
+/// For every row, the function adds its outer product `row * rowᵀ` to the
+/// returned 4 × 4 matrix in the explicit `i`/`j` loop order.
 pub fn normal_matrix_4_unweighted_row_outer(rows: &[[f64; 4]]) -> [[f64; 4]; 4] {
     let mut a = [[0.0_f64; 4]; 4];
     for row in rows {
@@ -632,6 +737,10 @@ pub fn normal_matrix_4_unweighted_row_outer(rows: &[[f64; 4]]) -> [[f64; 4]; 4] 
     a
 }
 
+/// Apply a 4 × 4 matrix to a four-element vector.
+///
+/// Each result entry is the [`dot4`] product of one matrix row with `v`, in
+/// matrix-row order.
 pub fn mat4_vec4(m: &[[f64; 4]; 4], v: &[f64; 4]) -> [f64; 4] {
     [
         dot4(&m[0], v),
@@ -641,10 +750,18 @@ pub fn mat4_vec4(m: &[[f64; 4]; 4], v: &[f64; 4]) -> [f64; 4] {
     ]
 }
 
+/// Compute the fixed-order four-term dot product used by the velocity fit.
+///
+/// The terms are accumulated as `row[0] * v[0] + row[1] * v[1] +
+/// row[2] * v[2] + row[3] * v[3]`.
 pub fn dot4(row: &[f64; 4], v: &[f64; 4]) -> f64 {
     row[0] * v[0] + row[1] * v[1] + row[2] * v[2] + row[3] * v[3]
 }
 
+/// Compute a 4 × 4 determinant by cofactor expansion.
+///
+/// The implementation forms six 2 × 2 minors, four cofactors, and the
+/// alternating sum across the first row. It does not validate the input.
 pub fn det4_cofactor(a: &[[f64; 4]; 4]) -> f64 {
     let m01 = a[2][0] * a[3][1] - a[2][1] * a[3][0];
     let m02 = a[2][0] * a[3][2] - a[2][2] * a[3][0];
@@ -661,6 +778,11 @@ pub fn det4_cofactor(a: &[[f64; 4]; 4]) -> f64 {
     a[0][0] * c0 - a[0][1] * c1 + a[0][2] * c2 - a[0][3] * c3
 }
 
+/// Compute the determinant of the 3 × 3 matrix left after removing one row and
+/// one column from a 4 × 4 matrix.
+///
+/// The remaining entries are evaluated with the explicit three-term cofactor
+/// expansion used by [`invert_4x4_cofactor`].
 pub fn minor3_of_4(a: &[[f64; 4]; 4], skip_r: usize, skip_c: usize) -> f64 {
     let mut rows = [0_usize; 3];
     let mut cols = [0_usize; 3];
@@ -692,6 +814,10 @@ pub fn minor3_of_4(a: &[[f64; 4]; 4], skip_r: usize, skip_c: usize) -> f64 {
     b00 * (b11 * b22 - b12 * b21) - b01 * (b10 * b22 - b12 * b20) + b02 * (b10 * b21 - b11 * b20)
 }
 
+/// Invert a 4 × 4 matrix with its determinant and cofactor expansion.
+///
+/// A zero or non-finite determinant, or any non-finite entry in the resulting
+/// adjugate inverse, returns `None`.
 pub fn invert_4x4_cofactor(a: &[[f64; 4]; 4]) -> Option<[[f64; 4]; 4]> {
     let det = det4_cofactor(a);
     if det == 0.0 || !det.is_finite() {
@@ -711,6 +837,10 @@ pub fn invert_4x4_cofactor(a: &[[f64; 4]; 4]) -> Option<[[f64; 4]; 4]> {
     Some(inv)
 }
 
+/// Invert a 3 × 3 matrix with its explicit adjugate formula.
+///
+/// The function returns `None` when the determinant is non-finite or has
+/// absolute value `<= PIVOT_EPSILON`, or when an inverse entry is non-finite.
 pub fn invert_3x3_adjugate(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
     let [[a, b, c], [d, e, f], [g, h, i]] = *m;
     let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
@@ -741,6 +871,14 @@ pub fn invert_3x3_adjugate(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
     Some(inverse)
 }
 
+/// Invert a finite symmetric positive-definite matrix by fixed-order Cholesky
+/// factorization.
+///
+/// The input must be nonempty, square, and symmetric within
+/// `128 * f64::EPSILON * max(n, 1) * max(scale, 1)`. The function factors
+/// `N = L Lᵀ`, inverts `L`, and forms `L⁻ᵀ L⁻¹`; malformed or non-finite input,
+/// a symmetry failure, a non-positive or non-finite pivot, or a non-finite
+/// inverse returns `None`.
 pub fn invert_symmetric_pd(n: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     let p = n.len();
     if p == 0 {

--- a/crates/sidereon-core/src/astro/math/robust.rs
+++ b/crates/sidereon-core/src/astro/math/robust.rs
@@ -19,21 +19,40 @@ pub const HUBER_K: f64 = 1.345;
 pub const MAD_NORMAL_CONST: f64 = 1.4826;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+/// An input validation error from [`median`] or [`mad_scale`].
+///
+/// The solver callers map the contained field and reason into their public
+/// input-error types.
 pub enum RobustError {
     #[error("invalid robust statistic {field}: {reason}")]
+    /// A robust-statistic input failed a finiteness or positivity check.
+    ///
+    /// [`median`] and [`mad_scale`] use this variant for invalid samples or an
+    /// invalid scale floor.
     InvalidInput {
+        /// The rejected argument: `"values"` for non-finite samples or
+        /// `"scale_floor"` for an invalid scale floor.
         field: &'static str,
+        /// The validation failure: `"not finite"` or `"not positive"`.
         reason: &'static str,
     },
 }
 
 impl RobustError {
+    /// Returns the rejected input name from [`RobustError::InvalidInput`].
+    ///
+    /// The static and single-point positioning adapters use this value to
+    /// distinguish the scale floor from the robust sample values.
     pub const fn field(&self) -> &'static str {
         match self {
             Self::InvalidInput { field, .. } => field,
         }
     }
 
+    /// Returns the validation failure from [`RobustError::InvalidInput`].
+    ///
+    /// The static and single-point positioning adapters use this value to map
+    /// non-finite and non-positive inputs to their public error kinds.
     pub const fn reason(&self) -> &'static str {
         match self {
             Self::InvalidInput { reason, .. } => reason,

--- a/crates/sidereon-core/src/astro/math/vec3.rs
+++ b/crates/sidereon-core/src/astro/math/vec3.rs
@@ -10,7 +10,11 @@ pub enum Vec3Error {
     /// A vector input or output contained NaN or infinity.
     #[error("invalid vec3 {field}: {reason}")]
     InvalidInput {
+        /// Label of the operand or computed result rejected by [`checked_add3`]:
+        /// `"a"`, `"b"`, or `"sum"`.
         field: &'static str,
+        /// Validation reason emitted by [`checked_add3`]. The current reason is
+        /// `"not finite"` for a NaN or infinity in an input or computed sum.
         reason: &'static str,
     },
 }
@@ -40,51 +44,96 @@ pub fn checked_add3(a: [f64; 3], b: [f64; 3]) -> Result<[f64; 3], Vec3Error> {
 }
 
 #[inline]
+/// Subtract corresponding components in the explicit order used by the
+/// position, baseline, relative-state, and finite-difference callers.
+///
+/// The result is `[a[0] - b[0], a[1] - b[1], a[2] - b[2]]`; this helper does not
+/// validate the operands or the result for finiteness.
 pub fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
 
 #[inline]
+/// Negate each component, returning `[-v[0], -v[1], -v[2]]`.
+///
+/// The angle and PPP correction callers use this to reverse a position or a
+/// local basis direction; no finiteness check is performed.
 pub fn neg3(v: [f64; 3]) -> [f64; 3] {
     [-v[0], -v[1], -v[2]]
 }
 
 #[inline]
+/// Multiply every component by `s` in index order.
+///
+/// The result is `[v[0] * s, v[1] * s, v[2] * s]`; callers use this for unit
+/// vector scaling, time-step integration, and finite differences, and the
+/// helper does not validate the operands or result.
 pub fn scale3(v: [f64; 3], s: f64) -> [f64; 3] {
     [v[0] * s, v[1] * s, v[2] * s]
 }
 
 #[inline]
+/// Compute the explicit dot-product reduction
+/// `a[0] * b[0] + a[1] * b[1] + a[2] * b[2]`.
+///
+/// The addition order is retained for floating-point parity in projection,
+/// angle, and orbit-geometry calculations.
 pub fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
     a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 }
 
 #[inline]
+/// Compute the borrowed-vector dot product using the explicit reduction
+/// `a[0] * b[0] + a[1] * b[1] + a[2] * b[2]`.
+///
+/// This preserves the same addition order as [`dot3`] for IOD, Lambert, tide,
+/// and reduced-orbit calculations.
 pub fn dot3_ref(a: &[f64; 3], b: &[f64; 3]) -> f64 {
     a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 }
 
 #[inline]
+/// Compute the alternate borrowed-vector reduction
+/// `a[2] * b[2] + (a[1] * b[1] + a[0] * b[0])`.
+///
+/// The z term is added to the grouped y/x subtotal, which gives callers a
+/// separately selectable floating-point operation order.
 pub fn dot3_z_yx_ref(a: &[f64; 3], b: &[f64; 3]) -> f64 {
     a[2] * b[2] + (a[1] * b[1] + a[0] * b[0])
 }
 
 #[inline]
+/// Compute the fused alternate reduction
+/// `fma(a[2], b[2], fma(a[1], b[1], a[0] * b[0]))`.
+///
+/// The inner x product seeds the y fusion, and the resulting subtotal is fused
+/// with the z product through [`libm::fma`].
 pub fn dot3_fused_z_yx_ref(a: &[f64; 3], b: &[f64; 3]) -> f64 {
     libm::fma(a[2], b[2], libm::fma(a[1], b[1], a[0] * b[0]))
 }
 
 #[inline]
+/// Compute the Euclidean magnitude as `dot3(v, v).sqrt()`.
+///
+/// No finiteness or zero check is performed; callers that need those checks
+/// apply them around this parity-sensitive reduction.
 pub fn norm3(v: [f64; 3]) -> f64 {
     dot3(v, v).sqrt()
 }
 
 #[inline]
+/// Compute the borrowed-vector Euclidean magnitude as `dot3_ref(v, v).sqrt()`.
+///
+/// Non-finite and zero results are left for the caller to handle.
 pub fn norm3_ref(v: &[f64; 3]) -> f64 {
     dot3_ref(v, v).sqrt()
 }
 
 #[inline]
+/// Normalize `v` with `scale3(v, 1.0 / n)` when `n = norm3(v)` is positive.
+///
+/// Returns `None` when `n` is not greater than `0.0`, including a zero or NaN
+/// norm. The helper does not make a separate finiteness check before scaling.
 pub fn unit3(v: [f64; 3]) -> Option<[f64; 3]> {
     match norm3(v) {
         n if n > 0.0 => Some(scale3(v, 1.0 / n)),
@@ -93,12 +142,20 @@ pub fn unit3(v: [f64; 3]) -> Option<[f64; 3]> {
 }
 
 #[inline]
+/// Divide each component by the borrowed vector's `norm3_ref` result.
+///
+/// This helper performs no zero or finiteness check; its IOD, Lambert, and RTN
+/// callers establish a usable norm before invoking it.
 pub fn unit3_ref_unchecked(v: &[f64; 3]) -> [f64; 3] {
     let n = norm3_ref(v);
     [v[0] / n, v[1] / n, v[2] / n]
 }
 
 #[inline]
+/// Compute the explicit right-handed cross product in component order.
+///
+/// The result is `[a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
+/// a[0] * b[1] - a[1] * b[0]]`.
 pub fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
     [
         a[1] * b[2] - a[2] * b[1],
@@ -108,6 +165,11 @@ pub fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
 }
 
 #[inline]
+/// Compute the borrowed-vector cross product with the same component order as
+/// [`cross3`].
+///
+/// The result is `[a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
+/// a[0] * b[1] - a[1] * b[0]]`.
 pub fn cross3_ref(a: &[f64; 3], b: &[f64; 3]) -> [f64; 3] {
     [
         a[1] * b[2] - a[2] * b[1],

--- a/crates/sidereon-core/src/astro/oem.rs
+++ b/crates/sidereon-core/src/astro/oem.rs
@@ -42,9 +42,22 @@ const STATE_NUMBER_KEYS: [&str; 9] = [
 /// Canonical, format-agnostic OEM container.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Oem {
+    /// KVN readers copy `CCSDS_OEM_VERS`, while XML readers prefer the trimmed
+    /// `<oem version>` attribute and otherwise use the `CCSDS_OEM_VERS`
+    /// element. An empty KVN value is rejected, and both encoders write the
+    /// stored version.
     pub ccsds_oem_vers: String,
+    /// Optional `CREATION_DATE` header text copied by both readers and emitted
+    /// by both encoders; a missing value becomes an empty KVN header value or
+    /// XML element.
     pub creation_date: Option<String>,
+    /// Optional `ORIGINATOR` header text copied by both readers and emitted by
+    /// both encoders; a missing value becomes an empty KVN header value or XML
+    /// element.
     pub originator: Option<String>,
+    /// Segments occur in KVN `META_START` order or XML document order. Both
+    /// encoders iterate this vector in order; a message with no segment returns
+    /// [`OemError::Field`].
     pub segments: Vec<OemSegment>,
     /// Forgiving-parse count of ephemeris data lines skipped as malformed.
     pub skipped_states: usize,
@@ -53,41 +66,89 @@ pub struct Oem {
 /// One OEM metadata/data segment.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OemSegment {
+    /// Metadata read between KVN markers or from the XML `<metadata>` child.
+    /// Encoders write it before the segment data.
     pub metadata: OemMetadata,
+    /// State vectors are collected in input order; malformed KVN lines are
+    /// skipped, while XML state-vector errors fail parsing. Both encoders write
+    /// states before covariances.
     pub states: Vec<OemState>,
+    /// Covariance blocks are collected in input order from KVN
+    /// `COVARIANCE_START` blocks or XML `<covarianceMatrix>` elements. Both
+    /// encoders write them after the states.
     pub covariances: Vec<OemCovariance>,
 }
 
 /// OEM segment metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OemMetadata {
+    /// Required `OBJECT_NAME` text copied by `parse_metadata` and emitted under
+    /// the same key or element by both encoders.
     pub object_name: String,
+    /// Required `OBJECT_ID` text copied by `parse_metadata` and emitted under
+    /// the same key or element by both encoders.
     pub object_id: String,
+    /// Required `CENTER_NAME` text copied by `parse_metadata` and emitted under
+    /// the same key or element by both encoders.
     pub center_name: String,
+    /// Required `REF_FRAME` text copied by `parse_metadata` and emitted under
+    /// the same key or element by both encoders.
     pub ref_frame: String,
+    /// Required `TIME_SYSTEM` text copied by `parse_metadata` and emitted under
+    /// the same key or element by both encoders.
     pub time_system: String,
+    /// Required `START_TIME` text retained without date conversion and emitted
+    /// under the same key or element by both encoders.
     pub start_time: String,
+    /// Required `STOP_TIME` text retained without date conversion and emitted
+    /// under the same key or element by both encoders.
     pub stop_time: String,
+    /// Optional `USEABLE_START_TIME` text; absent input yields `None`, and both
+    /// encoders omit the field when it is `None`.
     pub useable_start_time: Option<String>,
+    /// Optional `USEABLE_STOP_TIME` text; absent input yields `None`, and both
+    /// encoders omit the field when it is `None`.
     pub useable_stop_time: Option<String>,
+    /// Optional `INTERPOLATION` text; absent input yields `None`, and both
+    /// encoders omit the field when it is `None`.
     pub interpolation: Option<String>,
+    /// Optional `INTERPOLATION_DEGREE` parsed as a strict `u32`; an invalid
+    /// integer becomes an [`OemError::InvalidField`], and encoders write it in
+    /// decimal form only when present.
     pub interpolation_degree: Option<u32>,
 }
 
 /// One OEM Cartesian state sample.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OemState {
+    /// The first KVN token or required XML `EPOCH` text, retained without time-
+    /// system resolution or normalization and written back by both encoders.
     pub epoch: String,
+    /// Strict numeric `X`, `Y`, and `Z` values stored in that array order and
+    /// encoded back under those fields through `fmt_num`.
     pub position_km: [f64; 3],
+    /// Strict numeric `X_DOT`, `Y_DOT`, and `Z_DOT` values stored in that array
+    /// order and encoded back under those fields through `fmt_num`.
     pub velocity_km_s: [f64; 3],
+    /// KVN supplies acceleration only for a ten-token state line, while XML
+    /// supplies it only when all three acceleration elements are present. A
+    /// partial XML triple is an error, and encoders omit these fields for
+    /// `None`.
     pub acceleration_km_s2: Option<[f64; 3]>,
 }
 
 /// One OEM covariance block.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OemCovariance {
+    /// Required `EPOCH` text retained in the covariance block and emitted under
+    /// the same field or element without date conversion.
     pub epoch: String,
+    /// Optional `COV_REF_FRAME` text retained when present and omitted by both
+    /// encoders when absent.
     pub cov_ref_frame: Option<String>,
+    /// Symmetric, positive-semidefinite [`Covariance6`] built by mirroring the
+    /// 21 lower-triangle covariance fields on read; encoding emits that lower
+    /// triangle in the shared CCSDS key order.
     pub matrix: Covariance6,
 }
 
@@ -98,7 +159,10 @@ pub enum OemError {
     MissingField(&'static str),
     /// A decoded scalar field failed validation.
     InvalidField {
+        /// Static source-field label retained from validation and included in
+        /// the error's display text.
         field: &'static str,
+        /// Validation category mapped from the shared [`validate::FieldError`].
         kind: OemInputErrorKind,
     },
     /// A structural or XML-level error.

--- a/crates/sidereon-core/src/astro/omm.rs
+++ b/crates/sidereon-core/src/astro/omm.rs
@@ -93,11 +93,23 @@ const GP_CSV_FIELDS: &[&str] = &[
 /// re-encodes losslessly and converts directly to the SGP4 epoch.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct OmmEpoch {
+    /// Civil year copied from the parsed `EPOCH`, or derived from an SGP4 split
+    /// Julian date without applying the TLE two-digit-year pivot.
     pub year: i32,
+    /// Civil month copied from the parsed `EPOCH`, or derived from an SGP4 split
+    /// Julian date when a fit produces an [`OmmEpoch`].
     pub month: u32,
+    /// Civil day copied from the parsed `EPOCH`, or derived from an SGP4 split
+    /// Julian date when a fit produces an [`OmmEpoch`].
     pub day: u32,
+    /// Civil hour passed to the calendar-to-Julian-date conversion; parsed
+    /// year-end OMMs retain hour 23 when bridged to SGP4.
     pub hour: u32,
+    /// Civil minute passed to the calendar-to-Julian-date conversion; the ISS
+    /// fixture's `04:32` epoch decodes this field as 32.
     pub minute: u32,
+    /// Civil second copied from the parsed `EPOCH`; UTC-like input may retain
+    /// leap-second value 60, while continuous-time input rejects it.
     pub second: u32,
     /// Fractional second expressed in whole microseconds (0..=999_999).
     pub microsecond: u32,
@@ -118,18 +130,36 @@ pub struct OmmEpoch {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Omm {
     // -- Header / metadata --
+    /// OMM format version from `CCSDS_OMM_VERS`; field mapping defaults it to
+    /// `"2.0"`, and encoders place it in the format-specific version field.
     pub ccsds_omm_vers: String,
+    /// Optional validated `CREATION_DATE` header text, emitted as empty/`null`
+    /// when absent according to the selected encoding.
     pub creation_date: Option<String>,
+    /// Optional validated `ORIGINATOR` header text, emitted as empty/`null`
+    /// when absent according to the selected encoding.
     pub originator: Option<String>,
+    /// Optional `OBJECT_NAME` text used by constellation conversion to resolve
+    /// a PRN and retained in CelesTrak source or skipped-entry identity.
     pub object_name: Option<String>,
     /// International designator, CCSDS form (e.g. `"1998-067A"`).
     pub object_id: Option<String>,
+    /// Optional `CENTER_NAME` metadata; CelesTrak JSON may omit it, yielding
+    /// `None` in cross-encoding comparisons.
     pub center_name: Option<String>,
+    /// Optional `REF_FRAME` metadata; CelesTrak JSON may omit it, yielding
+    /// `None` in cross-encoding comparisons.
     pub ref_frame: Option<String>,
+    /// Optional `TIME_SYSTEM` metadata that selects UTC-like parsing for absent,
+    /// `UTC`, `GLO`, and `GLONASS` labels and continuous parsing otherwise.
     pub time_system: Option<String>,
+    /// Optional validated `MEAN_ELEMENT_THEORY` text; XML encoding preserves
+    /// legal carriage returns through character-reference escaping.
     pub mean_element_theory: Option<String>,
 
     // -- Mean elements --
+    /// Parsed `EPOCH` calendar value emitted as ISO-8601 and used by
+    /// [`Omm::to_element_set`] when no exact in-memory split Julian date exists.
     pub epoch: OmmEpoch,
     /// Mean motion, revolutions per day.
     pub mean_motion: f64,
@@ -145,10 +175,20 @@ pub struct Omm {
     pub mean_anomaly_deg: f64,
 
     // -- TLE-derived parameters --
+    /// Optional `EPHEMERIS_TYPE`, defaulting to integer 0 when absent; fit-
+    /// generated OMMs also set it to 0.
     pub ephemeris_type: i32,
+    /// `CLASSIFICATION_TYPE`, defaulting to `"U"` when absent; fit-generated
+    /// OMMs copy the classification from their TLE metadata.
     pub classification_type: String,
+    /// Required `NORAD_CAT_ID` parsed as `u32`; it feeds the SGP4 catalog number
+    /// and constellation record identity.
     pub norad_cat_id: u32,
+    /// Optional `ELEMENT_SET_NO`, defaulting to integer 999 when absent; fit-
+    /// generated OMMs copy `TleMetadata::element_set_number`.
     pub element_set_no: i32,
+    /// Optional `REV_AT_EPOCH`, defaulting to integer 0 when absent; TLE
+    /// conversion requires a fit-generated value to fit in `i32`.
     pub rev_at_epoch: i64,
     /// SGP4 drag term B\*, inverse earth-radii.
     pub bstar: f64,
@@ -188,7 +228,9 @@ pub enum OmmError {
     MissingField(&'static str),
     /// A decoded scalar field failed boundary validation.
     InvalidField {
+        /// Static field label returned by the shared validator.
         field: &'static str,
+        /// OMM validation category derived from the shared validator.
         kind: OmmInputErrorKind,
     },
     /// A numeric/integer field could not be parsed.

--- a/crates/sidereon-core/src/astro/opm.rs
+++ b/crates/sidereon-core/src/astro/opm.rs
@@ -54,68 +54,141 @@ const MANEUVER_KEYS: [&str; 7] = [
 /// Canonical, format-agnostic OPM container.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Opm {
+    /// Version copied from `CCSDS_OPM_VERS` in KVN or the `<opm version>`/
+    /// `CCSDS_OPM_VERS` value in XML. [`parse_kvn`] rejects an empty KVN
+    /// version, and both encoders write this value back.
     pub ccsds_opm_vers: String,
+    /// Optional `CREATION_DATE` header text copied by both readers and emitted
+    /// as text by both encoders; `None` becomes an empty header value.
     pub creation_date: Option<String>,
+    /// Optional `ORIGINATOR` header text copied by both readers and emitted as
+    /// text by both encoders; `None` becomes an empty header value.
     pub originator: Option<String>,
+    /// Required metadata assembled by `parse_metadata` from the five metadata
+    /// fields and emitted before state data by both encoders.
     pub metadata: OpmMetadata,
+    /// Required Cartesian state assembled by `parse_state` and emitted by both
+    /// encoders after [`Opm::metadata`].
     pub state: OpmState,
+    /// Optional Keplerian block. KVN sets it when any Keplerian key is present,
+    /// XML sets it for `keplerianElements`, and a present block must contain
+    /// one, and only one, anomaly field.
     pub keplerian: Option<OpmKeplerian>,
+    /// Optional spacecraft-parameters block. KVN sets it when any spacecraft
+    /// key is present, XML sets it for `spacecraftParameters`, and each of its
+    /// numeric fields may still be absent.
     pub spacecraft: Option<OpmSpacecraft>,
+    /// Optional covariance block. KVN sets it for `COV_REF_FRAME` or any
+    /// covariance entry, XML sets it for `covarianceMatrix`, and a present
+    /// block must provide all 21 matrix entries.
     pub covariance: Option<OpmCovariance>,
+    /// Maneuver blocks in source order. Both readers append them in encounter
+    /// order, and both encoders iterate this vector in that same order.
     pub maneuvers: Vec<OpmManeuver>,
 }
 
 /// OPM metadata block.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmMetadata {
+    /// Required `OBJECT_NAME` text copied by `parse_metadata` and emitted under
+    /// the same key by both encoders.
     pub object_name: String,
+    /// Required `OBJECT_ID` text copied by `parse_metadata` and emitted under
+    /// the same key by both encoders.
     pub object_id: String,
+    /// Required `CENTER_NAME` text copied by `parse_metadata` and emitted under
+    /// the same key by both encoders.
     pub center_name: String,
+    /// Required `REF_FRAME` label copied by `parse_metadata` and emitted under
+    /// the same key by both encoders.
     pub ref_frame: String,
+    /// Required `TIME_SYSTEM` label copied by `parse_metadata` and emitted under
+    /// the same key by both encoders.
     pub time_system: String,
 }
 
 /// OPM Cartesian state vector.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmState {
+    /// Required `EPOCH` text. The readers do not convert or normalize it, and
+    /// both encoders write the stored text back.
     pub epoch: String,
+    /// Strict numeric values from `X`, `Y`, and `Z`, in that order; encoders map
+    /// the entries back to those keys without conversion.
     pub position_km: [f64; 3],
+    /// Strict numeric values from `X_DOT`, `Y_DOT`, and `Z_DOT`, in that order;
+    /// encoders map the entries back to those keys without conversion.
     pub velocity_km_s: [f64; 3],
 }
 
 /// Optional OPM Keplerian elements.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmKeplerian {
+    /// Strict numeric `SEMI_MAJOR_AXIS` value stored directly and emitted under
+    /// the same field name.
     pub semi_major_axis_km: f64,
+    /// Strict numeric `ECCENTRICITY` value stored directly and emitted under
+    /// the same field name; no orbital-range check is applied here.
     pub eccentricity: f64,
+    /// Strict numeric `INCLINATION` value stored directly and emitted under the
+    /// same field name.
     pub inclination_deg: f64,
+    /// Strict numeric `RA_OF_ASC_NODE` value stored directly and emitted under
+    /// the same field name.
     pub ra_of_asc_node_deg: f64,
+    /// Strict numeric `ARG_OF_PERICENTER` value stored directly and emitted
+    /// under the same field name.
     pub arg_of_pericenter_deg: f64,
+    /// Selected by exactly one of `TRUE_ANOMALY` and `MEAN_ANOMALY`; missing or
+    /// simultaneous fields produce [`OpmError::Field`], and the selected key is
+    /// emitted on encoding.
     pub anomaly: OpmAnomaly,
+    /// Strict numeric `GM` value stored directly and emitted under the same
+    /// field name.
     pub gm_km3_s2: f64,
 }
 
 /// OPM true or mean anomaly.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OpmAnomaly {
+    /// Value from `TRUE_ANOMALY`, accepted only when `MEAN_ANOMALY` is absent;
+    /// encoders write it as `TRUE_ANOMALY`.
     True(f64),
+    /// Value from `MEAN_ANOMALY`, accepted only when `TRUE_ANOMALY` is absent;
+    /// encoders write it as `MEAN_ANOMALY`.
     Mean(f64),
 }
 
 /// Optional OPM spacecraft parameters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmSpacecraft {
+    /// Optional strict numeric `MASS` value; `None` causes the encoders to omit
+    /// the `MASS` field.
     pub mass_kg: Option<f64>,
+    /// Optional strict numeric `SOLAR_RAD_AREA` value; `None` causes the
+    /// encoders to omit the field.
     pub solar_rad_area_m2: Option<f64>,
+    /// Optional strict numeric `SOLAR_RAD_COEFF` value; `None` causes the
+    /// encoders to omit the field.
     pub solar_rad_coeff: Option<f64>,
+    /// Optional strict numeric `DRAG_AREA` value; `None` causes the encoders to
+    /// omit the field.
     pub drag_area_m2: Option<f64>,
+    /// Optional strict numeric `DRAG_COEFF` value; `None` causes the encoders to
+    /// omit the field.
     pub drag_coeff: Option<f64>,
 }
 
 /// Optional OPM 6x6 covariance.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmCovariance {
+    /// Optional `COV_REF_FRAME` label retained on the covariance block and
+    /// emitted only when present. In KVN, its presence also makes the block
+    /// present, so all matrix fields are then required.
     pub cov_ref_frame: Option<String>,
+    /// Symmetric, positive-semidefinite [`Covariance6`] built by mirroring the
+    /// 21 lower-triangle fields on read; encoding emits that lower triangle in
+    /// the shared CCSDS key order.
     pub matrix: Covariance6,
 }
 
@@ -123,10 +196,20 @@ pub struct OpmCovariance {
 /// maneuver is present, including `MAN_REF_FRAME`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OpmManeuver {
+    /// Required `MAN_EPOCH_IGNITION` text retained without date conversion and
+    /// emitted under the same key.
     pub epoch_ignition: String,
+    /// Strict numeric `MAN_DURATION` value stored directly and emitted under
+    /// the same key.
     pub duration_s: f64,
+    /// Strict numeric `MAN_DELTA_MASS` value, including its sign, stored
+    /// directly and emitted under the same key.
     pub delta_mass_kg: f64,
+    /// Required `MAN_REF_FRAME` text stored for this maneuver and emitted under
+    /// the same key.
     pub ref_frame: String,
+    /// Strict numeric values from `MAN_DV_1`, `MAN_DV_2`, and `MAN_DV_3`, in that
+    /// order; encoders map the entries back to those keys.
     pub dv_km_s: [f64; 3],
 }
 
@@ -137,7 +220,10 @@ pub enum OpmError {
     MissingField(&'static str),
     /// A decoded scalar field failed validation.
     InvalidField {
+        /// Static source-field label retained from validation and included in
+        /// the error's display text.
         field: &'static str,
+        /// Validation category mapped from the shared [`validate::FieldError`].
         kind: OpmInputErrorKind,
     },
     /// A structural or XML-level error.

--- a/crates/sidereon-core/src/astro/passes.rs
+++ b/crates/sidereon-core/src/astro/passes.rs
@@ -191,15 +191,29 @@ struct UtcComponents {
 /// Ground-station geodetic coordinates.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GroundStation {
+    /// Geodetic latitude in degrees, passed to the WGS84 geodetic and
+    /// topocentric transforms. Pass and look-angle entry points require a
+    /// finite value in `[-90, 90]`.
     pub latitude_deg: f64,
+    /// Geodetic longitude in degrees, passed to the WGS84 geodetic and
+    /// topocentric transforms. Pass and look-angle entry points require a
+    /// finite value in `[-180, 180]`.
     pub longitude_deg: f64,
+    /// Station height above the reference ellipsoid in meters. The geometry
+    /// code requires it to be finite and converts it to kilometers before
+    /// constructing the geodetic station.
     pub altitude_m: f64,
 }
 
 /// Pass-prediction options.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PassPredictionOptions {
+    /// Elevation threshold in degrees applied after each horizon-bounded pass's
+    /// maximum elevation is found. The value must be finite and in `[-90, 90]`.
     pub min_elevation_deg: f64,
+    /// Positive integer interval in seconds between samples in the coarse
+    /// elevation scan. If the interval does not land on `end_time`, the scan
+    /// adds an explicit sample at that endpoint.
     pub step_seconds: i64,
 }
 
@@ -215,9 +229,17 @@ impl Default for PassPredictionOptions {
 /// Predicted visible pass.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PredictedPass {
+    /// UTC instant used as the pass rise: the refined rising horizon crossing,
+    /// or `start_time` when the first sample is already above the horizon.
     pub rise: UtcInstant,
+    /// UTC instant of the refined falling horizon crossing that closes the
+    /// emitted pass within the requested window.
     pub set: UtcInstant,
+    /// Elevation in degrees evaluated at the best time found by the
+    /// golden-section search between [`Self::rise`] and [`Self::set`].
     pub max_elevation_deg: f64,
+    /// UTC instant selected by the golden-section search for the highest
+    /// elevation between [`Self::rise`] and [`Self::set`].
     pub max_elevation_time: UtcInstant,
 }
 
@@ -225,8 +247,15 @@ pub struct PredictedPass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum PassError {
     #[error("invalid pass input {field}: {reason}")]
+    /// A pass or visibility entry point rejected an input before producing its
+    /// result; [`Self::InvalidInput::field`] and [`Self::InvalidInput::reason`]
+    /// identify the rejected value and validation outcome.
     InvalidInput {
+        /// Stable label for the rejected value, such as `step_seconds` or
+        /// `ground_station.latitude_deg`.
         field: &'static str,
+        /// Short validation diagnostic, such as `not finite`, `not positive`,
+        /// or `out of range`.
         reason: &'static str,
     },
 }
@@ -242,24 +271,42 @@ pub struct LookAngle {
     /// [`crate::constants::AZIMUTH_ZENITH_EPS`], rather than returning rounding
     /// noise or erroring.
     pub azimuth_deg: f64,
+    /// Topocentric elevation in degrees produced by the GCRS-to-topocentric
+    /// transform and checked for finiteness before it is returned.
     pub elevation_deg: f64,
+    /// Topocentric line-of-sight distance in kilometers produced by the
+    /// GCRS-to-topocentric transform and checked for finiteness before return.
     pub range_km: f64,
 }
 
 /// One member of a TLE-backed constellation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConstellationMember {
+    /// Identifier copied into [`VisibleSatellite::catalog_number`] when this
+    /// member is emitted by [`visible_from_constellation`].
     pub catalog_number: String,
+    /// Element set passed to SGP4 initialization with [`OpsMode::Afspc`]; a
+    /// member whose initialization fails is skipped by the visibility search.
     pub elements: ElementSet,
 }
 
 /// One satellite visible from a ground station at an instant.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VisibleSatellite {
+    /// Identifier copied from the constellation member or the parallel `ids`
+    /// entry that supplied this result.
     pub catalog_number: String,
+    /// Topocentric azimuth in degrees copied from the successful look-angle
+    /// calculation.
     pub azimuth_deg: f64,
+    /// Topocentric elevation in degrees copied from the successful look-angle
+    /// calculation; only values at or above the requested threshold are kept.
     pub elevation_deg: f64,
+    /// Topocentric line-of-sight distance in kilometers copied from the
+    /// successful look-angle calculation.
     pub range_km: f64,
+    /// Propagated satellite position in the TEME frame, in kilometers, copied
+    /// from [`Prediction::position`].
     pub position_km: [f64; 3],
 }
 
@@ -267,15 +314,26 @@ pub struct VisibleSatellite {
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum LookAngleError {
     #[error("invalid look-angle input {field}: {reason}")]
+    /// A look-angle or ground-track entry point rejected a station, datetime,
+    /// or computed look value; the fields carry its stable diagnostic.
     InvalidInput {
+        /// Stable label for the rejected input or computed output, such as
+        /// `datetime` or `ground_station.latitude_deg`.
         field: &'static str,
+        /// Short validation diagnostic, such as `not finite` or
+        /// `invalid UTC instant`.
         reason: &'static str,
     },
     #[error("SGP4 initialization failed: {0}")]
+    /// SGP4 could not initialize the element set supplied to [`look_angle`].
     Init(crate::astro::sgp4::Error),
     #[error("SGP4 propagation failed: {0}")]
+    /// SGP4 could not propagate the requested epoch; arc operations stop at
+    /// the first propagation failure.
     Propagate(crate::astro::sgp4::Error),
     #[error("look-angle frame transform failed: {0}")]
+    /// A frame conversion failed while deriving a look angle or ground-track
+    /// point from the propagated state.
     FrameTransform(#[from] FrameTransformError),
 }
 

--- a/crates/sidereon-core/src/astro/propagator/api.rs
+++ b/crates/sidereon-core/src/astro/propagator/api.rs
@@ -48,14 +48,42 @@ impl PropagationContext {
     }
 }
 
+/// Options forwarded to the selected [`crate::astro::integrators::Integrator`]
+/// by [`crate::astro::propagator::StatePropagator`].
+///
+/// [`crate::astro::integrators::RK4`] uses the initial step, step limit, and
+/// point-output flag; [`crate::astro::integrators::DP54`] also uses the
+/// tolerance and adaptive step fields.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IntegratorOptions {
+    /// Additive error scale used by DP54 for the position and velocity error
+    /// estimates. The adaptive validator requires a finite positive value;
+    /// RK4 does not read this field.
     pub abs_tol: f64,
+    /// Relative error factor used by DP54 with the larger current/proposed
+    /// position and velocity norms. The adaptive validator requires a finite
+    /// positive value; RK4 does not read this field.
     pub rel_tol: f64,
+    /// Minimum step magnitude in seconds accepted after a rejected DP54 step.
+    /// If the controller proposes a smaller magnitude, DP54 returns a
+    /// [`PropagationError::NumericalFailure`].
     pub min_step: f64,
+    /// Maximum step magnitude in seconds used by DP54 when clamping its
+    /// initial and controller-selected steps. RK4 validates this field but
+    /// does not use it to select steps.
     pub max_step: f64,
+    /// Initial step magnitude in seconds. Both integrators limit it to the
+    /// absolute target span and apply the direction toward the target; DP54
+    /// also clamps it to `max_step`.
     pub initial_step: f64,
+    /// Maximum number of step outcomes allowed for one propagation. RK4 counts
+    /// completed steps, while DP54 counts accepted and rejected steps; either
+    /// integrator returns [`PropagationError::MaxStepsExceeded`] at the limit.
     pub max_steps: u32,
+    /// Whether to retain every completed step in the `points` field of
+    /// [`crate::astro::propagator::PropagationResult`].
+    /// DP54 additionally captures its stages and returns dense output when this
+    /// is enabled; with it disabled, DP54 returns no dense output.
     pub dense_output: bool,
 }
 

--- a/crates/sidereon-core/src/astro/propagator/controller.rs
+++ b/crates/sidereon-core/src/astro/propagator/controller.rs
@@ -1,7 +1,22 @@
+/// Adaptive step-size controller used by [`crate::astro::integrators::DP54`]
+/// after each trial step. DP54 initializes it from its defaults, overrides
+/// [`PIController::order`] to `5.0`, and separately bounds the returned step by
+/// [`crate::astro::propagator::api::IntegratorOptions::max_step`].
 pub struct PIController {
+    /// Multiplier applied to the power-law factor before the scale bounds are
+    /// applied in [`PIController::next_step`]. The default is `0.9`.
     pub safety_factor: f64,
+    /// Lower bound for the scale factor in the ordinary error branch of
+    /// [`PIController::next_step`]. The default is `0.33`; very small errors
+    /// use [`PIController::max_scale`] directly instead.
     pub min_scale: f64,
+    /// Upper bound for the scale factor in the ordinary error branch of
+    /// [`PIController::next_step`], and the direct multiplier for errors at or
+    /// below `1e-15`. The default is `6.0`.
     pub max_scale: f64,
+    /// Value used in the denominator of the power exponent as `order + 1.0`.
+    /// [`crate::astro::integrators::DP54`] overrides the default `8.0` with
+    /// `5.0` for its fifth-order error estimate.
     pub order: f64,
 }
 
@@ -17,6 +32,13 @@ impl Default for PIController {
 }
 
 impl PIController {
+    /// Compute the next signed integration step from a normalized error.
+    /// `current_h` is the trial step in seconds, while DP54 supplies `error` as
+    /// the larger of its normalized position and velocity error ratios. For
+    /// `error <= 1e-15`, this returns `current_h * max_scale`; otherwise it
+    /// applies the classic Hairer/Wanner factor
+    /// `safety_factor * pow(1.0 / error, 1.0 / (order + 1.0))`, clamps that
+    /// factor to `[min_scale, max_scale]`, and multiplies by `current_h`.
     pub fn next_step(&self, current_h: f64, error: f64) -> f64 {
         if error <= 1e-15 {
             return current_h * self.max_scale;

--- a/crates/sidereon-core/src/astro/propagator/covariance.rs
+++ b/crates/sidereon-core/src/astro/propagator/covariance.rs
@@ -24,7 +24,14 @@ pub enum CovarianceFrame {
 /// A covariance plus the frame label it is expressed in.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LabeledCovariance6 {
+    /// Initial 6x6 state covariance passed to
+    /// [`StatePropagator::propagate_covariance`]. If `frame` is
+    /// [`CovarianceFrame::Rtn`], the propagator rotates it to inertial axes at
+    /// the initial state before transport.
     pub covariance: Covariance6,
+    /// Frame in which `covariance` is supplied. [`CovarianceFrame::Inertial`]
+    /// selects direct transport, while [`CovarianceFrame::Rtn`] selects the
+    /// initial RTN-to-ECI covariance transform.
     pub frame: CovarianceFrame,
 }
 
@@ -36,8 +43,20 @@ pub enum ProcessNoise {
     None,
     /// Per-axis white acceleration PSD in RTN, km^2/s^3.
     RtnAccelerationPsd {
+        /// Radial component of the RTN white-acceleration PSD, in km^2/s^3.
+        /// Validation rejects non-finite or negative values; transport uses
+        /// this component in the radial position/velocity covariance terms
+        /// with `|dt|^3 / 3`, `|dt|^2 / 2`, and `|dt|` factors.
         q_radial_km2_s3: f64,
+        /// Transverse component of the RTN white-acceleration PSD, in
+        /// km^2/s^3. Validation rejects non-finite or negative values;
+        /// transport uses this component in the transverse position/velocity
+        /// covariance terms with `|dt|^3 / 3`, `|dt|^2 / 2`, and `|dt|` factors.
         q_transverse_km2_s3: f64,
+        /// Normal component of the RTN white-acceleration PSD, in km^2/s^3.
+        /// Validation rejects non-finite or negative values; transport uses
+        /// this component in the normal position/velocity covariance terms
+        /// with `|dt|^3 / 3`, `|dt|^2 / 2`, and `|dt|` factors.
         q_normal_km2_s3: f64,
     },
 }
@@ -45,7 +64,16 @@ pub enum ProcessNoise {
 /// Options for a covariance propagation run.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CovariancePropagationOptions {
+    /// Process-noise model validated and applied by
+    /// [`StatePropagator::propagate_covariance`] and
+    /// [`transport_covariance`]. The default is [`ProcessNoise::None`]; RTN
+    /// PSD noise is evaluated using each segment's midpoint state, rotated
+    /// into inertial axes, and added after `Phi * P * Phi^T` transport.
     pub process_noise: ProcessNoise,
+    /// Frame used for each returned [`CovarianceNode`] covariance. The default
+    /// is [`CovarianceFrame::Inertial`]; [`CovarianceFrame::Rtn`] applies the
+    /// ECI-to-RTN transform at each node, so
+    /// [`CovarianceEphemeris::covariance_at`] rejects that ephemeris.
     pub output_frame: CovarianceFrame,
 }
 

--- a/crates/sidereon-core/src/astro/propagator/decay.rs
+++ b/crates/sidereon-core/src/astro/propagator/decay.rs
@@ -149,10 +149,18 @@ pub enum DecayError {
     InvalidConfig(&'static str),
     /// The orbit did not decay within the requested horizon.
     #[error("no decay within horizon {horizon_s} s")]
-    NoDecayWithinHorizon { horizon_s: f64 },
+    NoDecayWithinHorizon {
+        /// Configured maximum elapsed scan time, in seconds, reached before a crossing was found.
+        horizon_s: f64,
+    },
     /// The coarse scan hit its sample budget before the horizon.
     #[error("scan budget exhausted after {samples} samples and {scanned_s} s")]
-    ScanBudgetExhausted { scanned_s: f64, samples: u32 },
+    ScanBudgetExhausted {
+        /// Elapsed time covered by completed coarse samples, in seconds, when the budget check failed.
+        scanned_s: f64,
+        /// Number of completed coarse propagation samples reported at the budget check.
+        samples: u32,
+    },
 }
 
 /// Estimate time to reentry using drag-perturbed numerical propagation.

--- a/crates/sidereon-core/src/astro/propagator/dense_output.rs
+++ b/crates/sidereon-core/src/astro/propagator/dense_output.rs
@@ -59,10 +59,15 @@ mod error_display_tests {
 /// Currently implements Shampine's 4th-order continuous extension for DP5(4).
 #[derive(Debug, Clone)]
 pub struct DenseSegment {
+    /// Absolute TDB epoch in seconds at the beginning of the accepted DP54 step.
     pub t_start: f64,
+    /// Signed duration in seconds of the accepted step, following the requested propagation direction.
     pub h: f64,
+    /// [`CartesianState`] at the beginning of the accepted step, used as the interpolation base.
     pub y_start: CartesianState,
+    /// [`CartesianState`] produced at the accepted step endpoint and returned for exact endpoint evaluation.
     pub y_end: CartesianState,
+    /// Seven Dormand-Prince derivative stages captured for the accepted step; position derivatives are in kilometers per second and velocity derivatives in kilometers per second squared.
     pub ks: [StateDerivative; 7],
 }
 
@@ -154,6 +159,8 @@ impl DenseSegment {
         })
     }
 
+    /// Builds a segment from the seven stages captured for one accepted DP54 step.
+    /// The stage array and the supplied start/end states are copied into the segment for interpolation and endpoint evaluation.
     pub fn from_dp54_stages(
         t_start: f64,
         h: f64,
@@ -170,6 +177,8 @@ impl DenseSegment {
         }
     }
 
+    /// Returns the segment endpoint epoch as `t_start + h`.
+    /// For reverse-time propagation, this endpoint is earlier than `t_start`.
     pub fn t_end(&self) -> f64 {
         self.t_start + self.h
     }
@@ -178,6 +187,8 @@ impl DenseSegment {
 /// Collection of dense segments covering a full propagation range.
 #[derive(Debug, Clone, Default)]
 pub struct DenseOutput {
+    /// Accepted-step interpolants in propagation order.
+    /// DP54 appends one [`DenseSegment`] for each accepted step when dense output is enabled; a zero-duration request leaves this vector empty, and [`DenseOutput::eval`] relies on the ordering when locating a segment.
     pub segments: Vec<DenseSegment>,
 }
 

--- a/crates/sidereon-core/src/astro/propagator/result.rs
+++ b/crates/sidereon-core/src/astro/propagator/result.rs
@@ -4,25 +4,67 @@ use crate::astro::propagator::dense_output::DenseOutput;
 use crate::astro::state::CartesianState;
 
 #[derive(Debug, Clone)]
+/// A Cartesian state sample emitted by a numerical integrator.
+///
+/// The built-in integrators emit the initial sample and, when dense output is
+/// enabled, a sample at every accepted step endpoint. Without dense output,
+/// they emit the initial and final states.
 pub struct PropagationPoint {
+    /// Absolute TDB epoch in seconds copied from the integrator's current time.
+    /// The first sample uses the initial epoch, and later samples use accepted
+    /// step endpoints.
     pub epoch_tdb_seconds: f64,
+    /// Cartesian x, y, and z position components in kilometers, copied by
+    /// [`CartesianState::position_array`]. A non-finite component is rejected
+    /// before the propagation result is returned.
     pub position_km: [f64; 3],
+    /// Cartesian x, y, and z velocity components in kilometers per second,
+    /// copied by [`CartesianState::velocity_array`]. A non-finite component is
+    /// rejected before the propagation result is returned.
     pub velocity_km_s: [f64; 3],
 }
 
 #[derive(Debug, Clone, Default)]
+/// Work counters collected while building a [`PropagationResult`].
+///
+/// RK4 reports no rejected attempts, while DP54 records adaptive error-control
+/// rejections; both integrators count derivative evaluations.
 pub struct PropagationStats {
+    /// Number of integration steps accepted and applied to advance the state.
     pub accepted_steps: u32,
+    /// Number of DP54 attempts whose estimated error exceeded 1 and were
+    /// retried with a smaller step; RK4 always reports zero.
     pub rejected_steps: u32,
+    /// Number of right-hand-side derivative evaluations used by the integrator.
+    /// RK4 uses four per step, while DP54 includes its initial FSAL evaluation
+    /// and evaluations from accepted and rejected attempts.
     pub evaluations: u32,
 }
 
 #[derive(Debug, Clone)]
+/// Aggregate returned by a numerical integrator after propagation.
+///
+/// The built-in RK4 and DP54 paths validate the final state and every emitted
+/// [`PropagationPoint`] before returning this aggregate.
 pub struct PropagationResult {
+    /// Cartesian state held when the integrator reaches the requested end
+    /// epoch. A zero-duration DP54 request returns the unchanged initial state.
     pub final_state: CartesianState,
+    /// Emitted samples in integration order. With dense output enabled, entries
+    /// after the first correspond to accepted step endpoints; otherwise only
+    /// the initial and final states are emitted.
     pub points: Vec<PropagationPoint>,
+    /// Event records returned by the propagation path. The built-in RK4 and
+    /// DP54 paths set this to an empty vector because they do not invoke an
+    /// event finder.
     pub events: Vec<DetectedEvent>,
+    /// Step and derivative-evaluation counters from the selected integrator.
+    /// A zero-duration DP54 request reports zero for every counter.
     pub stats: PropagationStats,
+    /// DP54's optional continuous interpolant. It is `Some` only when dense
+    /// output is enabled, with one segment per accepted step; RK4 always leaves
+    /// it `None`. A zero-duration DP54 request has an empty interpolant when
+    /// dense output is enabled.
     pub dense: Option<DenseOutput>,
 }
 

--- a/crates/sidereon-core/src/astro/space_weather.rs
+++ b/crates/sidereon-core/src/astro/space_weather.rs
@@ -147,7 +147,12 @@ pub enum SpaceWeatherError {
     UnrecognizedFormat,
     /// Structural failure that prevents a table from being built.
     #[error("malformed space-weather input at line {line}: {reason}")]
-    Malformed { line: usize, reason: String },
+    Malformed {
+        /// Source line associated with the structural failure. CSV header failures and an empty table use `1`; fixed-width section errors use the current one-based line, while an unterminated section uses `text.lines().count()`.
+        line: usize,
+        /// Owned description of the structural cause, including missing or unexpected CSV headers, nested or mismatched fixed-width sections, an unterminated section, or no parseable rows. The error message places it after the line number and a colon.
+        reason: String,
+    },
     /// Input bytes are not UTF-8 text.
     #[error("space-weather input is not valid UTF-8")]
     NotText,

--- a/crates/sidereon-core/src/astro/state.rs
+++ b/crates/sidereon-core/src/astro/state.rs
@@ -1,13 +1,40 @@
 use nalgebra::Vector3;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Epoch-tagged position and velocity vectors exchanged by the astrodynamics
+/// APIs.
+///
+/// Numerical propagation uses ECI/GCRF vectors in kilometers and kilometers
+/// per second and advances the epoch along the TDB seconds-from-J2000 axis.
+/// The [`crate::astro::relative`] APIs reuse this container for chief-frame
+/// relative vectors.
 pub struct CartesianState {
+    /// Propagation epoch in TDB seconds from J2000.
+    ///
+    /// Integrators validate this value as finite and advance it by each step.
+    /// Relative transforms copy an input epoch, while
+    /// [`crate::astro::relative::cw_propagate`] adds its `dt`.
     pub epoch_tdb_seconds: f64,
+    /// Position components in kilometers, stored in x/y/z order.
+    ///
+    /// Numerical propagation and force/frame transforms use ECI/GCRF
+    /// coordinates; [`crate::astro::relative`] uses this field for
+    /// deputy-minus-chief components in the chief's rotating frame.
     pub position_km: Vector3<f64>,
+    /// Velocity components in kilometers per second, stored in x/y/z order.
+    ///
+    /// Numerical propagation and force/frame transforms use ECI/GCRF
+    /// coordinates; [`crate::astro::relative`] uses this field for relative
+    /// velocity components in the chief's rotating frame.
     pub velocity_km_s: Vector3<f64>,
 }
 
 impl CartesianState {
+    /// Construct a state from an epoch and position and velocity arrays.
+    ///
+    /// The arrays are copied into nalgebra vectors in x/y/z order and the
+    /// epoch is copied unchanged. This constructor performs no finiteness or
+    /// frame validation.
     pub fn new(epoch_tdb_seconds: f64, position: [f64; 3], velocity: [f64; 3]) -> Self {
         Self {
             epoch_tdb_seconds,
@@ -16,10 +43,18 @@ impl CartesianState {
         }
     }
 
+    /// Copy position components into an `[x, y, z]` array.
+    ///
+    /// Values are returned in the order accepted by [`Self::new`], without
+    /// unit conversion or validation.
     pub fn position_array(&self) -> [f64; 3] {
         [self.position_km.x, self.position_km.y, self.position_km.z]
     }
 
+    /// Copy velocity components into an `[x, y, z]` array.
+    ///
+    /// Values are returned in the order accepted by [`Self::new`], without
+    /// unit conversion or validation.
     pub fn velocity_array(&self) -> [f64; 3] {
         [
             self.velocity_km_s.x,
@@ -30,12 +65,30 @@ impl CartesianState {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Cartesian position and velocity rates supplied to a numerical integrator.
+///
+/// Dynamics models provide the two rates, RK4 and DP54 integrate both into a
+/// [`CartesianState`], and DP54 retains seven derivatives for dense output.
 pub struct StateDerivative {
+    /// Position rate in kilometers per second.
+    ///
+    /// [`crate::astro::propagator::dynamics::OrbitalDynamics`] sets this to
+    /// the state's velocity; integrators multiply it by elapsed seconds before
+    /// adding it to position.
     pub dpos_km_s: Vector3<f64>,
+    /// Velocity rate (acceleration) in kilometers per second squared.
+    ///
+    /// [`crate::astro::propagator::dynamics::OrbitalDynamics`] obtains this
+    /// from the force model; integrators multiply it by elapsed seconds before
+    /// adding it to velocity.
     pub dvel_km_s2: Vector3<f64>,
 }
 
 impl StateDerivative {
+    /// Construct a derivative from position and velocity rates.
+    ///
+    /// The supplied vectors are stored unchanged as the two ODE components;
+    /// this constructor performs no validation.
     pub fn new(dpos: Vector3<f64>, dvel: Vector3<f64>) -> Self {
         Self {
             dpos_km_s: dpos,

--- a/crates/sidereon-core/src/astro/tca.rs
+++ b/crates/sidereon-core/src/astro/tca.rs
@@ -405,25 +405,35 @@ impl Default for CatalogScreeningOptions {
 /// A prefiltered catalog pair.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CatalogScreeningCandidate {
+    /// Lower catalog index emitted by [`screen_catalog_pairs`].
     pub i: usize,
+    /// Higher catalog index emitted by [`screen_catalog_pairs`].
     pub j: usize,
+    /// Optional identifier cloned from [`CatalogStateVector::id`] for the object at index `i`.
     pub id1: Option<String>,
+    /// Optional identifier cloned from [`CatalogStateVector::id`] for the object at index `j`.
     pub id2: Option<String>,
+    /// Euclidean separation of the paired catalog positions, in kilometers, computed by [`screen_catalog_pairs`].
     pub miss_km: f64,
 }
 
 /// Successful collision-probability evaluation for a catalog candidate.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CatalogCollision {
+    /// [`CollisionPc`] returned by [`crate::astro::conjunction::collision_probability`] for the pair using its combined hard-body radius.
     pub probability: CollisionPc,
+    /// [`PcMethod`] passed through [`CatalogScreeningOptions::method`] to the conjunction solver.
     pub method: PcMethod,
 }
 
 /// One catalog screening result row.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CatalogScreeningResult {
+    /// [`CatalogScreeningCandidate`] produced by the position prefilter; it remains present when Pc evaluation fails.
     pub candidate: CatalogScreeningCandidate,
+    /// `Some` for a successful [`CatalogCollision`] evaluation, or `None` when the conjunction solver returns an error.
     pub collision: Option<CatalogCollision>,
+    /// [`ConjunctionError`] returned by the solver; `None` for a successful collision-probability evaluation.
     pub error: Option<ConjunctionError>,
 }
 

--- a/crates/sidereon-core/src/astro/time/eop.rs
+++ b/crates/sidereon-core/src/astro/time/eop.rs
@@ -82,14 +82,33 @@ pub enum DegradeReason {
 /// Invalid civil-time input kind for time-scale conversion boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimeScaleInputErrorKind {
+    /// A required input was absent; table validation uses this for empty leap-second tables,
+    /// UT1 tables with fewer than two rows, or too few effective UT1 rows.
     Missing,
+    /// A numeric input was NaN or infinite; time-scale validation uses this for date seconds,
+    /// table offsets, checked UTC lookups, and coverage queries.
     NonFinite,
+    /// A mapped validation failure required the value to be strictly greater than zero; the
+    /// generic field-error mapper preserves this classification for downstream tide errors.
     NotPositive,
+    /// A mapped validation failure rejected a negative value where a non-negative value was
+    /// required; the generic field-error mapper preserves this classification for downstream
+    /// tide errors.
     Negative,
+    /// An input fell outside an accepted range or table ordering; table validation uses this for
+    /// non-increasing MJD entries, and checked leap lookup uses it before the first table entry.
     OutOfRange,
+    /// A textual floating-point field could not be parsed; the generic field-error mapper
+    /// preserves this classification for downstream tide errors.
     FloatParse,
+    /// A textual integer field could not be parsed; the generic field-error mapper preserves
+    /// this classification for downstream tide errors.
     IntParse,
+    /// Calendar fields did not form a valid civil date; UTC conversion reports this before
+    /// time-scale arithmetic, including for an invalid date such as 2001-02-29.
     InvalidCivilDate,
+    /// Clock fields did not form a valid civil time; UTC validation reports this for an
+    /// out-of-range clock or a second value that is not an allowed leap-second label.
     InvalidCivilTime,
 }
 
@@ -130,7 +149,12 @@ impl<T> Validated<T> {
 pub enum CoverageError {
     /// Time-scale conversion input is malformed or outside its accepted domain.
     InvalidInput {
+        /// Stable label for the rejected input. Civil validation copies it from the field
+        /// validator, while table and coverage checks use labels such as `leap_seconds`,
+        /// `ut1_utc`, and `jd_tt`; formatting this error includes the label.
         field: &'static str,
+        /// Classification selected by civil or table validation, or by a non-finite coverage
+        /// query; downstream tide errors translate this classification one-for-one.
         kind: TimeScaleInputErrorKind,
     },
     /// Instant is outside the table's covered interval.

--- a/crates/sidereon-core/src/astro/tle.rs
+++ b/crates/sidereon-core/src/astro/tle.rs
@@ -95,21 +95,76 @@ pub struct TleElements {
     /// representation (for example, `"A0000"`). Use
     /// [`decode_catalog_number`] to obtain the numeric catalog id.
     pub catalog_number: String,
+    /// Classification character from line 1 byte index 7 (column 8).
+    /// [`parse`] defaults a missing position to `"U"`, while [`encode`] emits it
+    /// immediately after the catalog field.
     pub classification: String,
+    /// Launch international designator from line 1 byte indices 9..=16
+    /// (columns 10-17). [`parse`] removes right padding, and [`encode`] restores
+    /// the eight-character field width.
     pub international_designator: String,
+    /// Full calendar year after applying the TLE two-digit pivot: parsed values
+    /// below 57 become 2000+, and all others become 1900+. [`encode`] emits the
+    /// year modulo 100, while [`TleElements::to_element_set`] uses the full year.
     pub epoch_year: i32,
+    /// One-based fractional day of year from line 1 byte indices 20..=31.
+    /// [`TleElements::to_element_set`] converts it through Vallado `days2mdhms`
+    /// and split-Julian-date math; [`encode`] emits eight decimal places.
     pub epoch_day_of_year: f64,
+    /// First mean-motion derivative (`ndot`) in rev/day², read from line 1 byte
+    /// indices 33..=42. [`encode`] removes its leading zero, and
+    /// [`TleElements::to_element_set`] passes it to SGP4 for conversion to
+    /// radians per minute squared.
     pub mean_motion_dot: f64,
+    /// Second mean-motion derivative (`nddot`) in rev/day³, read from line 1
+    /// byte indices 44..=51 as a signed assumed-decimal value. The parser and
+    /// encoder use the five-digit mantissa codec, and the element bridge passes
+    /// it to SGP4 for conversion to radians per minute cubed.
     pub mean_motion_double_dot: f64,
+    /// Vallado B* drag term in the dimensionless 1/earth-radii TLE convention,
+    /// decoded from line 1 byte indices 53..=60 with the assumed-decimal codec.
+    /// [`TleElements::to_element_set`] passes it unchanged to SGP4.
     pub bstar: f64,
+    /// Integer ephemeris-type field at line 1 byte index 62 (column 63).
+    /// [`parse`] maps a blank field to zero, fitted TLE records emit zero, and
+    /// [`TleElements::to_element_set`] omits this bookkeeping value from
+    /// [`ElementSet`].
     pub ephemeris_type: i32,
+    /// Element-set number from line 1 byte indices 64..=67 (columns 65-68).
+    /// A blank field parses as zero, and [`encode`] writes the value in a
+    /// four-character field.
     pub elset_number: i32,
+    /// Inclination in degrees from line 2 byte indices 8..=15, formatted with
+    /// four decimal places. [`TleElements::to_element_set`] preserves the degree
+    /// value in [`ElementSet`], whose SGP4 initializer converts it to radians.
     pub inclination_deg: f64,
+    /// Right ascension of the ascending node in degrees from line 2 byte
+    /// indices 17..=24, formatted with four decimal places. The element bridge
+    /// maps it to [`ElementSet::right_ascension_deg`] before SGP4 converts it to
+    /// radians.
     pub raan_deg: f64,
+    /// Dimensionless eccentricity from line 2 byte indices 26..=32, interpreted
+    /// as an implicit-leading-decimal fraction with spaces replaced by zeroes.
+    /// The element bridge requires a finite value in `[0, 1)`, while [`encode`]
+    /// emits seven fractional digits without the leading `0.`.
     pub eccentricity: f64,
+    /// Argument of perigee in degrees from line 2 byte indices 34..=41,
+    /// formatted with four decimal places. The element bridge maps it to
+    /// [`ElementSet::argument_of_perigee_deg`] before SGP4 converts it to
+    /// radians.
     pub arg_perigee_deg: f64,
+    /// Mean anomaly in degrees from line 2 byte indices 43..=50, formatted with
+    /// four decimal places. The element bridge maps it to
+    /// [`ElementSet::mean_anomaly_deg`] before SGP4 converts it to radians.
     pub mean_anomaly_deg: f64,
+    /// Mean motion in revolutions per day from line 2 byte indices 52..=62,
+    /// formatted with eight decimal places. The element bridge requires a
+    /// finite positive value, copies it to [`ElementSet::mean_motion_rev_per_day`],
+    /// and SGP4 converts it to radians per minute.
     pub mean_motion: f64,
+    /// Revolution number at the TLE epoch from line 2 byte indices 63..=67.
+    /// A blank field parses as zero, and [`encode`] writes the value in a
+    /// five-character field for the fit metadata's `rev_at_epoch` value.
     pub rev_number: i32,
 }
 
@@ -166,7 +221,13 @@ pub struct ChecksumWarning {
 /// The result of [`parse`]: the elements plus any advisory checksum warnings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParsedTle {
+    /// Orbital and bookkeeping fields extracted from the validated line pair.
+    /// This is the value passed to [`encode`] for round trips or to
+    /// [`TleElements::to_element_set`] for SGP4 initialization.
     pub elements: TleElements,
+    /// Advisory checksum discrepancies, ordered by line 1 then line 2. A
+    /// warning is added only when a full-width line has a numeric column-69
+    /// digit that differs from the modulo-10 checksum of columns 1-68.
     pub checksum_warnings: Vec<ChecksumWarning>,
 }
 

--- a/crates/sidereon-core/src/bias/mod.rs
+++ b/crates/sidereon-core/src/bias/mod.rs
@@ -23,14 +23,27 @@ use crate::validate::{self, CivilSecondPolicy};
 use crate::{frequencies, GnssSatelliteId, GnssSystem};
 
 const BIAS_SINEX_MAJOR_VERSION: &str = "1";
+/// Denominator used when converting Bias-SINEX slope values and slope
+/// uncertainties to the internal per-second representation and back.
 pub const SINEX_BIAS_SLOPE_DENOMINATOR_S: f64 = 1.0;
 const DSB_INCONSISTENCY_TOL_S: f64 = 1.0e-15;
 const RINEX_VERSION_FOR_BIAS_CODES: f64 = 3.04;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Bias-SINEX solution records are classified by the token parsed into this
+/// enum and by whether the record carries one observable or a pair.
+///
+/// The parser accepts the `OSB`, `DSB`, and `ISB` labels. OSB records address
+/// one observable; DSB and ISB records carry a pair.
 pub enum BiasKind {
+    /// The `OSB` token, which is indexed by one observable and has no second
+    /// observable in a solution record.
     Osb,
+    /// The `DSB` token, which is resolved as a signed difference between two
+    /// observables.
     Dsb,
+    /// The `ISB` token, which requires two observables when a solution line is
+    /// parsed.
     Isb,
 }
 
@@ -58,27 +71,53 @@ impl FromStr for BiasKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// PRN and station columns are decoded into one of four target forms in this
+/// enum, which controls the lookup key used for a bias record.
+///
+/// [`BiasSet::parse_bias_sinex`] selects a variant from the PRN and station columns;
+/// station values are normalized before they are stored.
 pub enum BiasTarget {
+    /// A one-character PRN with no station, written back as the system letter.
     System(GnssSystem),
+    /// A multi-character PRN parsed as [`GnssSatelliteId`] with no station.
     Satellite(GnssSatelliteId),
+    /// A one-character PRN paired with a station, with the station normalized
+    /// before storage.
     Receiver {
+        /// GNSS system identified by the one-character PRN column.
         system: GnssSystem,
+        /// Receiver station identifier after station normalization.
         station: String,
     },
+    /// A multi-character PRN paired with a station, with the station
+    /// normalized before storage.
     SatelliteReceiver {
+        /// Satellite identified by the PRN column.
         sat: GnssSatelliteId,
+        /// Receiver station identifier after station normalization.
         station: String,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// Canonical index key corresponding to a [`BiasTarget`].
+///
+/// Receiver station strings are normalized by the constructors so that
+/// lookups and parsed receiver records use the same key.
 pub struct BiasTargetKey {
+    /// System component copied from a target or from its satellite identifier.
     pub system: GnssSystem,
+    /// Satellite component used to distinguish satellite-specific lookup from
+    /// the system fallback, when present.
     pub sat: Option<GnssSatelliteId>,
+    /// Normalized station component used to distinguish receiver lookup, when
+    /// present.
     pub station: Option<String>,
 }
 
 impl BiasTargetKey {
+    /// Creates the key used for a system-wide target, with no satellite or
+    /// station component.
     pub fn system(system: GnssSystem) -> Self {
         Self {
             system,
@@ -87,6 +126,8 @@ impl BiasTargetKey {
         }
     }
 
+    /// Creates a key for one satellite by copying its system and identifier;
+    /// the station component is absent.
     pub fn satellite(sat: GnssSatelliteId) -> Self {
         Self {
             system: sat.system,
@@ -95,6 +136,10 @@ impl BiasTargetKey {
         }
     }
 
+    /// Creates a key for one receiver in `system` and stores no satellite
+    /// component.
+    ///
+    /// The station is trimmed, uppercased, and normalized before it is stored.
     pub fn receiver(system: GnssSystem, station: &str) -> Self {
         Self {
             system,
@@ -103,6 +148,10 @@ impl BiasTargetKey {
         }
     }
 
+    /// Creates a key containing the satellite's system and identifier plus a
+    /// normalized receiver station.
+    ///
+    /// The station is trimmed, uppercased, and normalized before it is stored.
     pub fn satellite_receiver(sat: GnssSatelliteId, station: &str) -> Self {
         Self {
             system: sat.system,
@@ -126,13 +175,29 @@ impl From<&BiasTarget> for BiasTargetKey {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Bias-SINEX validity fields store this calendar epoch as year, day of year,
+/// and second of day before lookup converts it to a split Julian date.
+///
+/// The three components are converted to a split Julian date by
+/// [`bias_epoch_instant`].
 pub struct BiasEpoch {
+    /// Calendar year used by [`BiasEpoch::new`] to determine the leap-year day
+    /// bound and by [`BiasEpoch::format_sinex`] as the four-digit prefix.
     pub year: i32,
+    /// One-based day checked against the length of `year` and formatted as a
+    /// three-digit SINEX component.
     pub day_of_year: u16,
+    /// Second checked against `SECONDS_PER_DAY_I64` and formatted as a
+    /// five-digit SINEX component.
     pub second_of_day: u32,
 }
 
 impl BiasEpoch {
+    /// Constructs an epoch after validating its calendar day and second.
+    ///
+    /// `day_of_year` must be within the number of days in `year`, and
+    /// `second_of_day` must not exceed `SECONDS_PER_DAY_I64`; violations return
+    /// [`BiasError::InvalidEpoch`].
     pub fn new(year: i32, day_of_year: u16, second_of_day: u32) -> Result<Self, BiasError> {
         if !(1..=days_in_year(year)).contains(&i32::from(day_of_year)) {
             return Err(BiasError::InvalidEpoch);
@@ -147,6 +212,11 @@ impl BiasEpoch {
         })
     }
 
+    /// Parses a Bias-SINEX epoch token.
+    ///
+    /// An empty token and `0000:000:00000` represent an absent epoch. Every
+    /// other token must contain exactly three colon-separated integer fields
+    /// accepted by [`BiasEpoch::new`].
     pub fn parse_sinex(token: &str) -> Result<Option<Self>, BiasError> {
         let token = token.trim();
         if token.is_empty() || token == "0000:000:00000" {
@@ -162,6 +232,8 @@ impl BiasEpoch {
         Self::new(year, doy, sod).map(Some)
     }
 
+    /// Formats the epoch as the fixed-width `YYYY:DDD:SSSSS` form used by
+    /// Bias-SINEX solution records.
     pub fn format_sinex(self) -> String {
         format!(
             "{:04}:{:03}:{:05}",
@@ -202,94 +274,208 @@ impl BiasEpoch {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A parsed solution line stores code values in seconds or phase values in
+/// cycles, with validity and optional slope data carried alongside the
+/// target and observables.
+///
+/// Code values and uncertainties are stored in seconds, phase values and
+/// uncertainties in cycles, and optional slopes are evaluated against the
+/// record's validity start by [`BiasSet::code_osb_seconds`] or the related
+/// query methods.
 pub struct BiasRecord {
+    /// Parsed classification that selects one-observable OSB or two-observable
+    /// DSB/ISB indexing and query behavior.
     pub kind: BiasKind,
+    /// Parsed PRN/station target used to build the set's [`BiasTargetKey`].
     pub target: BiasTarget,
+    /// Optional SVN text copied from the solution line.
     pub svn: Option<String>,
+    /// First observable code used alone for OSB indexing or with `obs2` for
+    /// DSB/ISB indexing.
     pub obs1: String,
+    /// Second observable for DSB and ISB records; absent for OSB records.
     pub obs2: Option<String>,
+    /// Inclusive validity start, when the solution line supplies one.
     pub valid_from: Option<BiasEpoch>,
+    /// Exclusive validity end, when the solution line supplies one.
     pub valid_until: Option<BiasEpoch>,
+    /// Trimmed source start and end tokens retained for serialization.
     pub raw_epochs: (String, String),
+    /// Bias value in seconds for code records or cycles for phase records.
     pub value: f64,
+    /// Optional uncertainty in the same units as [`BiasRecord::value`].
     pub sigma: Option<f64>,
+    /// Optional slope converted from the SINEX slope columns and applied over
+    /// elapsed seconds from `valid_from`.
     pub slope: Option<f64>,
+    /// Optional uncertainty converted with the same unit rule as `slope`.
     pub slope_sigma: Option<f64>,
+    /// Records parsed from `cyc` set this true; `ns` records set it false and
+    /// are eligible for code queries.
     pub is_phase: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// Interpretation declared by the Bias-SINEX `BIAS_MODE` description.
 pub enum BiasMode {
+    /// Selected by `BIAS_MODE ABSOLUTE`; non-OSB solution records then produce
+    /// mismatch warnings.
     Absolute,
+    /// Selected by `BIAS_MODE RELATIVE` and assigned to every parsed DCB set;
+    /// OSB solution records then produce mismatch warnings.
     Relative,
+    /// Default and fallback for an unrecognized `BIAS_MODE`; the SINEX writer
+    /// rejects it as missing mode metadata.
     #[default]
     Unspecified,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
+/// Bias-SINEX clock-reference description lines populate this per-system map,
+/// which PPP code-bias correction later uses to select a reference pair.
 pub struct ClockReferenceObservables {
+    /// Map populated by `SATELLITE_CLOCK_REFERENCE_OBSERVABLES` lines and read
+    /// by PPP code-bias correction as the pair for each satellite system.
     pub per_system: BTreeMap<GnssSystem, (String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
+/// Bias-SINEX header blocks and legacy DCB metadata are retained in these
+/// fields for diagnostics, inspection, and serialization.
 pub struct BiasSetHeader {
+    /// Third whitespace token from the `%=BIA` header, required by the SINEX
+    /// writer when present as the agency value.
     pub agency: Option<String>,
+    /// Ordered key/value pairs accumulated from nonempty `FILE/REFERENCE`
+    /// lines.
     pub file_reference: Vec<(String, String)>,
+    /// Description map accumulated from `BIAS/DESCRIPTION` lines, including
+    /// system-suffixed clock-reference keys.
     pub description: BTreeMap<String, String>,
+    /// Parsed integer following `+BIAS/SOLUTION`, used for the record-count
+    /// mismatch warning.
     pub declared_bias_count: Option<usize>,
+    /// DCB options retained by `parse_code_dcb` for `write_code_dcb`, when
+    /// available.
     pub dcb_meta: Option<CodeDcbOptions>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A parsed product retains its records, lookup metadata, and diagnostics so
+/// code and phase bias queries can apply the product's validity rules.
+///
+/// The parsers build an index by target and observable, retain typed
+/// diagnostics for skipped input, and expose the source metadata for writing.
 pub struct BiasSet {
     records: Vec<BiasRecord>,
     index: BTreeMap<(BiasTargetKey, String), Vec<usize>>,
+    /// Mode parsed from `BIAS_MODE`, or `Relative` for a DCB-created set.
     pub mode: BiasMode,
+    /// Scale parsed from `TIME_SYSTEM` or DCB metadata; query epochs on another
+    /// scale are rejected by coverage checks.
     pub time_scale: TimeScale,
+    /// Pairs parsed from `SATELLITE_CLOCK_REFERENCE_OBSERVABLES` and consumed by
+    /// `code_bias_model_m`.
     pub clock_reference: ClockReferenceObservables,
+    /// Source file/description metadata and optional DCB options retained for
+    /// serialization.
     pub header: BiasSetHeader,
     diagnostics: Diagnostics,
     skipped_records: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Legacy DCB parsing and writing use these fields to identify the observable
+/// pair, product interval, time scale, and optional receiver constellation.
+///
+/// The pair and month control observable mapping and the generated validity
+/// interval, while `receiver_system` supplies missing system columns.
 pub struct CodeDcbOptions {
+    /// Legacy observable labels, such as `P1` and `C1`, to map per system.
     pub pair: (String, String),
+    /// Calendar year used to construct the first day of the product interval.
     pub year: i32,
+    /// Calendar month checked as 1 through 12 and used to find the next-month
+    /// exclusive interval end.
     pub month: u8,
+    /// Scale copied to the parsed [`BiasSet`] and emitted in the DCB title.
     pub time_scale: TimeScale,
+    /// Optional system used to recognize and target receiver rows whose first
+    /// column does not contain a system letter.
     pub receiver_system: Option<GnssSystem>,
 }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
+/// These variants identify the parser, time conversion, query metadata, or
+/// writer condition that stopped a bias operation.
 pub enum BiasError {
     #[error("invalid bias input {field}: {reason}")]
+    /// A parser found a missing or invalid field, or a writer received an
+    /// unsupported set component.
     InvalidInput {
+        /// Name of the input or output component that failed, such as `month`
+        /// or `bias target`.
         field: &'static str,
+        /// Fixed explanation selected by the validation branch, such as
+        /// `missing` or `out of range`.
         reason: &'static str,
     },
     #[error("invalid bias epoch")]
+    /// A calendar epoch or split Julian date could not be validated.
     InvalidEpoch,
     #[error("unknown RINEX observable code {code}")]
-    UnknownObservable { code: String },
+    /// Represents an unknown RINEX observable code; the current frequency
+    /// lookup returns `None` instead of constructing this variant.
+    UnknownObservable {
+        /// Unrecognized RINEX observable code.
+        code: String,
+    },
     #[error("unsupported Bias-SINEX version {version}")]
-    UnsupportedVersion { version: String },
+    /// The Bias-SINEX version token does not start with supported major version
+    /// `1`.
+    UnsupportedVersion {
+        /// Complete version token that failed the major-version check.
+        version: String,
+    },
     #[error("missing DCB pair or product month")]
+    /// Neither caller options nor the first twelve title lines supplied DCB
+    /// pair, year, and month metadata.
     MissingDcbMetadata,
     #[error("missing satellite clock reference observables")]
+    /// PPP lookup found no clock-reference pair for the requested satellite's
+    /// system.
     MissingClockReference,
     #[error("bias writer missing required metadata {field}")]
-    MissingWriterMetadata { field: &'static str },
+    /// A writer was called without agency, mode, clock-reference, or DCB
+    /// metadata required by its output format.
+    MissingWriterMetadata {
+        /// Name of the required set component that was absent.
+        field: &'static str,
+    },
     #[error("input is not UTF-8")]
+    /// Indicates a UTF-8 decoding failure; the current byte parsers use
+    /// `String::from_utf8_lossy` instead.
     Utf8,
 }
 
 impl BiasSet {
+    /// Parses a Bias-SINEX byte stream.
+    ///
+    /// The byte stream is decoded lossily as UTF-8. Valid solution records are
+    /// retained in the returned [`Parsed`] value, while malformed records,
+    /// unknown blocks, metadata mismatches, overlaps, and missing file-reference
+    /// metadata are reported through [`BiasSet::diagnostics`].
     pub fn parse_bias_sinex(input: &[u8]) -> Result<Parsed<BiasSet>, BiasError> {
         let text = String::from_utf8_lossy(input);
         parse_bias_sinex_text(text.as_ref())
     }
 
+    /// Parses a legacy code DCB byte stream.
+    ///
+    /// Metadata is taken from `options` or the product title, validated, and
+    /// used to convert accepted nanosecond rows into code DSB records in
+    /// seconds. Rows that cannot be represented are retained as typed skips in
+    /// the returned [`Parsed`] value.
     pub fn parse_code_dcb(
         input: &[u8],
         options: Option<CodeDcbOptions>,
@@ -298,22 +484,41 @@ impl BiasSet {
         parse_code_dcb_text(text.as_ref(), options)
     }
 
+    /// Returns parser and indexing diagnostics retained by this set, including
+    /// skips and overlap warnings added while building its lookup index.
     pub fn diagnostics(&self) -> &Diagnostics {
         &self.diagnostics
     }
 
+    /// Returns the number of entries in [`BiasSet::diagnostics`] that were
+    /// skipped during parsing.
     pub fn skipped_records(&self) -> usize {
         self.skipped_records
     }
 
+    /// Returns a covering code OSB in seconds for `sat` and `obs`.
+    ///
+    /// Lookup checks the satellite target before the system target. Phase
+    /// records, scale-mismatched epochs, and epochs outside the validity
+    /// interval produce `None`; an optional record slope is evaluated at
+    /// `epoch`.
     pub fn code_osb_seconds(&self, sat: GnssSatelliteId, obs: &str, epoch: Instant) -> Option<f64> {
         self.osb_for_target_chain(sat, obs, epoch, false)
     }
 
+    /// Returns a covering phase OSB in cycles for `sat` and `obs`.
+    ///
+    /// Lookup checks the satellite target before the system target and requires
+    /// the record unit to be `cyc`; an optional slope is evaluated at `epoch`.
     pub fn phase_osb_cycles(&self, sat: GnssSatelliteId, obs: &str, epoch: Instant) -> Option<f64> {
         self.osb_for_target_chain(sat, obs, epoch, true)
     }
 
+    /// Resolves a covering code DSB in seconds for a satellite or its system.
+    ///
+    /// The satellite key is tried before the system key. Reversing the
+    /// observable arguments reverses the resolved sign, and multi-hop paths
+    /// are allowed when the active DSB records connect the observables.
     pub fn code_dsb_seconds(
         &self,
         sat: GnssSatelliteId,
@@ -332,6 +537,10 @@ impl BiasSet {
         )
     }
 
+    /// Returns a covering receiver code OSB in seconds.
+    ///
+    /// The lookup uses the normalized station and requested system as an exact
+    /// receiver key and excludes phase records.
     pub fn receiver_code_osb_seconds(
         &self,
         system: GnssSystem,
@@ -348,6 +557,10 @@ impl BiasSet {
         .and_then(|record| self.record_value_at(record, epoch))
     }
 
+    /// Resolves a covering receiver code DSB in seconds.
+    ///
+    /// The lookup uses the normalized station and requested system as an exact
+    /// receiver key.
     pub fn receiver_code_dsb_seconds(
         &self,
         system: GnssSystem,
@@ -359,6 +572,10 @@ impl BiasSet {
         self.dsb_for_key(&BiasTargetKey::receiver(system, station), obs1, obs2, epoch)
     }
 
+    /// Returns a covering satellite-receiver code OSB in seconds.
+    ///
+    /// The lookup uses the satellite and normalized station as an exact key
+    /// and excludes phase records.
     pub fn sat_receiver_code_osb_seconds(
         &self,
         sat: GnssSatelliteId,
@@ -375,6 +592,10 @@ impl BiasSet {
         .and_then(|record| self.record_value_at(record, epoch))
     }
 
+    /// Resolves a covering satellite-receiver code DSB in seconds.
+    ///
+    /// The lookup uses the requested satellite and normalized station as an
+    /// exact key.
     pub fn sat_receiver_code_dsb_seconds(
         &self,
         sat: GnssSatelliteId,
@@ -391,10 +612,18 @@ impl BiasSet {
         )
     }
 
+    /// Returns the parsed records in their stored vector order, which is the
+    /// input order for records accepted by either public parser.
     pub fn records(&self) -> &[BiasRecord] {
         &self.records
     }
 
+    /// Computes the code-bias model relative to a satellite-clock reference in meters.
+    ///
+    /// Matching observable pairs return exact zero. When both ionosphere-free
+    /// OSB combinations are available, the model is their difference times
+    /// [`C_M_S`]; otherwise the corresponding code DSBs are combined with the
+    /// ionosphere-free coefficients and converted to meters.
     pub fn code_bias_model_m(
         &self,
         sat: GnssSatelliteId,
@@ -664,6 +893,13 @@ impl BiasSet {
     }
 }
 
+/// Emits a `%=BIA 1.00` header and Bias-SINEX reference, description, and
+/// solution blocks for a [`BiasSet`].
+///
+/// The output contains file-reference, description, and solution blocks. The
+/// set must provide agency, a specified [`BiasMode`], and at least one
+/// [`ClockReferenceObservables`] entry; otherwise the corresponding
+/// [`BiasError::MissingWriterMetadata`] is returned.
 // invariant: formatting into a String uses infallible fmt::Write operations.
 #[allow(clippy::expect_used)]
 pub fn write_bias_sinex(set: &BiasSet) -> Result<String, BiasError> {
@@ -740,6 +976,12 @@ pub fn write_bias_sinex(set: &BiasSet) -> Result<String, BiasError> {
     Ok(out)
 }
 
+/// Emits a legacy code DCB title and satellite or receiver rows for a
+/// [`BiasSet`].
+///
+/// The set must contain [`CodeDcbOptions`] in its header. Every record must be
+/// a non-phase DSB targeting a satellite or receiver; stored code seconds and
+/// uncertainties are written in nanoseconds.
 // invariant: formatting into a String uses infallible fmt::Write operations.
 #[allow(clippy::expect_used)]
 pub fn write_code_dcb(set: &BiasSet) -> Result<String, BiasError> {
@@ -800,6 +1042,11 @@ pub fn write_code_dcb(set: &BiasSet) -> Result<String, BiasError> {
     Ok(out)
 }
 
+/// Returns the ionosphere-free coefficients for two carrier frequencies.
+///
+/// For finite positive unequal frequencies, the result is
+/// `(f1² / (f1² - f2²), -f2² / (f1² - f2²))`. Invalid frequencies and an equal
+/// frequency pair return `None`.
 pub fn ionosphere_free_coefficients(f1_hz: f64, f2_hz: f64) -> Option<(f64, f64)> {
     validate::finite_positive(f1_hz, "f1_hz").ok()?;
     validate::finite_positive(f2_hz, "f2_hz").ok()?;
@@ -1657,10 +1904,19 @@ fn instant_split(epoch: Instant) -> Option<JulianDateSplit> {
     }
 }
 
+/// Converts a [`BiasEpoch`] to an [`Instant`] on `scale`.
+///
+/// The calendar components are converted through a validated split Julian
+/// date; an invalid conversion returns [`BiasError::InvalidEpoch`].
 pub fn bias_epoch_instant(epoch: BiasEpoch, scale: TimeScale) -> Result<Instant, BiasError> {
     Ok(Instant::from_julian_date(scale, epoch.to_split()?))
 }
 
+/// Converts a civil date-time to an [`Instant`] on `scale`.
+///
+/// UTC and GLONASST use UTC-like second validation; all other scales use
+/// continuous-second validation. Invalid calendar or second values return
+/// [`BiasError::InvalidEpoch`].
 pub fn civil_datetime_instant(
     epoch: crate::ppp_corrections::CivilDateTime,
     scale: TimeScale,

--- a/crates/sidereon-core/src/combinations.rs
+++ b/crates/sidereon-core/src/combinations.rs
@@ -20,7 +20,12 @@ pub enum IonosphereFreeError {
     /// The constellation has no standard ionosphere-free carrier pair.
     UnknownSystem(char),
     /// The requested band is not known for the constellation.
-    UnknownBand { system: char, band: String },
+    UnknownBand {
+        /// The constellation letter associated with the failed carrier-band lookup; the error formatter includes it when identifying the affected constellation.
+        system: char,
+        /// The exact band string supplied to the lookup or override. The error retains this text for the formatter, whether parsing the token failed or the recognized band is unavailable for that constellation.
+        band: String,
+    },
     /// Equal carrier frequencies make the denominator vanish.
     EqualFrequencies,
     /// Cycle-to-meter conversion requires positive carrier frequencies.

--- a/crates/sidereon-core/src/data.rs
+++ b/crates/sidereon-core/src/data.rs
@@ -3377,34 +3377,6 @@ pub struct PublishedProduct {
     pub observed_at: Option<String>,
 }
 
-/// Parse the object entries out of an archive listing body.
-///
-/// Dialect detection is closed: the body must classify as exactly one of the
-/// listing surfaces the catalog's archives actually serve, each verified live
-/// on 2026-08-04 and recorded as a fixture, and a body that fits none of them
-/// is [`DataCatalogError::UnrecognizedArchiveListing`] - never a best-effort
-/// empty result. An error page, a login interstitial, or a format change at
-/// an archive must surface as "this is not a listing I understand", because a
-/// silent empty parse is indistinguishable from "nothing published" and would
-/// convert an archive change into a false publication-gap report.
-///
-/// - Apache `<pre>` autoindex and its older table flavor (GFZ
-///   `isdc-data.gfz.de`, BKG `igs.bkg.bund.de`) and the ESA XHTML table
-///   autoindex (`navigation-office.esa.int`): recognized by the autoindex
-///   `Index of` marker; objects are relative anchors, with the row's
-///   `YYYY-MM-DD HH:MM` text captured verbatim.
-/// - AIUB whole-tree CSV (`www.aiub.unibe.ch/download/full_listing.csv`):
-///   `path;bytes;ISO-8601;md5` rows; every non-empty row must fit that
-///   grammar.
-/// - Anonymous-FTP `LIST` output (WHU `igs.gnsswhu.cn`): Unix `ls -l` rows
-///   (an optional leading `total` line allowed); every other non-empty row
-///   must fit that grammar.
-///
-/// Within a recognized dialect, rows that by the dialect's own rules do not
-/// name an object (parent links, sort links, directories, symlinks) are
-/// skipped. The result preserves nothing but object paths and verbatim
-/// modification text; interpretation belongs to
-/// [`newest_published_product`].
 /// Position index backing archive-listing deduplication.
 ///
 /// Keyed by the hash of the path rather than by an owned copy of it, so a
@@ -3452,6 +3424,34 @@ fn default_path_hash(path: &str) -> u64 {
     hasher.finish()
 }
 
+/// Parse the object entries out of an archive listing body.
+///
+/// Dialect detection is closed: the body must classify as exactly one of the
+/// listing surfaces the catalog's archives actually serve, each verified live
+/// on 2026-08-04 and recorded as a fixture, and a body that fits none of them
+/// is [`DataCatalogError::UnrecognizedArchiveListing`] - never a best-effort
+/// empty result. An error page, a login interstitial, or a format change at
+/// an archive must surface as "this is not a listing I understand", because a
+/// silent empty parse is indistinguishable from "nothing published" and would
+/// convert an archive change into a false publication-gap report.
+///
+/// - Apache `<pre>` autoindex and its older table flavor (GFZ
+///   `isdc-data.gfz.de`, BKG `igs.bkg.bund.de`) and the ESA XHTML table
+///   autoindex (`navigation-office.esa.int`): recognized by the autoindex
+///   `Index of` marker; objects are relative anchors, with the row's
+///   `YYYY-MM-DD HH:MM` text captured verbatim.
+/// - AIUB whole-tree CSV (`www.aiub.unibe.ch/download/full_listing.csv`):
+///   `path;bytes;ISO-8601;md5` rows; every non-empty row must fit that
+///   grammar.
+/// - Anonymous-FTP `LIST` output (WHU `igs.gnsswhu.cn`): Unix `ls -l` rows
+///   (an optional leading `total` line allowed); every other non-empty row
+///   must fit that grammar.
+///
+/// Within a recognized dialect, rows that by the dialect's own rules do not
+/// name an object (parent links, sort links, directories, symlinks) are
+/// skipped. The result preserves nothing but object paths and verbatim
+/// modification text; interpretation belongs to
+/// [`newest_published_product`].
 pub fn parse_archive_listing(body: &str) -> Result<Vec<PublishedObject>, DataCatalogError> {
     let mut seen: Vec<PublishedObject> = Vec::new();
     // Listings are large (AIUB's whole-tree CSV is ~426k rows) and a row may

--- a/crates/sidereon-core/src/estimation/recipe.rs
+++ b/crates/sidereon-core/src/estimation/recipe.rs
@@ -78,11 +78,19 @@ pub enum ReferenceTarget {
 pub enum StrategyId {
     /// A reference-faithful strategy: 0-ULP to `target` for `technique`.
     Reference {
+        /// Technique passed to [`EstimationRecipe::for_reference`] and checked
+        /// against the input technique before runner dispatch.
         technique: Technique,
+        /// Reference target paired with `technique` when resolving the recipe;
+        /// unsupported pairs are rejected as incompatible targets.
         target: ReferenceTarget,
     },
     /// The canonical strategy for `technique` (bounded-tolerance, truth-gated).
-    Canonical { technique: Technique },
+    Canonical {
+        /// Technique passed to [`EstimationRecipe::for_canonical`] and used to
+        /// select the corresponding canonical runner and screen family.
+        technique: Technique,
+    },
 }
 
 impl Default for StrategyId {
@@ -272,10 +280,23 @@ pub enum SolverRecipe {
 /// reduced normals; see `estimation::strategies`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct EstimationRecipe {
+    /// SPP transmit-time branch copied into `SppModelRecipe` and consumed by
+    /// `sat_model`: the reference uses a measured-pseudorange seed with a fixed
+    /// iteration count, while the canonical branch iterates to convergence.
     pub range: RangeRecipe,
+    /// Earth-rotation operation passed by SPP to both satellite rotation and
+    /// geometric-range calculation in the shared range substrate.
     pub sagnac: SagnacRecipe,
+    /// Receiver-frame selection passed by SPP to the shared azimuth/elevation
+    /// substrate; SPP accepts the Skyfield and canonical WGS84 frame variants.
     pub frame: FrameRecipe,
+    /// Normal-equation reduction forwarded to the RTK and PPP solve seams; the
+    /// reference arms retain their tie orders and the canonical arm selects the
+    /// square-root reduction.
     pub normal: NormalRecipe,
+    /// Factorization selection forwarded to the SPP trust-region and RTK solve
+    /// seams; SPP recognizes its owned trust-region variant, while RTK uses the
+    /// owned Cholesky variant only with [`NormalRecipe::CanonicalSquareRoot`].
     pub solver: SolverRecipe,
 }
 
@@ -468,7 +489,11 @@ pub enum PartialResolution {
     /// Confidence-ranked then exhaustive subset fallback down to
     /// `min_ambiguities` retained (the RTK static fixed solver,
     /// `rtk_filter::search::search_partial_fixed_ambiguities`).
-    Exhaustive { min_ambiguities: usize },
+    Exhaustive {
+        /// Retained-subset floor copied from `partial_min_ambiguities` by
+        /// [`AmbiguityIdPolicy::rtk_static`].
+        min_ambiguities: usize,
+    },
 }
 
 /// The integer-ambiguity identity/eligibility policy a strategy resolves under:
@@ -477,9 +502,14 @@ pub enum PartialResolution {
 /// reference strategies. Named in P3; consumed by the runtime selector in P4.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AmbiguityIdPolicy {
+    /// Ambiguity identity convention: the RTK constructors store per-system
+    /// double differences, while [`AmbiguityIdPolicy::ppp`] stores undifferenced
+    /// per-satellite ambiguities.
     pub differencing: DifferencingMode,
     /// Exclude float-only constellations from the integer search set.
     pub float_only_gating: bool,
+    /// Resolution mode returned by the policy constructors: static RTK stores
+    /// an exhaustive fallback, while sequential RTK and PPP store `Disabled`.
     pub partial: PartialResolution,
     /// Ratio-test acceptance threshold passed to the LAMBDA kernel.
     pub ratio_threshold: f64,

--- a/crates/sidereon-core/src/estimation/strategies.rs
+++ b/crates/sidereon-core/src/estimation/strategies.rs
@@ -59,6 +59,8 @@ use crate::spp::{EphemerisSource, ReceiverSolution, SolveInputs, SolvePolicy, So
 /// strategy ([`StrategyId::default`]), matching the per-stage recipe defaults.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct EstimateOptions {
+    /// Strategy identity resolved by [`estimate`] before it checks the input
+    /// technique. The default is the SPP/Skyfield reference strategy.
     pub strategy: StrategyId,
 }
 
@@ -78,46 +80,95 @@ pub enum EstimateInput<'a> {
     /// SPP under the public validation/orchestration policy
     /// (`spp::solve_with_policy`).
     Spp {
+        /// Ephemeris source queried for selected satellites' transmit-time
+        /// positions and clocks.
         eph: &'a dyn EphemerisSource,
+        /// SPP epoch bundle whose observations, receive-time arguments, initial
+        /// state, and corrections are validated before the solve.
         inputs: &'a SolveInputs,
+        /// Whether the returned receiver solution includes its geodetic field;
+        /// `false` leaves that field as `None`.
         with_geodetic: bool,
+        /// SPP orchestration policy: coarse seeded candidates when configured,
+        /// or one solve followed by validation otherwise.
         policy: SolvePolicy,
     },
     /// Static multi-epoch float RTK baseline (`rtk_filter::solve_float_baseline`).
     RtkFloat {
+        /// Normalized static epochs whose double-difference code/phase rows are
+        /// accumulated into the batch normal system and residuals.
         epochs: &'a [Epoch],
+        /// Base-station ECEF position used by RTK geometry and weighting rows.
         base: [f64; 3],
+        /// Ordered ambiguity column keys paired with the float estimates and
+        /// covariance in the returned solution.
         ambiguity_ids: &'a [String],
+        /// Initial ECEF baseline estimate in meters for the iterated float state.
         initial_baseline_m: [f64; 3],
+        /// Code/phase sigmas, Sagnac choice, and stochastic model read while
+        /// constructing RTK rows.
         model: &'a MeasModel,
+        /// Position/ambiguity tolerances and maximum iteration count for the
+        /// float loop.
         opts: FloatSolveOpts,
+        /// Optional receiver antenna calibration applied while building RTK
+        /// rows; `None` supplies no antenna correction.
         receiver_antenna_corrections: Option<&'a ReceiverAntennaCorrections>,
     },
     /// Static fixed RTK baseline with residual validation/FDE
     /// (`rtk_filter::solve_fixed_baseline_validated`).
     RtkFixed {
+        /// Working static epoch set used by the float prerequisite, residual
+        /// validation exclusions, and integer-conditioned fixed re-solve.
         epochs: &'a [Epoch],
+        /// Base-station ECEF position shared by the validated float and fixed
+        /// RTK stages.
         base: [f64; 3],
+        /// Initial ambiguity ids, satellite map, cycle/meter scale, and
+        /// float-only systems for the fixed solve.
         initial_ambiguities: AmbiguitySet<'a>,
+        /// Initial ECEF baseline estimate used to seed the float prerequisite.
         initial_baseline_m: [f64; 3],
+        /// RTK measurement sigmas, Sagnac choice, and stochastic model shared by
+        /// both validated stages.
         model: &'a MeasModel,
+        /// Float, fixed, and residual-validation controls for the full fixed
+        /// workflow.
         opts: ValidatedFixedSolveOpts,
+        /// Optional receiver antenna calibration forwarded to both RTK stages;
+        /// `None` supplies no antenna correction.
         receiver_antenna_corrections: Option<&'a ReceiverAntennaCorrections>,
     },
     /// Static multi-epoch float PPP arc
     /// (`precise_positioning::solve_float_epochs`).
     PppFloat {
+        /// Observable ephemeris source used to predict satellite state while
+        /// PPP rows are built.
         source: &'a dyn ObservableEphemerisSource,
+        /// Static PPP arc; configured elevation filtering occurs before active
+        /// ambiguity ids and normal rows are built.
         epochs: &'a [FloatEpoch],
+        /// Initial receiver position, clocks, ambiguities, and enabled
+        /// atmospheric or residual-ionosphere states.
         initial_state: FloatState,
+        /// PPP weights, corrections, atmospheric settings, iteration controls,
+        /// and optional screening/state-estimation flags.
         config: FloatSolveConfig,
     },
     /// Integer-fixed PPP from an existing float solution
     /// (`precise_positioning::solve_fixed_from_float`).
     PppFixed {
+        /// Observable ephemeris source used for cutoff prediction, ambiguity
+        /// search rows, and the fixed re-solve.
         source: &'a dyn ObservableEphemerisSource,
+        /// Static arc used for integer search and the fixed re-solve, after any
+        /// configured elevation filtering.
         epochs: &'a [FloatEpoch],
+        /// Validated float result converted into the initial fixed state and
+        /// used with its ambiguity covariance for integer search.
         float_solution: FloatSolution,
+        /// PPP measurement/correction settings, integer-search controls,
+        /// convergence controls, and optional filtering/state estimation.
         config: FixedSolveConfig,
     },
 }
@@ -139,10 +190,19 @@ impl EstimateInput<'_> {
 /// pointer-sized regardless of which technique ran.
 #[derive(Debug, Clone)]
 pub enum EstimateOutput {
+    /// Successful SPP result produced by `spp::run` and boxed for the unified
+    /// output enum; the SPP compatibility wrapper unwraps this variant.
     Spp(Box<ReceiverSolution>),
+    /// Successful static RTK float result produced by `rtk_filter::run_float`.
     RtkFloat(Box<FloatBaselineSolution>),
+    /// Successful validated fixed RTK result produced by
+    /// `rtk_filter::run_fixed_validated`.
     RtkFixed(Box<ValidatedFixedBaselineSolution>),
+    /// Successful static PPP float result produced by
+    /// `precise_positioning::run_float_epochs`.
     PppFloat(Box<FloatSolution>),
+    /// Successful integer-fixed PPP result produced by
+    /// `precise_positioning::run_fixed_from_float`.
     PppFixed(Box<FixedSolution>),
 }
 
@@ -153,7 +213,9 @@ pub enum EstimateError {
     /// The selected strategy's technique does not match the input's technique
     /// (e.g. an RTK strategy with an SPP input).
     TechniqueMismatch {
+        /// Technique selected by the resolved strategy.
         strategy: Technique,
+        /// Technique returned by [`EstimateInput::technique`] for the input.
         input: Technique,
     },
     /// A `Reference` strategy named a `target` that is not a supported reference
@@ -161,7 +223,9 @@ pub enum EstimateError {
     /// oracle, or the owned deterministic solver for a non-SPP technique). The
     /// supported pairs are enumerated by [`EstimationRecipe::for_reference`].
     IncompatibleTarget {
+        /// Technique passed to [`EstimationRecipe::for_reference`].
         technique: Technique,
+        /// Reference target passed to [`EstimationRecipe::for_reference`].
         target: ReferenceTarget,
     },
     /// A `Canonical` strategy was selected for a technique whose canonical model
@@ -169,12 +233,24 @@ pub enum EstimateError {
     /// technique currently produces this; it is retained as the resolver's stable
     /// not-yet-implemented surface for any future technique.
     CanonicalUnavailable {
+        /// Technique for which [`EstimationRecipe::for_canonical`] returned no
+        /// recipe.
         technique: Technique,
     },
+    /// Error returned by the SPP runner and preserved for the compatibility
+    /// wrapper.
     Spp(SolvePolicyError),
+    /// Error returned by the static RTK float runner and preserved for the
+    /// compatibility wrapper.
     RtkFloat(RtkFloatSolveError),
+    /// Error returned by the validated RTK fixed runner and preserved for the
+    /// compatibility wrapper.
     RtkFixed(ValidatedFixedSolveError),
+    /// Error returned by the static PPP float runner and preserved for the
+    /// compatibility wrapper.
     PppFloat(PppFloatSolveError),
+    /// Error returned by the integer-fixed PPP runner and preserved for the
+    /// compatibility wrapper.
     PppFixed(FixedSolveError),
 }
 
@@ -184,8 +260,12 @@ pub enum EstimateError {
 /// resolved reference strategy dispatches bit-identically to the existing path.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ResolvedStrategy {
+    /// Requested strategy identity copied into the resolved record.
     pub id: StrategyId,
+    /// Technique selected by `id`, checked against the input before dispatch.
     pub technique: Technique,
+    /// Operation-order recipe selected by `id` and passed to the technique
+    /// runner.
     pub recipe: EstimationRecipe,
     /// The residual-screen families this technique applies (P3 `ScreenKind`).
     pub screens: &'static [ScreenKind],

--- a/crates/sidereon-core/src/frame.rs
+++ b/crates/sidereon-core/src/frame.rs
@@ -17,7 +17,9 @@ pub enum FrameValueError {
     /// A frame value component was non-finite or outside its documented domain.
     #[error("invalid frame value {field}: {reason}")]
     InvalidInput {
+        /// Static label of the rejected component, as assigned by the frame-value constructors (for example, `"x_m"` or `"lat_rad"`).
         field: &'static str,
+        /// Validation message for the rejected component. Constructors use `"must be finite"` for non-finite coordinates and velocities, and range-specific messages for latitude and longitude violations; conversion adapters preserve the message.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/ils.rs
+++ b/crates/sidereon-core/src/ils.rs
@@ -31,16 +31,36 @@ pub enum IlsError {
     /// The lattice yielded no candidate (an empty search box).
     NoCandidates(usize),
     /// The lattice exceeded `candidate_limit`.
-    TooManyCandidates { evaluated: usize, limit: usize },
+    TooManyCandidates {
+        /// Number of lattice leaves evaluated when enumeration crossed the
+        /// cap, or the computed count that was rejected during preflight.
+        evaluated: usize,
+        /// Candidate cap supplied to [`bounded_ils_search`] and carried into
+        /// the rejection details.
+        limit: usize,
+    },
     /// `float_cycles` was empty, or `covariance` was not exactly `n x n` for
     /// `n = float_cycles.len()` (`rows` is the offending row count, or the length
     /// of the first row that was not `n` wide).
-    InvalidDimensions { n: usize, rows: usize },
+    InvalidDimensions {
+        /// Number of values in the supplied `float_cycles` slice, which is the
+        /// required covariance row and column count.
+        n: usize,
+        /// Supplied covariance row count, or the width of the first row that
+        /// differs from `n`; this is zero for empty input.
+        rows: usize,
+    },
     /// A `float_cycles` or `covariance` entry was NaN or infinite.
     NonFinite,
     /// A public ILS option was malformed.
     InvalidInput {
+        /// Identifies `"ils ratio_threshold"` or `"ils covariance"` for a
+        /// validator failure, or `"ils float_cycles"` for an integer-domain
+        /// failure.
         field: &'static str,
+        /// Identifies `"negative"`, `"not finite"`, or `"not positive"` for a
+        /// validator failure, or `"outside integer search range"` for an
+        /// integer-domain failure.
         reason: &'static str,
     },
     /// The MLAMBDA search did not converge within `LAMBDA_LOOP_MAX` iterations

--- a/crates/sidereon-core/src/ionex/tec_grid.rs
+++ b/crates/sidereon-core/src/ionex/tec_grid.rs
@@ -91,12 +91,21 @@ mod error_display_tests {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// [`TecGrid::vtec_at_pierce_point`] converts `unix_nanos` to the temporal
+/// interpolation coordinate. `day_of_year` is retained for callers but is not
+/// read by this regular-grid implementation.
 pub struct TecGridEpoch {
+    /// Unix-epoch timestamp in nanoseconds, matching the grid's epoch axis.
     pub unix_nanos: i64,
+    /// Day-of-year companion carried with the timestamp but unused by grid interpolation.
     pub day_of_year: u16,
 }
 
 impl TecGridEpoch {
+    /// Builds an epoch by copying the supplied timestamp and day-of-year value.
+    ///
+    /// Neither value is validated here; validation of the timestamp occurs
+    /// when a grid query converts it to its floating-point axis coordinate.
     pub fn new(unix_nanos: i64, day_of_year: u16) -> Self {
         Self {
             unix_nanos,
@@ -106,12 +115,23 @@ impl TecGridEpoch {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+/// [`Self::shell_radius_m`] adds the shell height to the Earth radius, and
+/// [`tec_xyz`] uses the resulting radius for the pierce-point intersection and
+/// the slant-to-vertical mapping.
 pub struct TecGridShellGeometry {
+    /// Radius in meters used by the shell intersection and obliquity numerator;
+    /// evaluation requires it to be finite and positive.
     pub earth_radius_m: f64,
+    /// Height in meters added to the Earth radius for the shell intersection;
+    /// evaluation requires it to be finite and nonnegative.
     pub shell_height_m: f64,
 }
 
 impl TecGridShellGeometry {
+    /// Constructs shell geometry without validating its two distances.
+    ///
+    /// The distances are validated when the geometry is passed to [`tec_xyz`]
+    /// or [`iono_delay_xyz`].
     pub const fn new(earth_radius_m: f64, shell_height_m: f64) -> Self {
         Self {
             earth_radius_m,
@@ -119,6 +139,9 @@ impl TecGridShellGeometry {
         }
     }
 
+    /// Returns the default Earth radius and ionospheric shell height.
+    ///
+    /// [`Default::default`] delegates to this constructor.
     pub const fn default_shell() -> Self {
         Self {
             earth_radius_m: EARTH_RADIUS_M,
@@ -126,6 +149,7 @@ impl TecGridShellGeometry {
         }
     }
 
+    /// Returns the spherical shell radius as `earth_radius_m + shell_height_m`.
     pub fn shell_radius_m(self) -> f64 {
         self.earth_radius_m + self.shell_height_m
     }
@@ -138,15 +162,26 @@ impl Default for TecGridShellGeometry {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+/// [`tec_xyz`] consumes the epoch, elevation floor, fallback altitude, and
+/// shell geometry; [`iono_delay_xyz`] additionally uses the carrier frequency.
 pub struct TecGridEvalOptions {
+    /// Epoch passed to [`TecGrid::vtec_at_pierce_point`].
     pub epoch: TecGridEpoch,
+    /// Minimum elevation used by the thin-shell obliquity mapping, in radians.
     pub min_elevation_rad: f64,
+    /// Fallback pierce-point altitude in meters when the coordinate callback returns any NaN.
     pub nan_pierce_point_height_m: f64,
+    /// Carrier frequency used to convert slant TEC to group delay, in hertz.
     pub frequency_hz: f64,
+    /// Earth radius and shell height used by the pierce-point and obliquity calculations.
     pub shell_geometry: TecGridShellGeometry,
 }
 
 impl TecGridEvalOptions {
+    /// Creates options for the canonical GPS L1 frequency.
+    ///
+    /// The result uses a 5-degree minimum elevation, the default 450,000-meter
+    /// fallback height, and [`TecGridShellGeometry::default`].
     pub fn l1(epoch: TecGridEpoch) -> Self {
         // invariant: the built-in GNSS frequency table always defines GPS L1.
         #[allow(clippy::expect_used)]
@@ -161,6 +196,7 @@ impl TecGridEvalOptions {
         }
     }
 
+    /// Returns a copy using `shell_geometry` and its height as the NaN fallback altitude.
     pub fn with_shell_geometry(mut self, shell_geometry: TecGridShellGeometry) -> Self {
         self.nan_pierce_point_height_m = shell_geometry.shell_height_m;
         self.shell_geometry = shell_geometry;
@@ -169,6 +205,9 @@ impl TecGridEvalOptions {
 }
 
 #[derive(Clone, Debug)]
+/// [`TecGrid::new`] stores finite TECU values on strictly increasing epoch,
+/// latitude, and longitude axes in epoch-latitude-longitude order. Queries
+/// interpolate the eight corners of the surrounding cell.
 pub struct TecGrid {
     epochs_ns: Vec<f64>,
     latitudes_deg: Vec<f64>,
@@ -177,6 +216,12 @@ pub struct TecGrid {
 }
 
 impl TecGrid {
+    /// Builds a grid from epoch, latitude, and longitude axes and flat cell values.
+    ///
+    /// Each axis must contain at least two strictly increasing entries. The
+    /// value count must equal the checked product of the axis lengths, and all
+    /// values must be finite; otherwise the returned error describes the failed
+    /// invariant.
     pub fn new(
         epochs_ns: Vec<f64>,
         latitudes_deg: Vec<f64>,
@@ -212,6 +257,12 @@ impl TecGrid {
         })
     }
 
+    /// Returns VTEC interpolated at a pierce-point longitude and latitude.
+    ///
+    /// Latitude values outside `[-87.5, 87.5]` are clamped to that interval.
+    /// The epoch's Unix-nanosecond timestamp is converted to the grid's
+    /// floating-point epoch coordinate, and the effective epoch, latitude, and
+    /// longitude query values must be finite and within their respective axes.
     pub fn vtec_at_pierce_point(
         &self,
         epoch: TecGridEpoch,
@@ -290,6 +341,13 @@ impl TecGrid {
     }
 }
 
+/// Computes the ionospheric group delay for an ECEF satellite and receiver pair.
+///
+/// The callback receives the ECEF pierce point in meters and returns
+/// `[longitude_deg, latitude_deg, altitude]`. This function validates the
+/// carrier frequency, obtains slant TEC from [`tec_xyz`], and applies
+/// `IONOSPHERE_CONSTANT * stec / frequency_hz^2`, returning the finite result in
+/// meters. The altitude component is used only for the NaN check.
 pub fn iono_delay_xyz<F>(
     grid: &TecGrid,
     options: TecGridEvalOptions,
@@ -309,6 +367,14 @@ where
         .map(|_| delay_m)
 }
 
+/// Computes vertical and slant TEC for an ECEF satellite and receiver pair.
+///
+/// The callback receives the ECEF pierce point in meters and returns
+/// `[longitude_deg, latitude_deg, altitude]`; if any returned component is
+/// NaN, the receiver longitude/latitude and
+/// `nan_pierce_point_height_m` are used instead. The result is
+/// `(vtec_tecu, stec_tecu)`, with slant TEC obtained from the configured shell
+/// geometry and the elevation after applying `min_elevation_rad`.
 pub fn tec_xyz<F>(
     grid: &TecGrid,
     options: TecGridEvalOptions,

--- a/crates/sidereon-core/src/navigation/lnav.rs
+++ b/crates/sidereon-core/src/navigation/lnav.rs
@@ -83,40 +83,75 @@ impl LnavNumber {
 /// An LNAV parameter field, used to tag a range-validation failure.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LnavField {
+    /// The 17-bit time-of-week field in the HOW word.
     Tow,
+    /// The one-bit alert flag in the HOW word.
     Alert,
+    /// The one-bit anti-spoof flag in the HOW word.
     AntiSpoof,
+    /// The one-bit integrity flag in the TLM word.
     Integrity,
+    /// The 14-bit message field in the TLM word.
     TlmMessage,
+    /// The 10-bit GPS week transmitted in subframe 1 word 3.
     WeekNumber,
+    /// The two-bit L2 code in subframe 1 word 3.
     L2Code,
+    /// The one-bit L2-P data flag in subframe 1 word 4.
     L2PDataFlag,
+    /// The four-bit GPS user-range-accuracy index in subframe 1 word 3.
     UraIndex,
+    /// The six-bit satellite health value in subframe 1 word 3.
     SvHealth,
+    /// The ten-bit clock-data issue split across subframe 1 words 3 and 8.
     Iodc,
+    /// The signed eight-bit GPS group delay in subframe 1 word 7.
     Tgd,
+    /// The unsigned 16-bit clock reference time in subframe 1 word 8.
     Toc,
+    /// The signed eight-bit clock drift rate in subframe 1 word 9.
     Af2,
+    /// The signed 16-bit clock drift in subframe 1 word 9.
     Af1,
+    /// The signed 22-bit clock bias in subframe 1 word 10.
     Af0,
+    /// The eight-bit ephemeris-data issue in subframe 2 word 3 and word 10 of subframe 3.
     Iode,
+    /// The signed 16-bit radial sine correction in subframe 2 word 3.
     Crs,
+    /// The signed 16-bit mean-motion difference in subframe 2 word 4.
     DeltaN,
+    /// The signed 32-bit mean anomaly split across subframe 2 words 4 and 5.
     M0,
+    /// The signed 16-bit cosine correction in subframe 2 word 6.
     Cuc,
+    /// The unsigned 32-bit eccentricity split across subframe 2 words 6 and 7.
     Eccentricity,
+    /// The signed 16-bit sine correction in subframe 2 word 8.
     Cus,
+    /// The unsigned 32-bit square root of the semi-major axis split across subframe 2 words 8 and 9.
     SqrtA,
+    /// The unsigned 16-bit ephemeris reference time in subframe 2 word 10.
     Toe,
+    /// The one-bit curve-fit selector in subframe 2 word 10.
     FitIntervalFlag,
+    /// The five-bit age-of-data offset in subframe 2 word 10.
     Aodo,
+    /// The signed 16-bit cosine correction in subframe 3 word 3.
     Cic,
+    /// The signed 32-bit longitude of the ascending node split across subframe 3 words 3 and 4.
     Omega0,
+    /// The signed 16-bit sine correction in subframe 3 word 5.
     Cis,
+    /// The signed 32-bit inclination split across subframe 3 words 5 and 6.
     I0,
+    /// The signed 16-bit radial cosine correction in subframe 3 word 7.
     Crc,
+    /// The signed 32-bit argument of perigee split across subframe 3 words 7 and 8.
     Omega,
+    /// The signed 24-bit rate of right ascension in subframe 3 word 9.
     OmegaDot,
+    /// The signed 14-bit inclination rate in subframe 3 word 10.
     Idot,
 }
 
@@ -168,58 +203,111 @@ impl LnavField {
 pub enum LnavError {
     /// A parameter does not fit its transmitted field; echoes the offending
     /// value in its original numeric type.
-    OutOfRange { field: LnavField, value: LnavNumber },
+    OutOfRange {
+        /// The first parameter that does not fit its transmitted field.
+        field: LnavField,
+        /// The rejected input, preserving its original numeric variant.
+        value: LnavNumber,
+    },
     /// A word's recomputed parity did not match (1-based subframe and word).
-    ParityFailed { subframe: u8, word: u8 },
+    ParityFailed {
+        /// One-based subframe number whose parity check failed.
+        subframe: u8,
+        /// One-based word number of the first failed parity check.
+        word: u8,
+    },
     /// A parity source word was not exactly 24 data bits.
-    BadWordLength { expected: usize, actual: usize },
+    BadWordLength {
+        /// Required source-word length, fixed at 24 data bits.
+        expected: usize,
+        /// Supplied source-word length.
+        actual: usize,
+    },
     /// A subframe was not exactly [`SUBFRAME_LENGTH`] bits.
-    BadSubframeLength { subframe: u8 },
+    BadSubframeLength {
+        /// One-based subframe number associated with the invalid input length.
+        subframe: u8,
+    },
 }
 
 /// Clock and ephemeris parameters in engineering units (the per-field input to
 /// [`encode`]). Values preserve their numeric type for faithful error echoing.
 #[derive(Clone, Copy, Debug)]
 pub struct LnavParams {
+    /// Ten-bit GPS week placed in subframe 1 word 3; [`encode`] accepts integer values 0 through 1023.
     pub week_number: LnavNumber,
+    /// Two-bit L2 code placed in subframe 1 word 3 bits 11..12.
     pub l2_code: LnavNumber,
+    /// One-bit L2-P data flag placed in subframe 1 word 4 bit 1; [`decode`] does not recover it.
     pub l2_p_data_flag: LnavNumber,
+    /// Four-bit GPS URA index placed in subframe 1 word 3 bits 13..16.
     pub ura_index: LnavNumber,
+    /// Six-bit satellite health value placed in subframe 1 word 3 bits 17..22.
     pub sv_health: LnavNumber,
+    /// Ten-bit clock-data issue split between subframe 1 word 3 and word 8.
     pub iodc: LnavNumber,
+    /// GPS TGD in seconds, quantized with a 2^-31 LSB in subframe 1 word 7.
     pub tgd: LnavNumber,
+    /// Clock reference time in seconds of week, quantized to 16-second steps in subframe 1 word 8.
     pub toc: LnavNumber,
+    /// Clock bias in seconds, quantized with a 2^-31 LSB in subframe 1 word 10.
     pub af0: LnavNumber,
+    /// Clock drift in seconds per second, quantized with a 2^-43 LSB in subframe 1 word 9.
     pub af1: LnavNumber,
+    /// Clock drift rate in seconds per second squared, quantized with a 2^-55 LSB in subframe 1 word 9.
     pub af2: LnavNumber,
+    /// Eight-bit ephemeris-data issue placed in subframe 2 word 3 and duplicated in subframe 3 word 10.
     pub iode: LnavNumber,
+    /// Radial sine correction in meters, quantized with a 2^-5 LSB in subframe 2 word 3.
     pub crs: LnavNumber,
+    /// Mean-motion difference in semicircles per second, quantized with a 2^-43 LSB in subframe 2 word 4.
     pub delta_n: LnavNumber,
+    /// Mean anomaly in semicircles, quantized with a 2^-31 LSB and split across subframe 2 words 4 and 5.
     pub m0: LnavNumber,
+    /// Cosine correction in radians, quantized with a 2^-29 LSB in subframe 2 word 6.
     pub cuc: LnavNumber,
+    /// Dimensionless eccentricity, quantized with a 2^-33 LSB and split across subframe 2 words 6 and 7.
     pub eccentricity: LnavNumber,
+    /// Sine correction in radians, quantized with a 2^-29 LSB in subframe 2 word 8.
     pub cus: LnavNumber,
+    /// Square root of the semi-major axis in sqrt(m), quantized with a 2^-19 LSB and split across subframe 2 words 8 and 9.
     pub sqrt_a: LnavNumber,
+    /// Ephemeris reference time in seconds of week, quantized to 16-second steps in subframe 2 word 10.
     pub toe: LnavNumber,
+    /// One-bit curve-fit selector in subframe 2 word 10, interpreted with IODE and IODC downstream.
     pub fit_interval_flag: LnavNumber,
+    /// Five-bit raw age-of-data offset placed in subframe 2 word 10 and recovered without conversion.
     pub aodo: LnavNumber,
+    /// Cosine correction in radians, quantized with a 2^-29 LSB in subframe 3 word 3.
     pub cic: LnavNumber,
+    /// Longitude of the ascending node in semicircles, quantized with a 2^-31 LSB and split across subframe 3 words 3 and 4.
     pub omega0: LnavNumber,
+    /// Sine correction in radians, quantized with a 2^-29 LSB in subframe 3 word 5.
     pub cis: LnavNumber,
+    /// Inclination in semicircles, quantized with a 2^-31 LSB and split across subframe 3 words 5 and 6.
     pub i0: LnavNumber,
+    /// Radial cosine correction in meters, quantized with a 2^-5 LSB in subframe 3 word 7.
     pub crc: LnavNumber,
+    /// Argument of perigee in semicircles, quantized with a 2^-31 LSB and split across subframe 3 words 7 and 8.
     pub omega: LnavNumber,
+    /// Rate of right ascension in semicircles per second, quantized with a 2^-43 LSB in subframe 3 word 9.
     pub omega_dot: LnavNumber,
+    /// Inclination rate in semicircles per second, quantized with a 2^-43 LSB in subframe 3 word 10.
     pub idot: LnavNumber,
 }
 
 /// TLM/HOW options accompanying an [`encode`] (defaults applied by the caller).
 #[derive(Clone, Copy, Debug)]
 pub struct LnavOptions {
+    /// Integer time-of-week count placed in the 17-bit HOW field of each subframe.
     pub tow: LnavNumber,
+    /// Integer alert flag placed in HOW bit 18 of each subframe.
     pub alert: LnavNumber,
+    /// Integer anti-spoof flag placed in HOW bit 19 of each subframe.
     pub anti_spoof: LnavNumber,
+    /// Integer integrity flag placed in the TLM word of each subframe.
     pub integrity: LnavNumber,
+    /// Integer 14-bit TLM message placed after the preamble in each subframe.
     pub tlm_message: LnavNumber,
 }
 
@@ -229,34 +317,63 @@ pub struct LnavOptions {
 /// encode-only flag in word 4 and is not recovered.)
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LnavDecoded {
+    /// Ten-bit GPS week used as the residue checked against the caller's full week.
     pub week_number: i64,
+    /// Two-bit L2 code read from subframe 1 word 3 bits 11..12.
     pub l2_code: i64,
+    /// Four-bit URA index used to obtain the broadcast record's meter accuracy bound.
     pub ura_index: i64,
+    /// Six-bit health value copied to the broadcast record.
     pub sv_health: i64,
+    /// Recombined ten-bit clock-data issue from the two subframe 1 locations.
     pub iodc: i64,
+    /// GPS TGD in seconds recovered with the 2^-31 LSB and copied into the group delay.
     pub tgd: f64,
+    /// Clock reference time in integer seconds of week from the 16-second field.
     pub toc: i64,
+    /// Clock bias in seconds recovered from the signed 22-bit field.
     pub af0: f64,
+    /// Clock drift in seconds per second recovered with the 2^-43 LSB.
     pub af1: f64,
+    /// Clock drift rate in seconds per second squared recovered with the 2^-55 LSB.
     pub af2: f64,
+    /// Eight-bit ephemeris-data issue recovered from subframe 2 and used as the broadcast issue.
     pub iode: i64,
+    /// Radial sine correction in meters recovered with the 2^-5 LSB.
     pub crs: f64,
+    /// Mean-motion difference in semicircles per second recovered with the 2^-43 LSB.
     pub delta_n: f64,
+    /// Mean anomaly in semicircles recovered from the two-word field with the 2^-31 LSB.
     pub m0: f64,
+    /// Cosine correction in radians recovered with the 2^-29 LSB.
     pub cuc: f64,
+    /// Dimensionless eccentricity recovered from the two-word field with the 2^-33 LSB.
     pub eccentricity: f64,
+    /// Sine correction in radians recovered with the 2^-29 LSB.
     pub cus: f64,
+    /// Square root of the semi-major axis in sqrt(m) recovered with the 2^-19 LSB.
     pub sqrt_a: f64,
+    /// Ephemeris reference time in integer seconds of week from the 16-second field.
     pub toe: i64,
+    /// One-bit fit selector combined with IODE and IODC to derive the GPS fit interval.
     pub fit_interval_flag: i64,
+    /// Five-bit raw age-of-data offset recovered without conversion.
     pub aodo: i64,
+    /// Cosine correction in radians recovered with the 2^-29 LSB.
     pub cic: f64,
+    /// Longitude of the ascending node in semicircles recovered with the 2^-31 LSB.
     pub omega0: f64,
+    /// Sine correction in radians recovered with the 2^-29 LSB.
     pub cis: f64,
+    /// Inclination in semicircles recovered with the 2^-31 LSB.
     pub i0: f64,
+    /// Radial cosine correction in meters recovered with the 2^-5 LSB.
     pub crc: f64,
+    /// Argument of perigee in semicircles recovered with the 2^-31 LSB.
     pub omega: f64,
+    /// Rate of right ascension in semicircles per second recovered with the 2^-43 LSB.
     pub omega_dot: f64,
+    /// Inclination rate in semicircles per second recovered with the 2^-43 LSB.
     pub idot: f64,
 }
 

--- a/crates/sidereon-core/src/nmea/epoch.rs
+++ b/crates/sidereon-core/src/nmea/epoch.rs
@@ -9,33 +9,60 @@ use crate::format::{Diagnostics, Parsed, RecordRef, Warning, WarningKind};
 const RETAINED_CAP: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq)]
+/// One accumulated NMEA epoch, closed by an anchor-time, GSV-cycle, or sentence-budget boundary.
+/// Singleton sentence kinds retain their first body, while GSA and GSV data are accumulated in their respective entry and group vectors.
 pub struct EpochSnapshot {
+    /// Time from the first GGA, RMC, GLL, GST, or ZDA sentence in the epoch that carries one.
     pub time_of_day: Option<NmeaTime>,
+    /// The explicit RMC/ZDA date, or the date carried from [`NmeaAccumulator::with_date`] or an earlier dated sentence.
+    /// A differing explicit date replaces the prior value and records a mismatch warning; a backward transition over 12 hours advances the carried date for the next epoch.
     pub date: Option<NmeaDate>,
+    /// The first GGA body attached to the epoch; later GGA bodies are omitted and record a mismatch warning.
     pub gga: Option<Gga>,
+    /// The first RMC body attached to the epoch; later RMC bodies are omitted and record a mismatch warning.
     pub rmc: Option<Rmc>,
+    /// The first GLL body attached to the epoch; later GLL bodies are omitted and record a mismatch warning.
     pub gll: Option<Gll>,
+    /// The first GST body attached to the epoch; later GST bodies are omitted and record a mismatch warning.
     pub gst: Option<Gst>,
+    /// The first VTG body attached to the epoch; later VTG bodies are omitted and record a mismatch warning.
     pub vtg: Option<Vtg>,
+    /// The first ZDA body attached to the epoch; later ZDA bodies are omitted and record a mismatch warning.
     pub zda: Option<Zda>,
+    /// GSA bodies accumulated as [`GsaEntry`] values, with known systems deduplicated and unknown-system entries retained.
     pub gsa: Vec<GsaEntry>,
+    /// GSV pages accumulated as [`GsvGroup`] values, grouped by talker and optional signal.
     pub gsv: Vec<GsvGroup>,
+    /// Number of accepted sentences attached to the epoch, including duplicate bodies and sentences without a time.
     pub sentence_count: usize,
+    /// Assembly warnings for duplicate or inconsistent epoch data, GSV sequence/count errors, near-midnight backward time, and the sentence budget.
+    /// Parser skips and warnings are kept in [`NmeaChunkOutput::diagnostics`] instead.
     pub diagnostics: Diagnostics,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// One decoded GSA body together with the optional GNSS system context used to distinguish it within an [`EpochSnapshot`].
 pub struct GsaEntry {
+    /// The system copied from [`Gsa::system`], or None when parsing could not resolve a system context.
     pub system: Option<crate::GnssSystem>,
+    /// The cloned GSA body, including its sentence-order satellite list and optional DOP values.
     pub gsa: Gsa,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The accumulated GSV pages for one talker and optional signal within an [`EpochSnapshot`].
 pub struct GsvGroup {
+    /// The talker copied from the NMEA sentence carrying the GSV page.
     pub talker: NmeaTalker,
+    /// The optional signal copied from [`Gsv::signal`], used with `talker` to select the page group.
     pub signal: Option<NmeaSignalId>,
+    /// The first page’s optional claimed satellite count, replaced by the current page’s count after a sequence mismatch.
+    /// When the group completes, this value is compared with the number of listed satellite numbers.
     pub claimed_in_view: Option<u16>,
+    /// Satellite groups from the first page, extended in page order for an expected sequence or replaced after a sequence mismatch.
     pub satellites: Vec<GsvSatellite>,
+    /// Whether the latest attached page number equals its total page count.
+    /// A new page 1 for the same complete talker/signal group closes the current epoch before attachment.
     pub complete: bool,
 }
 
@@ -57,6 +84,8 @@ impl EpochSnapshot {
         }
     }
 
+    /// Returns a WGS-84 position using GGA first, then RMC, then GLL.
+    /// GGA requires both coordinates, MSL altitude, and geoid separation and converts their height sum to ellipsoidal height; RMC and GLL use zero height, and any missing required field or invalid WGS-84 construction returns `None`.
     pub fn position(&self) -> Option<crate::Wgs84Geodetic> {
         if let Some(gga) = &self.gga {
             let latitude = gga.latitude?;
@@ -82,6 +111,8 @@ impl EpochSnapshot {
         crate::Wgs84Geodetic::new(gll.latitude?.radians(), gll.longitude?.radians(), 0.0).ok()
     }
 
+    /// Converts the stored date and time to a UTC [`crate::astro::time::Instant`].
+    /// Nanoseconds are added to the whole seconds, and `None` is returned when either field is absent or the civil-time conversion rejects the values.
     pub fn instant_utc(&self) -> Option<crate::astro::time::Instant> {
         let date = self.date?;
         let time = self.time_of_day?;
@@ -97,24 +128,34 @@ impl EpochSnapshot {
         .ok()
     }
 
+    /// Returns the first position dilution of precision supplied by a GSA entry, in entry order.
+    /// Returns `None` when no GSA entry has a PDOP value.
     pub fn pdop(&self) -> Option<f64> {
         self.gsa.iter().find_map(|entry| entry.gsa.pdop)
     }
 
+    /// Returns the first horizontal dilution of precision supplied by a GSA entry, in entry order.
+    /// Returns `None` when no GSA entry has an HDOP value.
     pub fn hdop(&self) -> Option<f64> {
         self.gsa.iter().find_map(|entry| entry.gsa.hdop)
     }
 
+    /// Returns the first vertical dilution of precision supplied by a GSA entry, in entry order.
+    /// Returns `None` when no GSA entry has a VDOP value.
     pub fn vdop(&self) -> Option<f64> {
         self.gsa.iter().find_map(|entry| entry.gsa.vdop)
     }
 
+    /// Iterates over GSA satellite numbers in entry order and within each entry’s sentence order.
+    /// The iterator borrows the stored values and does not remove duplicates across entries.
     pub fn used_satellites(&self) -> impl Iterator<Item = &NmeaSatNumber> {
         self.gsa
             .iter()
             .flat_map(|entry| entry.gsa.satellites.iter())
     }
 
+    /// Counts unique `(resolved identity, raw number)` pairs listed by the GSV satellite groups.
+    /// Entries without a satellite number and the pages’ claimed counts are ignored.
     pub fn satellites_in_view(&self) -> usize {
         let mut seen = BTreeSet::new();
         for group in &self.gsv {
@@ -143,6 +184,8 @@ struct GsvProgress {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Streaming accumulator for one open NMEA epoch and the bytes waiting for a line terminator.
+/// It also carries dates across undated sentences, enforces a sentence budget, and numbers input lines for parser diagnostics.
 pub struct NmeaAccumulator {
     current: Option<OpenEpoch>,
     carried_date: Option<NmeaDate>,
@@ -159,6 +202,7 @@ impl Default for NmeaAccumulator {
 }
 
 impl NmeaAccumulator {
+    /// Creates an accumulator with no open epoch or carried date, a 256-sentence epoch limit, an empty byte remainder, and next line number 1.
     pub fn new() -> Self {
         Self {
             current: None,
@@ -170,6 +214,7 @@ impl NmeaAccumulator {
         }
     }
 
+    /// Creates the default accumulator with `date` available to epochs whose sentences do not carry a date.
     pub fn with_date(date: NmeaDate) -> Self {
         Self {
             carried_date: Some(date),
@@ -177,11 +222,14 @@ impl NmeaAccumulator {
         }
     }
 
+    /// Sets the per-epoch sentence budget, clamping values below 16 to 16.
     pub fn with_max_sentences_per_epoch(mut self, max: usize) -> Self {
         self.max_sentences_per_epoch = max.max(16);
         self
     }
 
+    /// Attaches one already parsed sentence and returns a snapshot when the prior epoch closes.
+    /// A close occurs when both time anchors differ, a completed GSV cycle restarts, or the sentence budget is reached; the incoming sentence is then attached to a newly opened epoch, and a budget close records a mismatch warning.
     pub fn push(&mut self, sentence: &NmeaSentence) -> Option<EpochSnapshot> {
         let incoming_time = sentence_time(sentence);
         let mut new_epoch_warning = false;
@@ -230,6 +278,8 @@ impl NmeaAccumulator {
         completed
     }
 
+    /// Buffers input until LF, CR, or CRLF, parses each complete line, and returns that chunk’s parsed sentences, completed snapshots, and line-numbered parser diagnostics.
+    /// If an unterminated buffer exceeds 1024 bytes, it is discarded and reported as a “sentence over length cap” skip.
     pub fn push_bytes(&mut self, chunk: &[u8]) -> NmeaChunkOutput {
         self.retained.extend_from_slice(chunk);
         let mut output = NmeaChunkOutput::default();
@@ -257,6 +307,8 @@ impl NmeaAccumulator {
         output
     }
 
+    /// Processes a nonempty unterminated remainder as one final line, then returns the final open snapshot, if any.
+    /// The temporary output produced while parsing that remainder is discarded, including any snapshot completed during that processing.
     pub fn finish(&mut self) -> Option<EpochSnapshot> {
         if !self.retained.is_empty() {
             let line = std::mem::take(&mut self.retained);
@@ -267,6 +319,7 @@ impl NmeaAccumulator {
         self.current.take().map(|epoch| epoch.snapshot)
     }
 
+    /// Returns the number of bytes currently buffered without a line terminator.
     pub fn retained_len(&self) -> usize {
         self.retained.len()
     }
@@ -594,8 +647,13 @@ fn push_line(
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
+/// Per-chunk results returned by [`NmeaAccumulator::push_bytes`].
+/// Completed snapshots and parsed sentences are kept separate from parser diagnostics, while epoch-assembly warnings remain on each snapshot.
 pub struct NmeaChunkOutput {
+    /// Snapshots completed while complete lines in the chunk were processed, in processing order; the still-open epoch is omitted.
     pub snapshots: Vec<EpochSnapshot>,
+    /// Successfully parsed sentences from complete lines in input order; skipped or still-buffered lines are omitted.
     pub sentences: Vec<NmeaSentence>,
+    /// Parser skips and warnings with one-based line references, including the retained-line length-cap skip.
     pub diagnostics: Diagnostics,
 }

--- a/crates/sidereon-core/src/nmea/fields.rs
+++ b/crates/sidereon-core/src/nmea/fields.rs
@@ -4,15 +4,24 @@ use crate::{GnssSatelliteId, GnssSystem, Wgs84Geodetic};
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An NMEA UTC time split into validated clock components and nanoseconds.
+/// The parser preserves the fractional digit count, which the GGA writer uses to enforce its two-decimal contract.
 pub struct NmeaTime {
+    /// The hour parsed from the first two digits; valid input limits it to 0 through 23.
     pub hour: u8,
+    /// The minute parsed from the middle two digits; valid input limits it to 0 through 59.
     pub minute: u8,
+    /// The whole second parsed from the final two digits; NMEA leap-second input may use 60.
     pub second: u8,
+    /// Nanoseconds obtained by scaling the fractional time token; epoch keys and UTC conversion consume this value.
     pub nanos: u32,
+    /// The number of fractional digits in the source token; GGA output requires this to be 2.
     pub decimals: u8,
 }
 
 impl NmeaTime {
+    /// Parses an NMEA time with six whole-time digits and up to nine fractional digits.
+    /// Empty, malformed, out-of-range, and over-precise tokens return the corresponding [`FieldError`].
     pub fn parse(token: &str) -> Result<Self, FieldError> {
         let token = token.trim();
         if token.is_empty() {
@@ -76,10 +85,13 @@ impl NmeaTime {
         })
     }
 
+    /// Returns the exact clock tuple used to compare epoch anchors, including fractional seconds.
     pub fn key(self) -> (u8, u8, u8, u32) {
         (self.hour, self.minute, self.second, self.nanos)
     }
 
+    /// Converts finite seconds of day in `[0, 86400)` to a time truncated to centiseconds.
+    /// The returned value always records two fractional digits for compatibility with GGA output.
     pub fn from_seconds_of_day_floor_centis(seconds: f64) -> Result<Self, crate::nmea::NmeaError> {
         if !seconds.is_finite() || !(0.0..86_400.0).contains(&seconds) {
             return Err(crate::nmea::NmeaError::InvalidInput {
@@ -101,14 +113,22 @@ impl NmeaTime {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An NMEA latitude or longitude retained as integer degrees and scaled minutes.
+/// The sign comes from the hemisphere or source decimal value and conversion to an epoch position uses WGS-84 radians.
 pub struct NmeaCoordinate {
+    /// The fixed-width degree component, bounded by 90 for latitude or 180 for longitude.
     pub degrees: u16,
+    /// Whole and fractional minutes multiplied by `10^decimals`, preserving the source precision.
     pub minutes_scaled: u64,
+    /// The number of fractional minute digits, limited to nine by the constructors.
     pub decimals: u8,
+    /// Whether the coordinate is south or west, or was supplied with a negative decimal sign.
     pub negative: bool,
 }
 
 impl NmeaCoordinate {
+    /// Parses an NMEA `ddmm.m...` or `dddmm.m...` coordinate with its hemisphere.
+    /// The parser enforces the latitude/longitude hemisphere pairing, minute bounds, and coordinate limit.
     pub fn parse(value: &str, hemisphere: &str, is_latitude: bool) -> Result<Self, FieldError> {
         let value = value.trim();
         let hemisphere = hemisphere.trim();
@@ -201,6 +221,8 @@ impl NmeaCoordinate {
         })
     }
 
+    /// Converts signed decimal degrees to rounded NMEA degrees and scaled minutes.
+    /// Minute rounding uses half-away-from-zero behavior and carries 60 rounded minutes into the next degree.
     pub fn from_degrees(
         degrees: f64,
         is_latitude: bool,
@@ -243,12 +265,14 @@ impl NmeaCoordinate {
         })
     }
 
+    /// Reconstructs signed decimal degrees from the stored degree/minute representation.
     pub fn degrees_f64(&self) -> f64 {
         let sign = if self.negative { -1.0 } else { 1.0 };
         let scale = 10_f64.powi(i32::from(self.decimals));
         sign * (f64::from(self.degrees) + (self.minutes_scaled as f64 / scale) / 60.0)
     }
 
+    /// Converts the reconstructed signed decimal degrees to radians for geodetic position construction.
     pub fn radians(&self) -> f64 {
         self.degrees_f64().to_radians()
     }
@@ -263,13 +287,18 @@ fn round_half_away_from_zero(value: f64) -> i64 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A validated civil date used by RMC/ZDA records and epoch date carry-forward.
 pub struct NmeaDate {
+    /// The validated calendar year, with RMC two-digit years expanded by [`NmeaDate::parse_rmc`].
     pub year: u16,
+    /// The validated calendar month used with the civil month-length table.
     pub month: u8,
+    /// The validated day within `month`; month and year rollover is handled by [`NmeaDate::next_day`].
     pub day: u8,
 }
 
 impl NmeaDate {
+    /// Parses an RMC `ddmmyy` date and applies the NMEA 80-year pivot before calendar validation.
     pub fn parse_rmc(token: &str) -> Result<Self, FieldError> {
         let token = token.trim();
         if token.len() != 6 || !token.bytes().all(|b| b.is_ascii_digit()) {
@@ -289,6 +318,7 @@ impl NmeaDate {
         Self::new(year, month, day)
     }
 
+    /// Constructs a date only when the month and day identify a valid civil calendar date.
     pub fn new(year: u16, month: u8, day: u8) -> Result<Self, FieldError> {
         let max_day = crate::astro::time::civil::days_in_month(i64::from(year), i64::from(month));
         if max_day == 0 || day == 0 || i64::from(day) > max_day {
@@ -302,6 +332,7 @@ impl NmeaDate {
         Ok(Self { year, month, day })
     }
 
+    /// Advances a valid date by one day, including month and December-to-January rollover.
     pub fn next_day(self) -> Self {
         let max_day =
             crate::astro::time::civil::days_in_month(i64::from(self.year), i64::from(self.month))
@@ -335,13 +366,19 @@ fn parse_u8(token: &str, field: &'static str) -> Result<u8, FieldError> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Classifies an NMEA two-byte talker prefix as a GNSS system, combined source, or raw address.
 pub enum NmeaTalker {
+    /// A recognized talker prefix carrying its corresponding [`GnssSystem`].
     System(GnssSystem),
+    /// The `GN` prefix, which combines multiple GNSS systems and has no single system context.
     Combined,
+    /// An unrecognized two-byte prefix retained as raw bytes for round-tripping when ASCII.
     Other([u8; 2]),
 }
 
 impl NmeaTalker {
+    /// Parses the known NMEA talker aliases and retains other two-byte tokens.
+    /// Tokens with any other length become `Other(*b"??")`.
     pub fn parse(token: &str) -> Self {
         match token.as_bytes() {
             b"GP" => Self::System(GnssSystem::Gps),
@@ -356,6 +393,8 @@ impl NmeaTalker {
         }
     }
 
+    /// Returns the canonical two-byte code used when writing a sentence.
+    /// Raw codes are accepted only when both bytes are ASCII; SBAS uses the GPS `GP` code.
     pub fn code(self) -> Result<[u8; 2], crate::nmea::NmeaError> {
         match self {
             Self::System(GnssSystem::Gps) | Self::System(GnssSystem::Sbas) => Ok(*b"GP"),
@@ -373,6 +412,7 @@ impl NmeaTalker {
         }
     }
 
+    /// Returns the embedded system for [`NmeaTalker::System`] and `None` for combined or raw talkers.
     pub fn system(self) -> Option<GnssSystem> {
         match self {
             Self::System(system) => Some(system),
@@ -382,20 +422,32 @@ impl NmeaTalker {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Decodes the numeric quality field carried by a GGA sentence.
 pub enum GgaQuality {
+    /// Quality code 0.
     Invalid,
+    /// Quality code 1.
     GpsSps,
+    /// Quality code 2.
     Differential,
+    /// Quality code 3.
     Pps,
+    /// Quality code 4.
     RtkFixed,
+    /// Quality code 5.
     RtkFloat,
+    /// Quality code 6.
     Estimated,
+    /// Quality code 7.
     Manual,
+    /// Quality code 8.
     Simulator,
+    /// A quality code other than 0 through 8, retained unchanged.
     Other(u8),
 }
 
 impl GgaQuality {
+    /// Parses a strict unsigned quality code, retaining unsupported values in [`GgaQuality::Other`].
     pub fn parse(token: &str) -> Result<Self, FieldError> {
         let value = validate::strict_int::<u8>(token, "gga quality")?;
         Ok(match value {
@@ -412,6 +464,7 @@ impl GgaQuality {
         })
     }
 
+    /// Returns the protocol byte represented by this quality value.
     pub fn value(self) -> u8 {
         match self {
             Self::Invalid => 0,
@@ -429,20 +482,34 @@ impl GgaQuality {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The optional fields decoded from a GGA fix sentence.
+/// Meter-tagged heights are kept separately so an epoch can combine MSL altitude with geoid separation.
 pub struct Gga {
+    /// The optional UTC time used to anchor an epoch.
     pub time: Option<NmeaTime>,
+    /// The optional latitude coordinate; writing requires it to be paired with [`Gga::longitude`].
     pub latitude: Option<NmeaCoordinate>,
+    /// The optional longitude coordinate; writing requires it to be paired with [`Gga::latitude`].
     pub longitude: Option<NmeaCoordinate>,
+    /// The optional decoded GGA quality code.
     pub quality: Option<GgaQuality>,
+    /// The optional number of satellites used, parsed in the inclusive range 0 through 99.
     pub satellites_used: Option<u8>,
+    /// The optional finite horizontal dilution of precision.
     pub hdop: Option<f64>,
+    /// The optional mean-sea-level altitude in meters, parsed with an `M` unit tag.
     pub altitude_msl_m: Option<f64>,
+    /// The optional geoid separation in meters, parsed with an `M` unit tag.
     pub geoid_separation_m: Option<f64>,
+    /// The optional differential-correction age in seconds.
     pub differential_age_s: Option<f64>,
+    /// The optional differential station identifier, parsed in the inclusive range 0 through 9999.
     pub differential_station_id: Option<u16>,
 }
 
 impl Gga {
+    /// Builds a GGA record from a WGS-84 position and fix metadata.
+    /// Coordinates are rounded at `coordinate_decimals`; the supplied ellipsoidal height is stored as MSL altitude, geoid separation is zero, and differential fields are absent.
     pub fn vrs_position(
         position: Wgs84Geodetic,
         time: NmeaTime,
@@ -481,18 +548,26 @@ impl Gga {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An NMEA satellite number together with its optional resolved GNSS identity.
 pub struct NmeaSatNumber {
+    /// The unsigned satellite number exactly as supplied in the NMEA field.
     pub raw: u16,
+    /// The GNSS system/PRN resolved from sentence context, when its numbering range is known.
     pub resolved: Option<GnssSatelliteId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An NMEA signal identifier paired with the talker-derived GNSS system context.
 pub struct NmeaSignalId {
+    /// The optional GNSS system used to interpret [`NmeaSignalId::id`].
     pub system: Option<GnssSystem>,
+    /// The numeric signal code parsed from the GSV signal field.
     pub id: u8,
 }
 
 impl NmeaSignalId {
+    /// Maps a known system and signal code to a [`CarrierBand`].
+    /// Missing system context and codes without a table entry return `None`.
     pub fn carrier_band(&self) -> Option<CarrierBand> {
         let system = self.system?;
         match system {
@@ -539,105 +614,176 @@ impl NmeaSignalId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Decodes the RMC/GLL status character while retaining unrecognized values.
 pub enum RmcStatus {
+    /// Status character `A`.
     Valid,
+    /// Status character `V`.
     Warning,
+    /// Any other nonempty status character.
     Other(char),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Decodes the GSA satellite-selection mode character.
 pub enum GsaSelectionMode {
+    /// Selection character `M`.
     Manual,
+    /// Selection character `A`.
     Automatic,
+    /// Any other nonempty selection character.
     Other(char),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Decodes the numeric GSA fix-mode field.
 pub enum GsaFixMode {
+    /// Fix-mode value 1.
     None,
+    /// Fix-mode value 2.
     TwoD,
+    /// Fix-mode value 3.
     ThreeD,
+    /// Any fix-mode value other than 1 through 3.
     Other(u8),
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The optional navigation and position fields decoded from an RMC sentence.
 pub struct Rmc {
+    /// The optional UTC time used as an epoch anchor.
     pub time: Option<NmeaTime>,
+    /// The optional status decoded from `A`, `V`, or another character.
     pub status: Option<RmcStatus>,
+    /// The optional latitude coordinate from the RMC value/hemisphere pair.
     pub latitude: Option<NmeaCoordinate>,
+    /// The optional longitude coordinate from the RMC value/hemisphere pair.
     pub longitude: Option<NmeaCoordinate>,
+    /// The optional speed over ground in knots.
     pub speed_over_ground_kn: Option<f64>,
+    /// The optional course over ground in degrees.
     pub course_over_ground_deg: Option<f64>,
+    /// The optional date from the RMC `ddmmyy` field.
     pub date: Option<NmeaDate>,
+    /// The optional magnetic variation in degrees after applying the parser's negative multiplier for direction `W`.
     pub magnetic_variation_deg: Option<f64>,
+    /// The optional single-character FAA mode.
     pub faa_mode: Option<char>,
+    /// The optional single-character navigational status.
     pub navigational_status: Option<char>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The fields decoded from a GSA satellite-selection and dilution record.
 pub struct Gsa {
+    /// The optional manual/automatic selection mode.
     pub selection_mode: Option<GsaSelectionMode>,
+    /// The optional numeric fix mode.
     pub fix_mode: Option<GsaFixMode>,
+    /// Nonempty satellite fields, retained in their sentence order.
     pub satellites: Vec<NmeaSatNumber>,
+    /// The optional position dilution of precision.
     pub pdop: Option<f64>,
+    /// The optional horizontal dilution of precision.
     pub hdop: Option<f64>,
+    /// The optional vertical dilution of precision.
     pub vdop: Option<f64>,
+    /// The optional numeric GNSS system identifier from the sentence.
     pub system_id: Option<u8>,
+    /// The optional system context used to resolve the satellite numbers.
     pub system: Option<GnssSystem>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// One four-field satellite group decoded from a GSV page.
 pub struct GsvSatellite {
+    /// The optional satellite number and resolved identity.
     pub sat_number: Option<NmeaSatNumber>,
+    /// The optional elevation in degrees, accepted from -90 through 90.
     pub elevation_deg: Option<i16>,
+    /// The optional azimuth in degrees, accepted from 0 through 359.
     pub azimuth_deg: Option<u16>,
+    /// The optional carrier-to-noise density ratio in dB-Hz, accepted from 0 through 99.
     pub cn0_db_hz: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// One GSV page and its decoded satellite groups.
+/// The epoch accumulator uses the page count, number, talker, and signal to combine a multi-page view.
 pub struct Gsv {
+    /// The required total page count, accepted from 1 through 15.
     pub total_messages: u8,
+    /// The required page number, accepted from 1 through [`Gsv::total_messages`].
     pub message_number: u8,
+    /// The optional claimed number of satellites in view, accepted from 0 through 999.
     pub satellites_in_view: Option<u16>,
+    /// Satellite groups in their page order, including groups with absent individual fields.
     pub satellites: Vec<GsvSatellite>,
+    /// The optional trailing signal identifier when the page has one signal field.
     pub signal: Option<NmeaSignalId>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The optional error statistics decoded from a GST sentence.
 pub struct Gst {
+    /// The optional UTC time used as an epoch anchor.
     pub time: Option<NmeaTime>,
+    /// The optional RMS range residual in meters.
     pub rms_range_residual_m: Option<f64>,
+    /// The optional semi-major position error in meters.
     pub semi_major_error_m: Option<f64>,
+    /// The optional semi-minor position error in meters.
     pub semi_minor_error_m: Option<f64>,
+    /// The optional error-ellipse orientation in degrees.
     pub orientation_deg: Option<f64>,
+    /// The optional latitude standard deviation in meters.
     pub latitude_sigma_m: Option<f64>,
+    /// The optional longitude standard deviation in meters.
     pub longitude_sigma_m: Option<f64>,
+    /// The optional altitude standard deviation in meters.
     pub altitude_sigma_m: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The optional course, speed, and FAA fields decoded from a VTG sentence.
 pub struct Vtg {
+    /// The optional true course in degrees, paired with a `T` unit tag.
     pub course_true_deg: Option<f64>,
+    /// The optional magnetic course in degrees, paired with an `M` unit tag.
     pub course_magnetic_deg: Option<f64>,
+    /// The optional speed in knots, paired with an `N` unit tag.
     pub speed_kn: Option<f64>,
+    /// The optional speed in kilometers per hour, paired with a `K` unit tag.
     pub speed_kmh: Option<f64>,
+    /// The optional single-character FAA mode.
     pub faa_mode: Option<char>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The optional position, time, status, and FAA fields decoded from a GLL sentence.
 pub struct Gll {
+    /// The optional latitude coordinate from the GLL value/hemisphere pair.
     pub latitude: Option<NmeaCoordinate>,
+    /// The optional longitude coordinate from the GLL value/hemisphere pair.
     pub longitude: Option<NmeaCoordinate>,
+    /// The optional UTC time used as an epoch anchor.
     pub time: Option<NmeaTime>,
+    /// The optional status decoded with the RMC `A`/`V`/other mapping.
     pub status: Option<RmcStatus>,
+    /// The optional single-character FAA mode.
     pub faa_mode: Option<char>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// The UTC time, civil date, and local offset fields decoded from a ZDA sentence.
 pub struct Zda {
+    /// The optional UTC time used as an epoch anchor.
     pub time: Option<NmeaTime>,
+    /// The optional date, present only when all day/month/year fields are present and valid.
     pub date: Option<NmeaDate>,
+    /// The optional local time-zone hour offset, accepted from -13 through 13.
     pub local_zone_hours: Option<i8>,
+    /// The optional local time-zone minute offset, accepted from 0 through 59.
     pub local_zone_minutes: Option<u8>,
 }
 

--- a/crates/sidereon-core/src/nmea/sentence.rs
+++ b/crates/sidereon-core/src/nmea/sentence.rs
@@ -9,20 +9,32 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
+/// A decoded sentence returned by [`crate::nmea::parse_sentence`], combining the parsed address prefix with the payload parser selected by the address suffix.
 pub struct NmeaSentence {
+    /// The address prefix parsed by [`NmeaTalker::parse`]. [`crate::nmea::NmeaAccumulator`] uses it to distinguish GSV groups.
     pub talker: NmeaTalker,
+    /// The typed payload selected by the sentence's three-letter address suffix. [`crate::nmea::NmeaAccumulator`] dispatches it to the corresponding epoch record.
     pub body: NmeaBody,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Parsed payloads for the sentence types handled by [`crate::nmea::parse_sentence`]: GGA, RMC, GSA, GSV, GST, VTG, GLL, and ZDA.
 pub enum NmeaBody {
+    /// The GGA payload produced by `parse_gga`; [`crate::nmea::NmeaAccumulator`] retains the first value in [`crate::nmea::EpochSnapshot::gga`], and [`crate::nmea::write_gga`] serializes a [`Gga`] value as GGA.
     Gga(Gga),
+    /// The RMC payload produced by `parse_rmc`; [`crate::nmea::NmeaAccumulator`] retains the first value, and the accumulator uses its time and date for epoch metadata.
     Rmc(Rmc),
+    /// The GSA payload produced by `parse_gsa`; [`crate::nmea::NmeaAccumulator`] stores one [`crate::nmea::GsaEntry`] per system and warns on duplicate or differing DOP data.
     Gsa(Gsa),
+    /// The GSV payload produced by `parse_gsv`; [`crate::nmea::NmeaAccumulator`] groups messages by talker and signal, then extends satellites in message order.
     Gsv(Gsv),
+    /// The GST payload produced by `parse_gst`; [`crate::nmea::NmeaAccumulator`] retains the first value and uses its time as an epoch anchor.
     Gst(Gst),
+    /// The VTG payload produced by `parse_vtg`; [`crate::nmea::NmeaAccumulator`] retains the first value, but the accumulator does not use VTG as a timestamp source.
     Vtg(Vtg),
+    /// The GLL payload produced by `parse_gll`; [`crate::nmea::NmeaAccumulator`] retains the first value and uses its time as an epoch anchor.
     Gll(Gll),
+    /// The ZDA payload produced by `parse_zda`; [`crate::nmea::NmeaAccumulator`] retains the first value and uses its time and date for epoch metadata.
     Zda(Zda),
 }
 

--- a/crates/sidereon-core/src/ntrip/chunk.rs
+++ b/crates/sidereon-core/src/ntrip/chunk.rs
@@ -5,6 +5,9 @@ const MAX_LINE: usize = 8 * 1024;
 const MAX_HEX_DIGITS: usize = 8;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Incremental decoder for an HTTP chunked response body.
+///
+/// It returns data bytes as complete chunks become available, including when size lines or data span multiple [`Self::push`] calls. It accepts optional chunk extensions, LF or CRLF data terminators, and trailer lines after the zero-size chunk; lines longer than 8 KiB, size fields with more than 8 hexadecimal digits, chunks larger than 16 MiB, and oversized trailer sections produce a parse error.
 pub struct ChunkedDecoder {
     buf: Vec<u8>,
     state: ChunkState,
@@ -28,6 +31,9 @@ impl Default for ChunkedDecoder {
 }
 
 impl ChunkedDecoder {
+    /// Creates an empty decoder ready to read a chunk-size line.
+    ///
+    /// The input buffer, completion flag, stored parse error, and trailer length start empty, false, absent, and zero, respectively.
     pub fn new() -> Self {
         Self {
             buf: Vec::new(),
@@ -38,6 +44,9 @@ impl ChunkedDecoder {
         }
     }
 
+    /// Feeds one fragment of a chunked response body and returns decoded data bytes.
+    ///
+    /// The fragment may end in the middle of a size line, chunk body, data terminator, or trailer; those bytes remain buffered. After the zero-size chunk and its terminating empty trailer line are consumed, later calls return an empty vector; malformed input returns [`Error::Parse`], and later calls return the same stored parse error.
     pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<u8>> {
         if let Some(message) = &self.poison {
             return Err(Error::Parse(message.clone()));
@@ -117,10 +126,16 @@ impl ChunkedDecoder {
         Ok(out)
     }
 
+    /// Reports whether the zero-size chunk and terminating empty trailer line have been consumed.
+    ///
+    /// [`crate::ntrip::NtripClientMachine`] uses this result to emit `StreamEnded` for a data response or finish a chunked sourcetable.
     pub fn finished(&self) -> bool {
         self.finished
     }
 
+    /// Discards buffered response bytes and returns the decoder to the initial state.
+    ///
+    /// This clears completion, trailer length, and any stored parse error, matching [`Self::new`].
     pub fn reset(&mut self) {
         *self = Self::new();
     }

--- a/crates/sidereon-core/src/ntrip/gga.rs
+++ b/crates/sidereon-core/src/ntrip/gga.rs
@@ -2,12 +2,21 @@ use crate::nmea::{self, Gga, GgaQuality, NmeaTalker, NmeaTime};
 use crate::{Error, Result, Wgs84Geodetic};
 
 #[derive(Clone, Debug, PartialEq)]
+/// Position and receiver metadata consumed by [`format_gga`].
+///
+/// `Default::default` supplies a zero-degree, zero-height position with fix quality 1, 10 satellites, and HDOP 1.0.
 pub struct GgaPosition {
+    /// WGS84 geodetic latitude in degrees. [`format_gga`] accepts only finite values in `[-90, 90]` and converts it to radians before GGA coordinate formatting.
     pub lat_deg: f64,
+    /// WGS84 geodetic longitude in degrees, positive east. [`format_gga`] accepts only finite values in `[-180, 180]` and converts it to radians before GGA coordinate formatting.
     pub lon_deg: f64,
+    /// Height passed to [`crate::Wgs84Geodetic::new`] and then to the GGA altitude field. [`format_gga`] requires it finite; the writer emits it in meters with one decimal place and an `M` unit marker.
     pub height_m: f64,
+    /// Numeric NMEA GGA fix-quality code. [`format_gga`] maps 0 through 8 to the corresponding [`crate::nmea::GgaQuality`] variant and preserves any other `u8` as `Other(value)` before writing it.
     pub fix_quality: u8,
+    /// Number passed to GGA's satellites-used field. [`format_gga`] does not otherwise constrain it, and the NMEA writer emits it zero-padded to two digits.
     pub num_satellites: u8,
+    /// Horizontal dilution of precision passed into GGA. [`format_gga`] requires a finite, non-negative value, and the NMEA writer emits it with two fractional digits.
     pub hdop: f64,
 }
 
@@ -24,6 +33,11 @@ impl Default for GgaPosition {
     }
 }
 
+/// Formats `position` and `utc_seconds_of_day` as a GPS NMEA GGA sentence and returns its UTF-8 bytes.
+///
+/// The formatter converts the degree coordinates to a WGS84 geodetic position, floors the time to centiseconds, maps the numeric fix-quality code, uses seven coordinate decimals, and omits geoid separation before writing the sentence.
+///
+/// It returns [`crate::Error::InvalidInput`] when the coordinates, height, HDOP, or time are non-finite, when latitude or longitude is outside its accepted interval, when HDOP is negative, or when the time is outside `[0, 86400)`; errors from geodetic construction, GGA construction, and sentence writing are mapped to the same variant.
 pub fn format_gga(position: &GgaPosition, utc_seconds_of_day: f64) -> Result<Vec<u8>> {
     validate(position, utc_seconds_of_day)?;
     let geodetic = Wgs84Geodetic::new(

--- a/crates/sidereon-core/src/ntrip/machine.rs
+++ b/crates/sidereon-core/src/ntrip/machine.rs
@@ -11,33 +11,59 @@ const MAX_SOURCETABLE: usize = 4 * 1024 * 1024;
 const PREFIX_LIMIT: usize = 256;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Lifecycle states used by [`NtripClientMachine`] while it parses a caster response.
+/// An instance starts in [`NtripState::Idle`], may wait for a status and HTTP headers, and ends in [`NtripState::Closed`] after rejection or completion.
 pub enum NtripState {
+    /// The initial state from [`NtripClientMachine::new`]; the first [`NtripClientMachine::push`] call changes it to [`NtripState::AwaitingStatus`] before parsing input.
     Idle,
+    /// The machine is collecting a line for an `ERROR`, `ICY`, `SOURCETABLE`, or `HTTP/1.0`/`HTTP/1.1` status.
+    /// A malformed or oversized line emits [`NtripEvent::Rejected`] and closes the machine.
     AwaitingStatus,
+    /// An HTTP status has been parsed, so subsequent CRLF-terminated lines are collected until a blank line selects a response class.
+    /// A header block larger than 64 KiB emits [`NtripEvent::Rejected`].
     AwaitingHeaders,
+    /// A data response has been accepted; [`NtripClientMachine::push`] emits payload bytes and dechunks them when required.
+    /// A chunked body closes the machine after decoder completion or failure.
     Streaming,
+    /// A sourcetable response has been accepted and its body is being collected for [`Sourcetable`](crate::ntrip::Sourcetable) parsing.
+    /// The machine closes after the terminator, chunked-body completion, or [`NtripClientMachine::finish`].
     Sourcetable,
+    /// A rejection or terminal response condition has occurred; subsequent [`NtripClientMachine::push`] calls return no events.
     Closed,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Connection metadata emitted by [`NtripEvent::Connected`] after a data response is accepted.
+/// It records the response revision, transfer encoding, and HTTP headers used by the parser.
 pub struct NtripHandshake {
+    /// The revision inferred from the response status: ICY and HTTP/1.0 produce [`NtripVersion::Rev1`], while HTTP/1.1 produces [`NtripVersion::Rev2`].
     pub version: NtripVersion,
+    /// Whether the HTTP response uses a case-insensitive `chunked` token in `Transfer-Encoding`; ICY responses always set this to `false`.
     pub chunked: bool,
+    /// HTTP header pairs in input order, with names trimmed and exactly one leading ASCII space removed from values; ICY responses provide an empty vector.
     pub headers: Vec<(String, String)>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Notifications produced while [`NtripClientMachine`] consumes a response or finishes a sourcetable at EOF.
 pub enum NtripEvent {
+    /// Emitted for ICY 200 and for HTTP 200 responses classified as GNSS data, before payload from the same input.
     Connected(NtripHandshake),
+    /// Bytes available to downstream consumers; chunked HTTP bodies are dechunked, and empty decoder output is omitted.
     Payload(Vec<u8>),
+    /// The accumulated sourcetable after [`parse_sourcetable`] succeeds at its terminator or through the finish-at-EOF path.
     Sourcetable(Sourcetable),
+    /// A status, response classification, or malformed/oversized handshake input was rejected; emitting this event closes the machine.
     Rejected(NtripRejection),
+    /// A chunked-body decoder or sourcetable parser failed; emitting this event closes the machine.
     StreamCorrupted { detail: String },
+    /// A chunked data body reached its zero-size chunk and trailer terminator; the machine becomes closed after this event.
     StreamEnded,
 }
 
 #[derive(Clone, Debug)]
+/// Stateful parser for one NTRIP response.
+/// It buffers incomplete status, header, sourcetable, and chunk records across [`Self::push`] calls and emits [`NtripEvent`] values as complete input becomes available.
 pub struct NtripClientMachine {
     config: NtripConfig,
     state: NtripState,
@@ -58,6 +84,8 @@ pub struct NtripClientMachine {
 }
 
 impl NtripClientMachine {
+    /// Creates an idle machine retaining `config` for request generation and optional GGA pacing.
+    /// Response buffers, the chunk decoder, and the prior-GGA timestamp all start empty.
     pub fn new(config: NtripConfig) -> Self {
         Self {
             config,
@@ -79,12 +107,16 @@ impl NtripClientMachine {
         }
     }
 
+    /// Serializes the retained [`NtripConfig`] and moves the machine to [`NtripState::AwaitingStatus`] after serialization succeeds.
+    /// Configuration errors are returned without changing the current state.
     pub fn connection_request(&mut self) -> Result<Vec<u8>> {
         let bytes = self.config.request_bytes()?;
         self.state = NtripState::AwaitingStatus;
         Ok(bytes)
     }
 
+    /// Feeds a response fragment to the parser and returns events in processing order.
+    /// Incomplete records remain buffered for later calls, while calls made after [`NtripState::Closed`] return no events and consume no input.
     pub fn push(&mut self, bytes: &[u8]) -> Vec<NtripEvent> {
         let mut events = Vec::new();
         if matches!(self.state, NtripState::Closed) {
@@ -123,6 +155,8 @@ impl NtripClientMachine {
         events
     }
 
+    /// Returns a due GGA sentence while streaming, converting errors from [`Self::try_gga_message`] into `None`.
+    /// Use [`Self::try_gga_message`] when the caller must distinguish an invalid position or time from a message that is not yet due.
     pub fn gga_message(
         &mut self,
         now_s: f64,
@@ -134,6 +168,8 @@ impl NtripClientMachine {
             .flatten()
     }
 
+    /// Attempts to produce a paced GGA sentence for the active stream.
+    /// It returns `Ok(None)` unless the machine is streaming, an interval is configured, `now_s` is finite, and the first or sufficiently delayed non-backwards call is due; formatter errors propagate, and a successful message records `now_s`.
     pub fn try_gga_message(
         &mut self,
         now_s: f64,
@@ -162,10 +198,12 @@ impl NtripClientMachine {
         Ok(Some(bytes))
     }
 
+    /// Returns the current parser state without changing buffered input or other machine state.
     pub fn state(&self) -> NtripState {
         self.state
     }
 
+    /// Restarts parsing with the same [`NtripConfig`] by replacing all parser and GGA pacing state with fresh state.
     pub fn reset(&mut self) {
         let config = self.config.clone();
         *self = Self::new(config);
@@ -353,6 +391,8 @@ impl NtripClientMachine {
         }
     }
 
+    /// Completes a sourcetable response at EOF.
+    /// In [`NtripState::Sourcetable`], a final unterminated buffered line is submitted, the accumulated text is parsed, [`NtripEvent::Sourcetable`] or [`NtripEvent::StreamCorrupted`] is emitted, and the machine closes; other states produce no events.
     pub fn finish(&mut self) -> Vec<NtripEvent> {
         let mut events = Vec::new();
         if self.state == NtripState::Sourcetable {

--- a/crates/sidereon-core/src/ntrip/request.rs
+++ b/crates/sidereon-core/src/ntrip/request.rs
@@ -1,25 +1,50 @@
 use crate::{Error, Result};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Selects the request and response revision used by the NTRIP client.
+/// Request construction maps the variants to HTTP/1.0 and HTTP/1.1, while response parsing maps ICY and HTTP/1.0 to [`NtripVersion::Rev1`] and HTTP/1.1 to [`NtripVersion::Rev2`].
 pub enum NtripVersion {
+    /// Produces an HTTP/1.0 request and is reported for ICY or HTTP/1.0 responses.
     Rev1,
+    /// Produces an HTTP/1.1 request with the Rev2-only request headers and is reported for HTTP/1.1 responses.
     Rev2,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Credentials encoded into the `Basic` authorization header of an NTRIP request.
+/// The request builder joins the two values with `:`, Base64-encodes the result, and rejects a username containing `:` or either value containing CR/LF.
 pub struct NtripCredentials {
+    /// Text placed before `:` when the request builder constructs the encoded authorization value.
+    /// This value must not contain `:` or CR/LF.
     pub username: String,
+    /// Text placed after `:` when the request builder constructs the encoded authorization value.
+    /// CR/LF in this value is rejected.
     pub password: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Inputs retained by the NTRIP client machine for request construction and optional GGA pacing.
+/// The default uses port 2101 and [`NtripVersion::Rev2`], leaves the host and mountpoint empty, uses `sidereon/<package version>` as the product, and disables credentials and GGA pacing.
 pub struct NtripConfig {
+    /// Caster host text, paired with [`NtripConfig::port`] in the Rev2 `Host` header.
+    /// CR/LF in this value causes request validation to fail.
     pub host: String,
+    /// Caster port rendered in decimal after [`NtripConfig::host`] in the Rev2 `Host` header.
+    /// Rev1 request headers do not use this value.
     pub port: u16,
+    /// Mountpoint appended to the request path; an empty value produces `/`.
+    /// ASCII controls, ASCII whitespace, `/`, and `?` in this value cause request validation to fail.
     pub mountpoint: String,
+    /// Request revision selected by the request builder and retained by the client machine.
     pub version: NtripVersion,
+    /// Optional credentials that add a Base64 `Basic` authorization header when present.
+    /// Invalid username punctuation or CR/LF in either credential causes request construction to fail.
     pub credentials: Option<NtripCredentials>,
+    /// Product text placed after `NTRIP ` in the `User-Agent` header.
+    /// It must be nonempty, contain exactly one `/`, and contain no ASCII control or whitespace byte.
     pub user_agent_product: String,
+    /// Optional positive, finite interval in seconds used to pace GGA messages while streaming.
+    /// `None` disables GGA output; with `Some`, the first message is immediately due and later messages require at least this interval since the last one.
     pub gga_interval_s: Option<f64>,
 }
 
@@ -38,6 +63,8 @@ impl Default for NtripConfig {
 }
 
 impl NtripConfig {
+    /// Validates this configuration and returns the complete CRLF-terminated GET request.
+    /// The request uses HTTP/1.0 and Rev1 headers for [`NtripVersion::Rev1`] or HTTP/1.1 and Rev2 headers for [`NtripVersion::Rev2`], followed by a final blank line; invalid configuration returns an error.
     pub fn request_bytes(&self) -> Result<Vec<u8>> {
         let path = self.validated_path()?;
         let headers = self.common_headers()?;
@@ -60,6 +87,8 @@ impl NtripConfig {
         Ok(out)
     }
 
+    /// Returns the validated request path and header pairs for an NTRIP Rev2 request.
+    /// Rev1 returns an invalid-input error because this helper is only defined for [`NtripVersion::Rev2`].
     pub fn request_headers(&self) -> Result<(String, Vec<(String, String)>)> {
         if self.version != NtripVersion::Rev2 {
             return Err(Error::InvalidInput(

--- a/crates/sidereon-core/src/ntrip/response.rs
+++ b/crates/sidereon-core/src/ntrip/response.rs
@@ -1,21 +1,69 @@
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Rejection outcomes produced while interpreting an NTRIP response.
 pub enum NtripRejection {
+    /// `NtripClientMachine` emits this for a password-related `ERROR -` reason or an HTTP 401
+    /// whose challenges are absent or include a non-Digest scheme.
     Unauthorized,
+    /// [`classify_http_response`] returns this for HTTP status 404.
     MountpointNotFound,
+    /// [`classify_http_response`] returns this for HTTP 401 when at least one challenge is
+    /// present and every detected scheme is Digest.
     DigestRequired,
-    CasterError { reason: String },
-    UnexpectedContentType { content_type: String },
-    HttpError { status: u16, reason: String },
-    MalformedHandshake { prefix: Vec<u8> },
+    /// The caster returned an `ERROR -` line that did not identify a password failure.
+    CasterError {
+        /// Text returned after the `ERROR - ` prefix.
+        reason: String,
+    },
+    /// A successful response used a media type this client does not accept.
+    UnexpectedContentType {
+        /// The normalized media type from the first `Content-Type` header.
+        content_type: String,
+    },
+    /// The machine received a non-200 ICY or SOURCETABLE status, or an HTTP status other than
+    /// 200, 401, and 404.
+    HttpError {
+        /// Numeric status parsed from the response status line.
+        status: u16,
+        /// Trimmed reason phrase parsed from the response status line.
+        reason: String,
+    },
+    /// The status line was unrecognized, or a handshake, header block, or sourcetable input
+    /// exceeded its byte limit.
+    MalformedHandshake {
+        /// Up to 256 bytes retained from the malformed or overlong handshake input.
+        prefix: Vec<u8>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Result returned after the response status and headers are classified by
+/// [`classify_http_response`].
 pub enum HttpClassification {
-    Stream { chunked: bool },
-    Sourcetable { chunked: bool },
+    /// A `gnss/data` response, or a response without `Content-Type`, carries stream payloads.
+    Stream {
+        /// Whether the body uses a comma-separated `Transfer-Encoding: chunked` token.
+        chunked: bool,
+    },
+    /// HTTP 200 with normalized media type `gnss/sourcetable` carries sourcetable text.
+    Sourcetable {
+        /// Whether the body uses a comma-separated `Transfer-Encoding: chunked` token.
+        chunked: bool,
+    },
+    /// The response must be closed with the given [`NtripRejection`].
     Rejection(NtripRejection),
 }
 
+/// Classifies an HTTP NTRIP response from its status, reason phrase, and headers.
+///
+/// HTTP 401 becomes [`NtripRejection::DigestRequired`] when at least one
+/// `WWW-Authenticate` scheme is present and every scheme is Digest; otherwise it
+/// becomes [`NtripRejection::Unauthorized`]. HTTP 404 becomes
+/// [`NtripRejection::MountpointNotFound`], and other non-200 statuses become
+/// [`NtripRejection::HttpError`]. A 200 response is a [`HttpClassification::Stream`]
+/// for no media type or `gnss/data`, a [`HttpClassification::Sourcetable`] for
+/// `gnss/sourcetable`, and an [`NtripRejection::UnexpectedContentType`] otherwise.
+/// The stream and sourcetable variants report whether a comma-separated
+/// `Transfer-Encoding` token is `chunked`, without regard to ASCII case.
 pub fn classify_http_response(
     status: u16,
     reason: &str,

--- a/crates/sidereon-core/src/ntrip/sourcetable.rs
+++ b/crates/sidereon-core/src/ntrip/sourcetable.rs
@@ -1,13 +1,19 @@
 use crate::{Error, Result};
 
 #[derive(Clone, Debug, PartialEq)]
+/// A sourcetable token that may be typed, blank, or preserved as source text.
+/// The parsers use [`Parsed`](Field::Parsed) for accepted values, [`Empty`](Field::Empty) for blank tokens, and [`Raw`](Field::Raw) when conversion fails; retaining `Raw` lets the serializer reproduce an otherwise unknown token.
 pub enum Field<T> {
+    /// A source token converted by the parser into `T`.
     Parsed(T),
+    /// A source token that was empty.
     Empty,
+    /// A non-empty source token that the parser could not convert into `T`.
     Raw(String),
 }
 
 impl<T> Field<T> {
+    /// Returns the parsed value, or `None` for [`Empty`](Field::Empty) and [`Raw`](Field::Raw).
     pub fn value(&self) -> Option<&T> {
         match self {
             Field::Parsed(value) => Some(value),
@@ -17,81 +23,144 @@ impl<T> Field<T> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Authentication markers used by [`StrRecord`] and [`NetRecord`] records.
+/// Parsing recognizes only the exact one-letter tokens `N`, `B`, and `D`; other tokens are retained in [`Other`](StrAuth::Other).
 pub enum StrAuth {
+    /// No authentication, serialized as `N`.
     None,
+    /// Basic authentication, serialized as `B`.
     Basic,
+    /// Digest authentication, serialized as `D`.
     Digest,
+    /// An authentication token other than `N`, `B`, or `D`.
     Other(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// A parsed NTRIP sourcetable, retaining records in their input order.
+/// [`Sourcetable::to_text`] writes those records in the same order and appends the protocol terminator.
 pub struct Sourcetable {
+    /// Records encountered before the sourcetable terminator, in input order.
     pub records: Vec<SourcetableRecord>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// One typed or unrecognized record from a sourcetable.
 pub enum SourcetableRecord {
+    /// A stream record with the STR field layout.
     Str(StrRecord),
+    /// A caster record with the CAS field layout.
     Cas(CasRecord),
+    /// A network record with the NET field layout.
     Net(NetRecord),
+    /// An unrecognized record retained without typed-field conversion.
     Other(OtherRecord),
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// An NTRIP STR stream record.
+/// `parse_sourcetable` maps the 18 semicolon-delimited fields after `STR` to these members, and serialization emits them in that same order.
 pub struct StrRecord {
+    /// The stream mountpoint from STR position 1; semicolons and line breaks are rejected when the record is serialized.
     pub mountpoint: String,
+    /// The stream identifier from STR position 2; semicolons and line breaks are rejected when the record is serialized.
     pub identifier: String,
+    /// The advertised data-format label from STR position 3; semicolons and line breaks are rejected when serialized.
     pub format: String,
+    /// Format-specific details from STR position 4; semicolons and line breaks are rejected when serialized.
     pub format_details: String,
+    /// The carrier indicator from STR position 5, parsed as `u8` when possible and otherwise retained as a [`Field`] variant.
     pub carrier: Field<u8>,
+    /// The supported navigation-system token from STR position 6; semicolons and line breaks are rejected when serialized.
     pub nav_system: String,
+    /// The network name from STR position 7; semicolons and line breaks are rejected when serialized.
     pub network: String,
+    /// The country token from STR position 8; semicolons and line breaks are rejected when serialized.
     pub country: String,
+    /// The latitude in decimal degrees from STR position 9; blank, invalid, and non-finite tokens remain [`Field::Raw`].
     pub lat_deg: Field<f64>,
+    /// The longitude in decimal degrees from STR position 10; blank, invalid, and non-finite tokens remain [`Field::Raw`].
     pub lon_deg: Field<f64>,
+    /// Whether NMEA is required, parsed from exact `0`/`1` tokens in STR position 11 and serialized with the same codes.
     pub nmea_required: Field<bool>,
+    /// Whether a network solution is available, parsed from exact `0`/`1` tokens in STR position 12 and serialized with the same codes.
     pub network_solution: Field<bool>,
+    /// The generator name from STR position 13; semicolons and line breaks are rejected when serialized.
     pub generator: String,
+    /// The compression description from STR position 14; semicolons and line breaks are rejected when serialized.
     pub compression: String,
+    /// The STR authentication marker from position 15, parsed into [`StrAuth`] using the exact `N`, `B`, and `D` codes.
     pub authentication: StrAuth,
+    /// Whether the stream has a fee, parsed from exact `N`/`Y` tokens in STR position 16 and serialized with the same codes.
     pub fee: Field<bool>,
+    /// The advertised bit rate from STR position 17, parsed as `u32` when possible and otherwise retained as a [`Field`] variant.
     pub bitrate: Field<u32>,
+    /// All STR tokens from position 18 onward, joined with semicolons so trailing fields survive a parse/render round trip.
     pub misc: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// An NTRIP CAS caster record.
+/// `parse_sourcetable` maps the 11 semicolon-delimited fields after `CAS` to these members, and serialization emits them in that same order.
 pub struct CasRecord {
+    /// The caster host from CAS position 1; semicolons and line breaks are rejected when serialized.
     pub host: String,
+    /// The caster port from CAS position 2, parsed as `u16` when possible and otherwise retained as a [`Field`] variant.
     pub port: Field<u16>,
+    /// The caster identifier from CAS position 3; semicolons and line breaks are rejected when serialized.
     pub identifier: String,
+    /// The operator name from CAS position 4; semicolons and line breaks are rejected when serialized.
     pub operator: String,
+    /// Whether NMEA is required, parsed from exact `0`/`1` tokens in CAS position 5 and serialized with the same codes.
     pub nmea_required: Field<bool>,
+    /// The country token from CAS position 6; semicolons and line breaks are rejected when serialized.
     pub country: String,
+    /// The latitude in decimal degrees from CAS position 7; blank, invalid, and non-finite tokens remain [`Field::Raw`].
     pub lat_deg: Field<f64>,
+    /// The longitude in decimal degrees from CAS position 8; blank, invalid, and non-finite tokens remain [`Field::Raw`].
     pub lon_deg: Field<f64>,
+    /// The fallback caster host from CAS position 9; semicolons and line breaks are rejected when serialized.
     pub fallback_host: String,
+    /// The fallback caster port from CAS position 10, parsed as `u16` when possible and otherwise retained as a [`Field`] variant.
     pub fallback_port: Field<u16>,
+    /// All CAS tokens from position 11 onward, joined with semicolons so trailing fields survive a parse/render round trip.
     pub misc: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// An NTRIP NET network record.
+/// `parse_sourcetable` maps the 8 semicolon-delimited fields after `NET` to these members, and serialization emits them in that same order.
 pub struct NetRecord {
+    /// The network identifier from NET position 1; semicolons and line breaks are rejected when serialized.
     pub identifier: String,
+    /// The network operator from NET position 2; semicolons and line breaks are rejected when serialized.
     pub operator: String,
+    /// The NET authentication marker from position 3, parsed into [`StrAuth`] using the exact `N`, `B`, and `D` codes.
     pub authentication: StrAuth,
+    /// Whether the network has a fee, parsed from exact `N`/`Y` tokens in NET position 4 and serialized with the same codes.
     pub fee: Field<bool>,
+    /// The network information URL from NET position 5; semicolons and line breaks are rejected when serialized.
     pub web_net: String,
+    /// The stream information URL from NET position 6; semicolons and line breaks are rejected when serialized.
     pub web_str: String,
+    /// The registration URL from NET position 7; semicolons and line breaks are rejected when serialized.
     pub web_reg: String,
+    /// All NET tokens from position 8 onward, joined with semicolons so trailing fields survive a parse/render round trip.
     pub misc: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// A record whose type tag is not one of the recognized STR, CAS, or NET tags.
+/// Its tokens remain text so unknown extensions can be parsed and rendered without typed conversion.
 pub struct OtherRecord {
+    /// The original first token of the unrecognized line, including any surrounding whitespace.
     pub type_tag: String,
+    /// The remaining semicolon-delimited tokens, in their original order.
     pub fields: Vec<String>,
 }
 
+/// Parses an NTRIP sourcetable into typed and unrecognized records.
+/// Empty lines are skipped, the `STR`, `CAS`, and `NET` tags are matched case-insensitively after trimming, and parsing stops at a case-insensitive `ENDSOURCETABLE` tag. Invalid typed tokens are retained as [`Field::Raw`] instead of rejecting the table.
 pub fn parse_sourcetable(text: &str) -> Result<Sourcetable> {
     let mut records = Vec::new();
     for raw_line in text.lines() {
@@ -122,6 +191,8 @@ pub fn parse_sourcetable(text: &str) -> Result<Sourcetable> {
 }
 
 impl Sourcetable {
+    /// Serializes the records with CRLF line endings and appends `ENDSOURCETABLE\r\n`.
+    /// Ordinary fields reject semicolons and every field rejects line breaks, returning [`Error::InvalidInput`] when the value cannot be represented by the line format.
     pub fn to_text(&self) -> Result<String> {
         let mut out = String::new();
         for record in &self.records {
@@ -132,6 +203,7 @@ impl Sourcetable {
         Ok(out)
     }
 
+    /// Iterates over STR records in their original order, skipping CAS, NET, and Other records.
     pub fn streams(&self) -> impl Iterator<Item = &StrRecord> {
         self.records.iter().filter_map(|record| match record {
             SourcetableRecord::Str(record) => Some(record),

--- a/crates/sidereon-core/src/ppp_corrections.rs
+++ b/crates/sidereon-core/src/ppp_corrections.rs
@@ -45,64 +45,116 @@ use crate::{GnssSatelliteId, GnssSystem};
 /// Civil date/time fields used by PPP correction tables.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CivilDateTime {
+    /// Gregorian calendar year passed to civil-time validation, tide evaluation,
+    /// and Julian-date conversion.
     pub year: i32,
+    /// One-based Gregorian calendar month passed to civil-time validation, tide
+    /// evaluation, and Julian-date conversion.
     pub month: u8,
+    /// Gregorian calendar day passed to civil-time validation, tide evaluation,
+    /// and Julian-date conversion.
     pub day: u8,
+    /// Civil-time hour used directly and in the fractional hour sent to tide
+    /// routines.
     pub hour: u8,
+    /// Civil-time minute used directly and in the fractional hour sent to tide
+    /// routines.
     pub minute: u8,
+    /// Fractional civil seconds validated with the selected time-scale policy,
+    /// converted to Julian-date time, and included in the tide fractional hour.
     pub second: f64,
 }
 
 /// One satellite observation row needed by the static correction precompute.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PppCorrectionObservation {
+    /// Physical satellite used for orbit prediction and per-satellite correction
+    /// lookup.
     pub sat: GnssSatelliteId,
+    /// First carrier frequency in hertz, used for wind-up and code-bias
+    /// ionosphere-free calculations.
     pub freq1_hz: f64,
+    /// Second carrier frequency in hertz, used for wind-up and code-bias
+    /// ionosphere-free calculations.
     pub freq2_hz: f64,
+    /// Optional GLONASS FDMA channel passed to RINEX-frequency lookup; when it is
+    /// absent, the channel is inferred from the two carrier frequencies when possible.
     pub glonass_channel: Option<i8>,
 }
 
 /// One receiver epoch and its visible satellite rows.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PppCorrectionEpoch {
+    /// Civil epoch used for Sun/Moon, station-displacement, and antenna-validity
+    /// evaluation.
     pub epoch: CivilDateTime,
+    /// Receiver time in seconds from J2000, used for precise-orbit prediction and
+    /// converted with the bias set's time scale for code-bias evaluation.
     pub t_rx_j2000_s: f64,
+    /// Visible observations traversed in input order for per-satellite correction
+    /// generation.
     pub observations: Vec<PppCorrectionObservation>,
 }
 
 /// Frequency-dependent satellite antenna calibration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatelliteAntennaFrequency {
+    /// Frequency label used to select this record from a satellite antenna block.
     pub label: String,
+    /// Satellite body-frame phase-center offset in meters, projected to ECEF
+    /// before the ionosphere-free combination.
     pub pco_m: [f64; 3],
+    /// No-azimuth PCV samples as `(nadir angle in degrees, correction in meters)`;
+    /// samples are sorted before interpolation and non-finite values are rejected.
     pub noazi_pcv_m: Vec<(f64, f64)>,
 }
 
 /// Satellite antenna block selected by PRN and validity window.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatelliteAntenna {
+    /// Satellite identifier used to select this antenna block.
     pub sat: GnssSatelliteId,
+    /// Inclusive lower civil-epoch bound for this block; `None` leaves it open.
     pub valid_from: Option<CivilDateTime>,
+    /// Inclusive upper civil-epoch bound for this block; `None` leaves it open.
     pub valid_until: Option<CivilDateTime>,
+    /// Frequency-specific PCO and no-azimuth PCV records searched by trimmed
+    /// frequency label.
     pub frequencies: Vec<SatelliteAntennaFrequency>,
 }
 
 /// Satellite antenna correction options.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatelliteAntennaOptions {
+    /// Trimmed label selecting the first signal's PCO and PCV records.
     pub freq1_label: String,
+    /// First configured carrier frequency in hertz; it must be finite, positive,
+    /// and distinct from [`Self::freq2_hz`]. When phase wind-up is enabled, this
+    /// value overrides the observation's first frequency.
     pub freq1_hz: f64,
+    /// Trimmed label selecting the second signal's PCO and PCV records.
     pub freq2_label: String,
+    /// Second configured carrier frequency in hertz; it must be finite, positive,
+    /// and distinct from [`Self::freq1_hz`]. When phase wind-up is enabled, this
+    /// value overrides the observation's second frequency.
     pub freq2_hz: f64,
+    /// Antenna blocks searched in vector order by satellite and civil validity.
     pub antennas: Vec<SatelliteAntenna>,
 }
 
 /// Offline code-bias correction options.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CodeBiasOptions {
+    /// Bias-SINEX or DCB model queried for the selected satellite and epoch.
     pub bias_set: BiasSet,
+    /// Per-satellite used code-observable pairs, taking precedence over system
+    /// defaults.
     pub used_observables_per_sat: BTreeMap<GnssSatelliteId, (String, String)>,
+    /// Per-system used code-observable pairs used when no satellite-specific pair
+    /// is present.
     pub used_observables_default: BTreeMap<GnssSystem, (String, String)>,
+    /// Optional per-system clock-reference pairs overriding the pairs in
+    /// [`BiasSet::clock_reference`].
     pub clock_reference: Option<ClockReferenceObservables>,
 }
 
@@ -124,109 +176,181 @@ pub struct PoleTideOptions {
 /// PPP correction precompute switches.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PppCorrectionsOptions {
+    /// Enables one Sun/Moon-driven solid-earth displacement per input epoch.
     pub solid_earth_tide: bool,
+    /// Enables one polar-motion-driven displacement per input epoch when present.
     pub pole_tide: Option<PoleTideOptions>,
     /// Ocean tide loading: the station's BLQ coefficients. The engine does not
     /// embed ocean-loading models, so the caller supplies the per-station BLQ
     /// block (Bos-Scherneck / OSO Chalmers or equivalent), exactly like the
     /// polar-motion data dependency of the pole tide.
     pub ocean_loading: Option<OceanLoadingBlq>,
+    /// Enables continuous per-satellite ionosphere-free phase wind-up corrections
+    /// in meters.
     pub phase_windup: bool,
+    /// Enables satellite PCO/PCV corrections after validating the configured
+    /// carrier pair and PCV samples.
     pub satellite_antenna: Option<SatelliteAntennaOptions>,
+    /// Enables clock-datum code-bias corrections for observations with a used
+    /// observable mapping.
     pub code_bias: Option<CodeBiasOptions>,
 }
 
 /// Indexed vector result. The epoch index refers to the input epoch slice.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct EpochVectorCorrection {
+    /// Zero-based index written while `build` enumerates the input epochs and used
+    /// as the station-correction lookup key.
     pub epoch_index: usize,
+    /// ECEF station-displacement vector in meters, later projected against the
+    /// predicted line of sight.
     pub vector_m: [f64; 3],
 }
 
 /// Indexed satellite scalar result. The epoch index refers to the input epoch slice.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatScalarCorrection {
+    /// Satellite copied from the observation and combined with [`Self::epoch_index`]
+    /// into the precise-positioning lookup key.
     pub sat: GnssSatelliteId,
+    /// Zero-based source-epoch index combined with [`Self::sat`] into the precise-
+    /// positioning lookup key.
     pub epoch_index: usize,
+    /// Ionosphere-free correction in meters: phase wind-up, satellite PCV, or
+    /// clock-datum code bias according to its containing table.
     pub value_m: f64,
 }
 
 /// Indexed satellite vector result. The epoch index refers to the input epoch slice.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatVectorCorrection {
+    /// Satellite copied from the observation and combined with [`Self::epoch_index`]
+    /// into the satellite PCO lookup key.
     pub sat: GnssSatelliteId,
+    /// Zero-based source-epoch index combined with [`Self::sat`] into the satellite
+    /// PCO lookup key.
     pub epoch_index: usize,
+    /// Ionosphere-free satellite PCO vector in ECEF meters, projected onto the
+    /// predicted line of sight by the PPP measurement model.
     pub vector_m: [f64; 3],
 }
 
 /// Precomputed PPP correction tables.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PppCorrections {
+    /// Solid-earth tide displacements indexed by input epoch.
     pub tide: Vec<EpochVectorCorrection>,
+    /// Solid-earth pole-tide displacements indexed by input epoch.
     pub pole_tide: Vec<EpochVectorCorrection>,
+    /// Ocean-loading displacements indexed by input epoch.
     pub ocean_loading: Vec<EpochVectorCorrection>,
+    /// Continuous ionosphere-free phase wind-up corrections indexed by satellite
+    /// and input epoch.
     pub windup_m: Vec<SatScalarCorrection>,
+    /// Ionosphere-free satellite PCO vectors in ECEF meters indexed by satellite
+    /// and input epoch.
     pub sat_pco_ecef: Vec<SatVectorCorrection>,
+    /// Ionosphere-free no-azimuth satellite PCV values in meters indexed by
+    /// satellite and input epoch.
     pub sat_pcv_m: Vec<SatScalarCorrection>,
+    /// Clock-datum code-bias corrections in meters indexed by satellite and input
+    /// epoch.
     pub code_bias_m: Vec<SatScalarCorrection>,
+    /// Diagnostics containing missing-metadata warnings for observations without a
+    /// code-bias used-observable mapping.
     pub diagnostics: crate::format::Diagnostics,
 }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
+/// Errors encountered while constructing static PPP correction tables.
 pub enum PppCorrectionsError {
     #[error("invalid PPP correction input {field}: {reason}")]
+    /// A receiver, antenna, prediction, or media input failed validation.
     InvalidInput {
+        /// Static label identifying the input that failed validation.
         field: &'static str,
+        /// Validator or prediction reason, such as `not finite` or `out of range`.
         reason: &'static str,
     },
     #[error("invalid PPP correction epoch at epoch {epoch_index}: {source}")]
+    /// Sun/Moon time-scale construction failed for an input epoch.
     Epoch {
+        /// Zero-based index of the invalid or out-of-coverage input epoch.
         epoch_index: usize,
         #[source]
+        /// Civil-time validation or embedded time-model coverage failure.
         source: CoverageError,
     },
     #[error("solid Earth tide correction failed at epoch {epoch_index}: {source}")]
+    /// Solid-earth tide evaluation failed after Sun/Moon data were obtained.
     Tide {
+        /// Zero-based index of the input epoch where evaluation failed.
         epoch_index: usize,
         #[source]
+        /// Underlying solid-earth tide failure.
         source: TideError,
     },
     #[error("solid Earth pole tide correction failed at epoch {epoch_index}: {source}")]
+    /// Solid-earth pole-tide evaluation failed.
     PoleTide {
+        /// Zero-based index of the input epoch where evaluation failed.
         epoch_index: usize,
         #[source]
+        /// Underlying polar-motion tide failure.
         source: TideError,
     },
     #[error("ocean tide loading correction failed at epoch {epoch_index}: {source}")]
+    /// BLQ ocean-loading evaluation failed.
     OceanLoading {
+        /// Zero-based index of the input epoch where evaluation failed.
         epoch_index: usize,
         #[source]
+        /// Underlying ocean-loading failure.
         source: TideError,
     },
     #[error(
         "invalid phase wind-up carrier frequencies at epoch {epoch_index} for {sat}: {field} {reason}"
     )]
+    /// A carrier pair selected for phase wind-up failed finite, positivity, or
+    /// separation validation.
     WindupFrequency {
+        /// Zero-based index of the observation epoch where validation failed.
         epoch_index: usize,
+        /// Satellite whose selected carrier pair failed validation.
         sat: GnssSatelliteId,
+        /// Static label identifying the failing frequency or frequency pair.
         field: &'static str,
+        /// Validation reason, such as `not finite`, `not positive`, or `must differ`.
         reason: &'static str,
     },
     #[error("invalid satellite antenna carrier frequencies: {field} {reason}")]
+    /// The configured satellite-antenna carrier pair failed validation before
+    /// per-observation processing.
     SatelliteAntennaFrequency {
+        /// Static label identifying the failing configured frequency or pair.
         field: &'static str,
+        /// Validation reason, such as `not finite`, `not positive`, or `must differ`.
         reason: &'static str,
     },
     #[error("code-bias correction failed: {source}")]
+    /// Code-bias setup failed because the required clock reference or bias epoch
+    /// conversion was unavailable.
     Bias {
         #[source]
+        /// Underlying bias-model failure, such as a missing clock reference.
         source: BiasError,
     },
     #[error("invalid code-bias observable at epoch {epoch_index} for {sat}: {field} {reason}")]
+    /// A code-bias used observable has an invalid or mismatched carrier frequency.
     CodeBiasObservable {
+        /// Zero-based index of the input epoch containing the invalid observation.
         epoch_index: usize,
+        /// Satellite containing the invalid or mismatched observation frequency.
         sat: GnssSatelliteId,
+        /// Static label identifying the used observable frequency field.
         field: &'static str,
+        /// Validation reason, including `not finite`, `not positive`, or
+        /// `frequency mismatch`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/rinex_qc/mod.rs
+++ b/crates/sidereon-core/src/rinex_qc/mod.rs
@@ -77,182 +77,335 @@ impl FindingRef {
 #[non_exhaustive]
 pub enum Finding {
     /// OBS parse failed before a parsed product existed.
-    ObsFatalParse { at: FindingRef, message: String },
+    ObsFatalParse {
+        /// Defaults to an empty [`FindingRef`] because no parsed location exists for the failure.
+        at: FindingRef,
+        /// Stringified CRINEX decoder or OBS parser error that prevented a parsed product.
+        message: String,
+    },
     /// OBS version is not one of the published versions covered here.
-    ObsUnpublishedVersion { at: FindingRef, version: f64 },
+    ObsUnpublishedVersion {
+        /// Points to `RINEX VERSION / TYPE` in the OBS header.
+        at: FindingRef,
+        /// Header version rejected by the published-version check.
+        version: f64,
+    },
     /// A mandatory OBS header retained by the current product is absent.
-    ObsMissingHeader { at: FindingRef, label: &'static str },
+    ObsMissingHeader {
+        /// Points to the absent header record.
+        at: FindingRef,
+        /// RINEX label of the absent header record.
+        label: &'static str,
+    },
     /// OBS header has no observation-code table.
-    ObsMissingObsTypes { at: FindingRef },
+    ObsMissingObsTypes {
+        /// Points to `SYS / # / OBS TYPES`.
+        at: FindingRef,
+    },
     /// OBS code syntax is not valid for this first slice.
     ObsInvalidObsCode {
+        /// Points to `SYS / # / OBS TYPES`.
         at: FindingRef,
+        /// GNSS system owning the rejected code table.
         system: GnssSystem,
+        /// Complete observation code rejected by the system-, band-, and attribute-specific check.
         code: String,
     },
     /// OBS code is duplicated in one system table.
     ObsDuplicateObsCode {
+        /// Points to `SYS / # / OBS TYPES`.
         at: FindingRef,
+        /// GNSS system whose header list repeats the code.
         system: GnssSystem,
+        /// Observation code repeated in that system's header list.
         code: String,
     },
     /// TIME OF FIRST OBS disagrees with the body.
     ObsTimeOfFirstMismatch {
+        /// Points to `TIME OF FIRST OBS`.
         at: FindingRef,
+        /// Epoch copied from the `TIME OF FIRST OBS` header.
         declared: ObsEpochTime,
+        /// Time scale copied from the `TIME OF FIRST OBS` header.
         declared_scale: TimeScale,
+        /// First body epoch with a normal observation flag.
         observed: ObsEpochTime,
+        /// Body time scale used for comparison with `declared_scale`.
         observed_scale: TimeScale,
     },
     /// TIME OF LAST OBS disagrees with the body epoch or with the file time
     /// system declared by TIME OF FIRST OBS (RINEX 3.05: TIME OF FIRST OBS
     /// defines the time system; TIME OF LAST OBS must agree with it).
     ObsTimeOfLastMismatch {
+        /// Points to `TIME OF LAST OBS`.
         at: FindingRef,
+        /// Epoch copied from the `TIME OF LAST OBS` header.
         declared: ObsEpochTime,
+        /// Time scale copied from the `TIME OF LAST OBS` header.
         declared_scale: TimeScale,
+        /// Last body epoch with a normal observation flag.
         observed: ObsEpochTime,
+        /// Body time scale used for comparison with `declared_scale`.
         observed_scale: TimeScale,
     },
     /// INTERVAL disagrees with the dominant epoch spacing.
     ObsIntervalMismatch {
+        /// Points to `INTERVAL`.
         at: FindingRef,
+        /// Usable interval declared by the OBS header, in seconds.
         declared_s: f64,
+        /// Dominant spacing inferred from normal epochs, in seconds.
         observed_s: f64,
     },
     /// # OF SATELLITES disagrees with the body.
     ObsSatelliteCountMismatch {
+        /// Points to `# OF SATELLITES`.
         at: FindingRef,
+        /// Nonzero satellite count declared by the OBS header.
         declared: usize,
+        /// Number of distinct satellites in normal body records.
         observed: usize,
     },
     /// PRN / # OF OBS disagrees with body tallies.
     ObsPrnObsCountMismatch {
+        /// Carries the affected satellite and points to `PRN / # OF OBS`.
         at: FindingRef,
+        /// Satellite key of the header count entry.
         satellite: GnssSatelliteId,
+        /// Observation code at the mismatching count index, or empty when absent.
         code: String,
+        /// Optional count declared by the header at that index.
         declared: Option<usize>,
+        /// Number of present values observed in the body at that index.
         observed: usize,
     },
     /// GLONASS observations need a valid slot/frequency table.
     ObsGlonassSlotIssue {
+        /// Carries the affected satellite and points to `GLONASS SLOT / FRQ #`.
         at: FindingRef,
+        /// GLONASS satellite with an invalid or missing slot entry.
         satellite: GnssSatelliteId,
+        /// `invalid channel` for an out-of-range header channel, or `missing slot` for a body satellite without an entry.
         issue: &'static str,
     },
     /// SYS / PHASE SHIFT names a code absent from SYS / # / OBS TYPES.
     ObsPhaseShiftUndeclaredCode {
+        /// Points to `SYS / PHASE SHIFT`.
         at: FindingRef,
+        /// GNSS system named by the phase-shift entry.
         system: GnssSystem,
+        /// Phase-shift code absent from that system's declared code list.
         code: String,
     },
     /// SYS / SCALE FACTOR is invalid or names an undeclared code.
     ObsScaleFactorIssue {
+        /// Points to `SYS / SCALE FACTOR`.
         at: FindingRef,
+        /// GNSS system named by the scale-factor entry.
         system: GnssSystem,
+        /// `None` for an unsupported factor; otherwise the undeclared code.
         code: Option<String>,
     },
     /// MARKER TYPE is not a RINEX Table 8 keyword.
-    ObsMarkerTypeIssue { at: FindingRef, marker_type: String },
+    ObsMarkerTypeIssue {
+        /// Points to `MARKER TYPE`.
+        at: FindingRef,
+        /// Original marker-type text copied from the header before trimming for validation.
+        marker_type: String,
+    },
     /// Identity/header field exceeds width or has non-printable ASCII.
     ObsIdentityFieldIssue {
+        /// Points to the identity field passed to the header checker.
         at: FindingRef,
+        /// Static RINEX label of the invalid identity field.
         label: &'static str,
+        /// Original identity value that exceeded its width or contained a non-printable byte.
         value: String,
     },
     /// Approximate position is implausible for a fixed marker.
-    ObsImplausibleApproxPosition { at: FindingRef, radius_m: f64 },
+    ObsImplausibleApproxPosition {
+        /// Points to `APPROX POSITION XYZ`.
+        at: FindingRef,
+        /// Nonzero ECEF radius computed from the header position, in meters.
+        radius_m: f64,
+    },
     /// Antenna height/east/north offset is implausible.
     ObsImplausibleAntennaDelta {
+        /// Points to `ANTENNA: DELTA H/E/N`.
         at: FindingRef,
+        /// Zero-based H, E, or N component index that exceeded the limit.
         component: usize,
+        /// Offending antenna offset component, in meters.
         value_m: f64,
     },
     /// Epoch times are not strictly increasing.
     ObsEpochOrder {
+        /// Carries the zero-based index of the current out-of-order epoch.
         at: FindingRef,
+        /// Previous normal epoch retained by the order scan.
         previous: ObsEpochTime,
+        /// Current normal epoch whose rounded key is earlier than `previous`.
         current: ObsEpochTime,
     },
     /// Two normal epochs carry the same timestamp.
-    ObsDuplicateEpoch { at: FindingRef, epoch: ObsEpochTime },
+    ObsDuplicateEpoch {
+        /// Carries the zero-based index of the later duplicate epoch.
+        at: FindingRef,
+        /// Later normal epoch whose rounded key was already seen.
+        epoch: ObsEpochTime,
+    },
     /// The parser skipped satellite records it could not represent.
-    ObsSkippedRecords { at: FindingRef, count: usize },
+    ObsSkippedRecords {
+        /// Defaults to an empty reference because the parser exposes no more specific location.
+        at: FindingRef,
+        /// Positive parser counter for records that could not be represented.
+        count: usize,
+    },
     /// Epoch record count disagreed with retained satellite records.
     ObsEpochSatCountMismatch {
+        /// Carries the zero-based epoch index.
         at: FindingRef,
+        /// `NUM SAT` count declared in the epoch record.
         declared: usize,
+        /// Number of satellite entries retained in the epoch map.
         retained: usize,
     },
     /// A retained event epoch had special records that are not retained.
-    ObsEventSpecialRecords { at: FindingRef, count: usize },
+    ObsEventSpecialRecords {
+        /// Carries the zero-based event epoch index.
+        at: FindingRef,
+        /// Number of special records recorded for the event epoch.
+        count: usize,
+    },
     /// Header record is outside the retained OBS product.
-    ObsUnretainedHeader { at: FindingRef, label: String },
+    ObsUnretainedHeader {
+        /// Uses the literal `header` location because only the unsupported label is retained.
+        at: FindingRef,
+        /// Header label recorded as unretained by the parser.
+        label: String,
+    },
     /// A pseudorange value is outside the configured plausibility window.
     ObsPseudorangeOutOfRange {
+        /// Carries the normal epoch and satellite containing the value.
         at: FindingRef,
+        /// Observation code selected at the value's index, or empty when unavailable.
         code: String,
+        /// Pseudorange value outside the 15,000,000 to 50,000,000 meter window.
         value_m: f64,
     },
     /// LLI digit is outside the three defined bits.
     ObsLossOfLockOutOfRange {
+        /// Carries the normal epoch and satellite containing the LLI.
         at: FindingRef,
+        /// Observation code selected at the LLI field's index, or empty when unavailable.
         code: String,
+        /// Raw loss-of-lock indicator greater than 7.
         lli: u8,
     },
     /// Event epoch retained with no special records.
-    ObsEventEpoch { at: FindingRef, flag: u8 },
+    ObsEventEpoch {
+        /// Carries the zero-based event epoch index.
+        at: FindingRef,
+        /// Parsed event flag greater than 1.
+        flag: u8,
+    },
     /// Satellite record has all observation fields blank.
-    ObsEmptySatelliteRecord { at: FindingRef },
+    ObsEmptySatelliteRecord {
+        /// Carries the normal epoch and satellite whose observation values are all absent.
+        at: FindingRef,
+    },
     /// Epoch gap is larger than 1.5 times the dominant interval.
     ObsEpochGap {
+        /// Carries the zero-based current normal epoch index.
         at: FindingRef,
+        /// Current-minus-previous normal epoch difference, in seconds.
         gap_s: f64,
+        /// Dominant normal-epoch interval used for the threshold, in seconds.
         interval_s: f64,
     },
     /// NAV parse failed before a parsed product existed.
-    NavFatalParse { at: FindingRef, message: String },
+    NavFatalParse {
+        /// Defaults to an empty reference because no reliable NAV record location exists.
+        at: FindingRef,
+        /// Stringified error returned by lenient NAV parsing.
+        message: String,
+    },
     /// NAV header has no LEAP SECONDS record.
-    NavLeapSecondsAbsent { at: FindingRef },
+    NavLeapSecondsAbsent {
+        /// Points to `LEAP SECONDS`.
+        at: FindingRef,
+    },
     /// NAV ionospheric correction records are malformed.
-    NavIonoMalformed { at: FindingRef, message: String },
+    NavIonoMalformed {
+        /// Points to `IONOSPHERIC CORR`.
+        at: FindingRef,
+        /// Stringified ionospheric-correction parse error.
+        message: String,
+    },
     /// NAV record block was dropped by lenient parsing.
     NavDroppedBlock {
+        /// Carries the skipped block's satellite token.
         at: FindingRef,
+        /// Satellite token stored by the lenient parser for the dropped block.
         satellite: String,
+        /// Lenient parser explanation for skipping the block.
         message: String,
     },
     /// Duplicate NAV records share an identity.
     NavDuplicateRecord {
+        /// Carries the zero-based index of the later duplicate record.
         at: FindingRef,
+        /// Satellite ID of the later duplicate broadcast record.
         satellite: GnssSatelliteId,
+        /// Whether the later record equals the first record with this NAV identity.
         same_payload: bool,
     },
     /// NAV records are not in canonical order.
-    NavUnsortedRecords { at: FindingRef },
+    NavUnsortedRecords {
+        /// Defaults to an empty reference because the check compares adjacent records.
+        at: FindingRef,
+    },
     /// NAV broadcast fields are outside this slice's plausibility limits.
     NavImplausibleRecord {
+        /// Carries the zero-based NAV record index.
         at: FindingRef,
+        /// Satellite ID of the record containing the out-of-range element.
         satellite: GnssSatelliteId,
+        /// Static label identifying the checked element: `eccentricity` or `sqrt_a`.
         field: &'static str,
+        /// Raw broadcast value that failed its range check.
         value: f64,
     },
     /// NAV records include unhealthy satellite records.
     NavUnhealthyRecords {
+        /// Defaults to an empty reference because this finding summarizes a system.
         at: FindingRef,
+        /// GNSS system in the unhealthy-record tally.
         system: GnssSystem,
+        /// Number of that system's records with nonzero `sv_health`.
         count: usize,
     },
     /// NAV records outside the retained/writable scope are present.
     NavOutOfScopeRecords {
+        /// Defaults to an empty reference because the text scan retains no record index.
         at: FindingRef,
+        /// Deterministic class of unsupported frame, message, or constellation.
         class: String,
+        /// Number of text records in the reported scope class.
         count: usize,
     },
     /// INTERVAL is zero, a standards-defined representation of unavailable metadata.
-    ObsIntervalUnavailable { at: FindingRef },
+    ObsIntervalUnavailable {
+        /// Points to `INTERVAL`.
+        at: FindingRef,
+    },
     /// INTERVAL is negative, or non-finite in a caller-constructed product.
-    ObsInvalidInterval { at: FindingRef, declared_s: f64 },
+    ObsInvalidInterval {
+        /// Points to `INTERVAL`.
+        at: FindingRef,
+        /// Raw interval value rejected as negative or non-finite, in seconds.
+        declared_s: f64,
+    },
 }
 
 impl Finding {

--- a/crates/sidereon-core/src/rtcm/ephemeris.rs
+++ b/crates/sidereon-core/src/rtcm/ephemeris.rs
@@ -302,42 +302,102 @@ impl GpsEphemeris {
 /// A decoded Galileo F/NAV broadcast ephemeris (message 1045).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GalileoFnavEphemeris {
+    /// Galileo SVID, decoded from the six-bit satellite field. [`Self::satellite`]
+    /// validates it against the Galileo PRN range before creating a
+    /// [`GnssSatelliteId`].
     pub satellite_id: u8,
+    /// Galileo GST week number, as transmitted in the twelve-bit field.
+    /// [`Self::to_broadcast_record`] adds the 1024-week Galileo-to-GPS epoch
+    /// offset when it builds the GST-tagged reference times.
     pub week_number: u16,
+    /// Ten-bit Galileo navigation-data issue copied to `BroadcastIssue.issue`.
     pub iod_nav: u16,
+    /// Eight-bit Galileo SISA index; [`Self::to_broadcast_record`] converts it
+    /// with the Galileo SISA table into meters.
     pub sisa: u8,
+    /// Signed fourteen-bit inclination rate, scaled as 2^-43 semicircles/s in
+    /// the wire message and converted to radians/s for broadcast evaluation.
     pub idot: i32,
+    /// Clock reference count from the fourteen-bit field; each count is 60 s
+    /// when [`Self::to_broadcast_record`] computes `toc_sow`.
     pub t_oc: u16,
+    /// Signed six-bit clock drift rate, with a 2^-59 scale to s/s^2.
     pub a_f2: i16,
+    /// Signed twenty-one-bit clock drift, with a 2^-46 scale to s/s.
     pub a_f1: i32,
+    /// Signed thirty-one-bit clock bias, with a 2^-34 scale to seconds.
     pub a_f0: i64,
+    /// Signed sixteen-bit orbit-radius sine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rs: i32,
+    /// Signed sixteen-bit mean-motion difference, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub delta_n: i32,
+    /// Signed thirty-two-bit mean anomaly, scaled as 2^-31 semicircles before
+    /// conversion to radians.
     pub m0: i64,
+    /// Signed sixteen-bit latitude-argument cosine correction, with a 2^-29
+    /// scale to radians.
     pub c_uc: i32,
+    /// Unsigned thirty-two-bit eccentricity, scaled by 2^-33 for the
+    /// dimensionless broadcast element.
     pub eccentricity: u64,
+    /// Signed sixteen-bit latitude-argument sine correction, with a 2^-29
+    /// scale to radians.
     pub c_us: i32,
+    /// Unsigned thirty-two-bit square-root semi-major axis, scaled by 2^-19
+    /// to the square-root-meter value used by the broadcast evaluator.
     pub sqrt_a: u64,
+    /// Ephemeris reference count from the fourteen-bit field; each count is 60 s
+    /// when [`Self::to_broadcast_record`] computes `toe_sow`.
     pub t_oe: u16,
+    /// Signed sixteen-bit inclination cosine correction, with a 2^-29 scale to
+    /// radians.
     pub c_ic: i32,
+    /// Signed thirty-two-bit ascending-node longitude, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub omega0: i64,
+    /// Signed sixteen-bit inclination sine correction, with a 2^-29 scale to
+    /// radians.
     pub c_is: i32,
+    /// Signed thirty-two-bit reference inclination, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub i0: i64,
+    /// Signed sixteen-bit orbit-radius cosine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rc: i32,
+    /// Signed thirty-two-bit argument of perigee, scaled as 2^-31 semicircles
+    /// before conversion to radians.
     pub omega: i64,
+    /// Signed twenty-four-bit right-ascension rate, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub omega_dot: i32,
+    /// Signed ten-bit E5a/E1 group-delay term, scaled by 2^-32 to seconds in
+    /// the broadcast record.
     pub bgd_e5a_e1: i16,
+    /// Two-bit E5a signal-health value. The broadcast conversion treats zero as
+    /// healthy only when [`Self::e5a_data_validity`] is false.
     pub e5a_signal_health: u8,
+    /// E5a data-validity flag; false is the value used by the broadcast health
+    /// predicate for valid data.
     pub e5a_data_validity: bool,
+    /// Seven-bit reserved tail retained by [`Self::encode`] for exact body
+    /// round trips; it is not used in broadcast conversion.
     pub reserved: u8,
 }
 
 impl GalileoFnavEphemeris {
+    /// Validate the decoded SVID and return its Galileo [`GnssSatelliteId`].
     pub fn satellite(&self) -> Result<GnssSatelliteId> {
         GnssSatelliteId::new(GnssSystem::Galileo, self.satellite_id)
             .map_err(|e| Error::Parse(format!("invalid Galileo SVID in 1045: {e}")))
     }
 
+    /// Decode an unframed RTCM 1045 body.
+    ///
+    /// The leading twelve-bit message number must be 1045; a different number
+    /// is a parse error, and a body that ends before the fields are complete is
+    /// reported as an input error.
     pub fn decode(body: &[u8]) -> Result<Self> {
         Self::decode_inner(body).map_err(Into::into)
     }
@@ -383,6 +443,10 @@ impl GalileoFnavEphemeris {
         })
     }
 
+    /// Encode the raw fields as an unframed RTCM 1045 body in decoder order.
+    /// The result preserves every field, including the reserved tail, so a
+    /// decode followed by an encode retains the 62-byte body used by the
+    /// round-trip test.
     pub fn encode(&self) -> Vec<u8> {
         let mut w = BitWriter::new();
         w.push_u(1045, 12);
@@ -417,6 +481,11 @@ impl GalileoFnavEphemeris {
         w.into_bytes()
     }
 
+    /// Convert this raw F/NAV message into the Galileo broadcast record used by
+    /// the orbital evaluator. Reference counts become seconds of GST week,
+    /// orbital and clock integers receive their broadcast scale factors, and
+    /// `iod_nav`, SISA, group delay, and health are copied into their canonical
+    /// record fields; an invalid SVID or overflowing aligned week is rejected.
     pub fn to_broadcast_record(&self) -> Result<BroadcastRecord> {
         galileo_to_record(
             self.satellite()?,
@@ -454,45 +523,111 @@ impl GalileoFnavEphemeris {
 /// A decoded Galileo I/NAV broadcast ephemeris (message 1046).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GalileoInavEphemeris {
+    /// Galileo SVID, decoded from the six-bit satellite field. [`Self::satellite`]
+    /// validates it against the Galileo PRN range before creating a
+    /// [`GnssSatelliteId`].
     pub satellite_id: u8,
+    /// Galileo GST week number, as transmitted in the twelve-bit field.
+    /// [`Self::to_broadcast_record`] adds the 1024-week Galileo-to-GPS epoch
+    /// offset when it builds the GST-tagged reference times.
     pub week_number: u16,
+    /// Ten-bit Galileo navigation-data issue copied to `BroadcastIssue.issue`.
     pub iod_nav: u16,
+    /// Eight-bit Galileo SISA index; [`Self::to_broadcast_record`] converts it
+    /// with the Galileo SISA table into meters.
     pub sisa_index: u8,
+    /// Signed fourteen-bit inclination rate, scaled as 2^-43 semicircles/s in
+    /// the wire message and converted to radians/s for broadcast evaluation.
     pub idot: i32,
+    /// Clock reference count from the fourteen-bit field; each count is 60 s
+    /// when [`Self::to_broadcast_record`] computes `toc_sow`.
     pub t_oc: u16,
+    /// Signed six-bit clock drift rate, with a 2^-59 scale to s/s^2.
     pub a_f2: i16,
+    /// Signed twenty-one-bit clock drift, with a 2^-46 scale to s/s.
     pub a_f1: i32,
+    /// Signed thirty-one-bit clock bias, with a 2^-34 scale to seconds.
     pub a_f0: i64,
+    /// Signed sixteen-bit orbit-radius sine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rs: i32,
+    /// Signed sixteen-bit mean-motion difference, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub delta_n: i32,
+    /// Signed thirty-two-bit mean anomaly, scaled as 2^-31 semicircles before
+    /// conversion to radians.
     pub m0: i64,
+    /// Signed sixteen-bit latitude-argument cosine correction, with a 2^-29
+    /// scale to radians.
     pub c_uc: i32,
+    /// Unsigned thirty-two-bit eccentricity, scaled by 2^-33 for the
+    /// dimensionless broadcast element.
     pub eccentricity: u64,
+    /// Signed sixteen-bit latitude-argument sine correction, with a 2^-29
+    /// scale to radians.
     pub c_us: i32,
+    /// Unsigned thirty-two-bit square-root semi-major axis, scaled by 2^-19
+    /// to the square-root-meter value used by the broadcast evaluator.
     pub sqrt_a: u64,
+    /// Ephemeris reference count from the fourteen-bit field; each count is 60 s
+    /// when [`Self::to_broadcast_record`] computes `toe_sow`.
     pub t_oe: u16,
+    /// Signed sixteen-bit inclination cosine correction, with a 2^-29 scale to
+    /// radians.
     pub c_ic: i32,
+    /// Signed thirty-two-bit ascending-node longitude, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub omega0: i64,
+    /// Signed sixteen-bit inclination sine correction, with a 2^-29 scale to
+    /// radians.
     pub c_is: i32,
+    /// Signed thirty-two-bit reference inclination, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub i0: i64,
+    /// Signed sixteen-bit orbit-radius cosine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rc: i32,
+    /// Signed thirty-two-bit argument of perigee, scaled as 2^-31 semicircles
+    /// before conversion to radians.
     pub omega: i64,
+    /// Signed twenty-four-bit right-ascension rate, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub omega_dot: i32,
+    /// Signed ten-bit E5a/E1 group-delay term, scaled by 2^-32 to seconds in
+    /// the broadcast record.
     pub bgd_e5a_e1: i16,
+    /// Signed ten-bit E5b/E1 group-delay term, scaled by 2^-32 to seconds in
+    /// the broadcast record.
     pub bgd_e5b_e1: i16,
+    /// Two-bit E5b signal-health value; it must be zero, with both validity
+    /// flags false and E1b health zero, for the broadcast record to be healthy.
     pub e5b_signal_health: u8,
+    /// E5b data-validity flag; false is required by the combined healthy-data
+    /// predicate in broadcast conversion.
     pub e5b_data_validity: bool,
+    /// Two-bit E1b signal-health value; it must be zero, with both validity
+    /// flags false and E5b health zero, for the broadcast record to be healthy.
     pub e1b_signal_health: u8,
+    /// E1b data-validity flag; false is required by the combined healthy-data
+    /// predicate in broadcast conversion.
     pub e1b_data_validity: bool,
+    /// Two-bit reserved tail retained by [`Self::encode`] for exact body round
+    /// trips; it is not used in broadcast conversion.
     pub reserved: u8,
 }
 
 impl GalileoInavEphemeris {
+    /// Validate the decoded SVID and return its Galileo [`GnssSatelliteId`].
     pub fn satellite(&self) -> Result<GnssSatelliteId> {
         GnssSatelliteId::new(GnssSystem::Galileo, self.satellite_id)
             .map_err(|e| Error::Parse(format!("invalid Galileo SVID in 1046: {e}")))
     }
 
+    /// Decode an unframed RTCM 1046 body.
+    ///
+    /// The leading twelve-bit message number must be 1046; a different number
+    /// is a parse error, and a body that ends before the fields are complete is
+    /// reported as an input error.
     pub fn decode(body: &[u8]) -> Result<Self> {
         Self::decode_inner(body).map_err(Into::into)
     }
@@ -541,6 +676,10 @@ impl GalileoInavEphemeris {
         })
     }
 
+    /// Encode the raw fields as an unframed RTCM 1046 body in decoder order.
+    /// The result preserves every field, including the reserved tail, so a
+    /// decode followed by an encode retains the 63-byte body used by the
+    /// round-trip test.
     pub fn encode(&self) -> Vec<u8> {
         let mut w = BitWriter::new();
         w.push_u(1046, 12);
@@ -578,6 +717,11 @@ impl GalileoInavEphemeris {
         w.into_bytes()
     }
 
+    /// Convert this raw I/NAV message into the Galileo broadcast record used by
+    /// the orbital evaluator. Reference counts become seconds of GST week,
+    /// orbital and clock integers receive their broadcast scale factors, and
+    /// both group delays plus the combined signal-health state are retained;
+    /// an invalid SVID or overflowing aligned week is rejected.
     pub fn to_broadcast_record(&self) -> Result<BroadcastRecord> {
         galileo_to_record(
             self.satellite()?,
@@ -703,42 +847,103 @@ fn galileo_to_record(
 /// A decoded BeiDou broadcast ephemeris (message 1042).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BeidouEphemeris {
+    /// BeiDou satellite number, decoded from the six-bit satellite field.
+    /// [`Self::satellite`] validates it against the BeiDou PRN range before
+    /// creating a [`GnssSatelliteId`].
     pub satellite_id: u8,
+    /// Native BeiDou BDT week from the thirteen-bit field; the conversion uses
+    /// it unchanged for the record week and both BDT reference times.
     pub week_number: u16,
+    /// Four-bit BeiDou signal-in-space accuracy index, mapped to meters by the
+    /// GPS URA table used in [`Self::to_broadcast_record`].
     pub sv_urai: u8,
+    /// Signed fourteen-bit inclination rate, scaled as 2^-43 semicircles/s and
+    /// converted to radians/s for broadcast evaluation.
     pub idot: i32,
+    /// Five-bit ephemeris-data issue copied to `BroadcastIssue.issue`; the
+    /// message is D1 or D2 according to the satellite's GEO classification.
     pub aode: u8,
+    /// Clock reference count from the seventeen-bit field; each count is 8 s
+    /// when [`Self::to_broadcast_record`] computes `toc_sow`.
     pub t_oc: u32,
+    /// Signed eleven-bit clock drift rate, with a 2^-66 scale to s/s^2.
     pub a_f2: i16,
+    /// Signed twenty-two-bit clock drift, with a 2^-50 scale to s/s.
     pub a_f1: i32,
+    /// Signed twenty-four-bit clock bias, with a 2^-33 scale to seconds.
     pub a_f0: i32,
+    /// Five-bit clock-data issue retained for raw round trips; broadcast issue
+    /// metadata comes from [`Self::aode`] instead.
     pub aodc: u8,
+    /// Signed eighteen-bit orbit-radius sine correction, with a 2^-6 scale to
+    /// meters.
     pub c_rs: i32,
+    /// Signed sixteen-bit mean-motion difference, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub delta_n: i32,
+    /// Signed thirty-two-bit mean anomaly, scaled as 2^-31 semicircles before
+    /// conversion to radians.
     pub m0: i64,
+    /// Signed eighteen-bit latitude-argument cosine correction, with a 2^-31
+    /// scale to radians.
     pub c_uc: i32,
+    /// Unsigned thirty-two-bit eccentricity, scaled by 2^-33 for the
+    /// dimensionless broadcast element.
     pub eccentricity: u64,
+    /// Signed eighteen-bit latitude-argument sine correction, with a 2^-31
+    /// scale to radians.
     pub c_us: i32,
+    /// Unsigned thirty-two-bit square-root semi-major axis, scaled by 2^-19
+    /// to the square-root-meter value used by the broadcast evaluator.
     pub sqrt_a: u64,
+    /// Ephemeris reference count from the seventeen-bit field; each count is 8 s
+    /// when [`Self::to_broadcast_record`] computes `toe_sow`.
     pub t_oe: u32,
+    /// Signed eighteen-bit inclination cosine correction, with a 2^-31 scale to
+    /// radians.
     pub c_ic: i32,
+    /// Signed thirty-two-bit ascending-node longitude, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub omega0: i64,
+    /// Signed eighteen-bit inclination sine correction, with a 2^-31 scale to
+    /// radians.
     pub c_is: i32,
+    /// Signed thirty-two-bit reference inclination, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub i0: i64,
+    /// Signed eighteen-bit orbit-radius cosine correction, with a 2^-6 scale to
+    /// meters.
     pub c_rc: i32,
+    /// Signed thirty-two-bit argument of perigee, scaled as 2^-31 semicircles
+    /// before conversion to radians.
     pub omega: i64,
+    /// Signed twenty-four-bit right-ascension rate, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub omega_dot: i32,
+    /// Signed ten-bit TGD1 value, multiplied by 1e-10 to produce seconds in the
+    /// BeiDou group-delay record.
     pub t_gd1: i16,
+    /// Signed ten-bit TGD2 value, multiplied by 1e-10 to produce seconds in the
+    /// BeiDou group-delay record.
     pub t_gd2: i16,
+    /// BeiDou health flag; false becomes `0.0` and true becomes `1.0` in the
+    /// broadcast record.
     pub sv_health: bool,
 }
 
 impl BeidouEphemeris {
+    /// Validate the decoded satellite number and return its BeiDou
+    /// [`GnssSatelliteId`].
     pub fn satellite(&self) -> Result<GnssSatelliteId> {
         GnssSatelliteId::new(GnssSystem::BeiDou, self.satellite_id)
             .map_err(|e| Error::Parse(format!("invalid BeiDou satellite ID in 1042: {e}")))
     }
 
+    /// Decode an unframed RTCM 1042 body.
+    ///
+    /// The leading twelve-bit message number must be 1042; a different number
+    /// is a parse error, and a body that ends before the fields are complete is
+    /// reported as an input error.
     pub fn decode(body: &[u8]) -> Result<Self> {
         Self::decode_inner(body).map_err(Into::into)
     }
@@ -784,6 +989,10 @@ impl BeidouEphemeris {
         })
     }
 
+    /// Encode the raw fields as an unframed RTCM 1042 body in decoder order.
+    /// The result preserves every field, including both delay terms, so a
+    /// decode followed by an encode retains the 64-byte body used by the
+    /// round-trip test.
     pub fn encode(&self) -> Vec<u8> {
         let mut w = BitWriter::new();
         w.push_u(1042, 12);
@@ -818,6 +1027,11 @@ impl BeidouEphemeris {
         w.into_bytes()
     }
 
+    /// Convert this raw message into the BDT-tagged BeiDou broadcast record
+    /// used by the orbital evaluator. The satellite selects the D1 or D2
+    /// message tag, integer fields receive their broadcast scales, and both
+    /// TGD terms are retained; an invalid satellite or unrepresentable time is
+    /// rejected.
     pub fn to_broadcast_record(&self) -> Result<BroadcastRecord> {
         let satellite_id = self.satellite()?;
         let week = u32::from(self.week_number);
@@ -879,43 +1093,104 @@ impl BeidouEphemeris {
 /// A decoded QZSS broadcast ephemeris (message 1044).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct QzssEphemeris {
+    /// QZSS satellite number, decoded from the four-bit satellite field.
+    /// [`Self::satellite`] validates it against the QZSS PRN range before
+    /// creating a [`GnssSatelliteId`].
     pub satellite_id: u8,
+    /// Clock reference count from the sixteen-bit field; each count is 16 s
+    /// when [`Self::to_broadcast_record`] computes `toc_sow`.
     pub t_oc: u16,
+    /// Signed eight-bit clock drift rate, with a 2^-55 scale to s/s^2.
     pub a_f2: i16,
+    /// Signed sixteen-bit clock drift, with a 2^-43 scale to s/s.
     pub a_f1: i32,
+    /// Signed twenty-two-bit clock bias, with a 2^-31 scale to seconds.
     pub a_f0: i32,
+    /// Eight-bit ephemeris-data issue copied to `BroadcastIssue.issue`.
     pub iode: u8,
+    /// Signed sixteen-bit orbit-radius sine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rs: i32,
+    /// Signed sixteen-bit mean-motion difference, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub delta_n: i32,
+    /// Signed thirty-two-bit mean anomaly, scaled as 2^-31 semicircles before
+    /// conversion to radians.
     pub m0: i64,
+    /// Signed sixteen-bit latitude-argument cosine correction, with a 2^-29
+    /// scale to radians.
     pub c_uc: i32,
+    /// Unsigned thirty-two-bit eccentricity, scaled by 2^-33 for the
+    /// dimensionless broadcast element.
     pub eccentricity: u64,
+    /// Signed sixteen-bit latitude-argument sine correction, with a 2^-29
+    /// scale to radians.
     pub c_us: i32,
+    /// Unsigned thirty-two-bit square-root semi-major axis, scaled by 2^-19
+    /// to the square-root-meter value used by the broadcast evaluator.
     pub sqrt_a: u64,
+    /// Ephemeris reference count from the sixteen-bit field; each count is 16 s
+    /// when [`Self::to_broadcast_record`] computes `toe_sow`.
     pub t_oe: u16,
+    /// Signed sixteen-bit inclination cosine correction, with a 2^-29 scale to
+    /// radians.
     pub c_ic: i32,
+    /// Signed thirty-two-bit ascending-node longitude, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub omega0: i64,
+    /// Signed sixteen-bit inclination sine correction, with a 2^-29 scale to
+    /// radians.
     pub c_is: i32,
+    /// Signed thirty-two-bit reference inclination, scaled as 2^-31
+    /// semicircles before conversion to radians.
     pub i0: i64,
+    /// Signed sixteen-bit orbit-radius cosine correction, with a 2^-5 scale to
+    /// meters.
     pub c_rc: i32,
+    /// Signed thirty-two-bit argument of perigee, scaled as 2^-31 semicircles
+    /// before conversion to radians.
     pub omega: i64,
+    /// Signed twenty-four-bit right-ascension rate, scaled as 2^-43
+    /// semicircles/s before conversion to radians/s.
     pub omega_dot: i32,
+    /// Signed fourteen-bit inclination rate, scaled as 2^-43 semicircles/s and
+    /// converted to radians/s for broadcast evaluation.
     pub idot: i32,
+    /// Two-bit L2 code value retained by [`Self::encode`]; the broadcast record
+    /// does not consume this raw signal indicator.
     pub codes_on_l2: u8,
+    /// Ten-bit GPS week residue checked against the caller-supplied `full_week`
+    /// by [`Self::to_broadcast_record`].
     pub week_number: u16,
+    /// Four-bit GPS URA index, mapped to meters by the GPS URA table.
     pub ura: u8,
+    /// Six-bit satellite-health word copied numerically to the broadcast
+    /// record, where zero is the healthy convention.
     pub sv_health: u8,
+    /// Signed eight-bit GPS-style group-delay value, scaled by 2^-31 to
+    /// seconds.
     pub t_gd: i16,
+    /// Ten-bit clock-data issue retained for exact encoding; broadcast issue
+    /// metadata comes from [`Self::iode`] instead.
     pub iodc: u16,
+    /// Fit-interval flag: false becomes two hours and true becomes six hours in
+    /// `BroadcastRecord.fit_interval_s`.
     pub fit_interval: bool,
 }
 
 impl QzssEphemeris {
+    /// Validate the decoded satellite number and return its QZSS
+    /// [`GnssSatelliteId`].
     pub fn satellite(&self) -> Result<GnssSatelliteId> {
         GnssSatelliteId::new(GnssSystem::Qzss, self.satellite_id)
             .map_err(|e| Error::Parse(format!("invalid QZSS satellite ID in 1044: {e}")))
     }
 
+    /// Decode an unframed RTCM 1044 body.
+    ///
+    /// The leading twelve-bit message number must be 1044; a different number
+    /// is a parse error, and a body that ends before the fields are complete is
+    /// reported as an input error.
     pub fn decode(body: &[u8]) -> Result<Self> {
         Self::decode_inner(body).map_err(Into::into)
     }
@@ -962,6 +1237,10 @@ impl QzssEphemeris {
         })
     }
 
+    /// Encode the raw fields as an unframed RTCM 1044 body in decoder order.
+    /// The result preserves every field, including the clock-data issue, so a
+    /// decode followed by an encode retains the 61-byte body used by the
+    /// round-trip test.
     pub fn encode(&self) -> Vec<u8> {
         let mut w = BitWriter::new();
         w.push_u(1044, 12);
@@ -997,6 +1276,11 @@ impl QzssEphemeris {
         w.into_bytes()
     }
 
+    /// Convert this raw message into the GPST-tagged QZSS L/NAV broadcast record
+    /// used by the orbital evaluator. `full_week` must have the same ten-bit
+    /// residue as [`Self::week_number`]; reference counts and scale factors are
+    /// applied before the record is returned, and mismatched weeks, invalid
+    /// satellite IDs, or unrepresentable times are rejected.
     pub fn to_broadcast_record(&self, full_week: u32) -> Result<BroadcastRecord> {
         if full_week % 1024 != u32::from(self.week_number) {
             return Err(Error::InvalidInput(format!(

--- a/crates/sidereon-core/src/rtk.rs
+++ b/crates/sidereon-core/src/rtk.rs
@@ -24,26 +24,45 @@ use std::collections::{BTreeMap, BTreeSet};
 /// One single-frequency code/carrier observation at a receiver.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Observation {
+    /// Satellite token used to join base and rover records. A token present on
+    /// only one side is placed in [`DoubleDifferenceResult::dropped_sats`].
     pub satellite_id: String,
+    /// Per-receiver ambiguity-arc token used to derive the single- and
+    /// double-difference ambiguity ids.
     pub ambiguity_id: String,
+    /// Code/pseudorange observable in meters. Double-difference construction
+    /// subtracts the receiver difference and then the reference difference.
     pub code_m: f64,
+    /// Carrier-phase observable in meters. Double-difference construction
+    /// subtracts the receiver difference and then the reference difference.
     pub phase_m: f64,
 }
 
 /// One single-frequency RTK observation for code-smoothing preprocessing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CodeSmoothingObservation {
+    /// Satellite token used for per-epoch ordering and receiver-map rebuilds.
     pub satellite_id: String,
+    /// Key for the Hatch running state; a different token uses a separate
+    /// state.
     pub ambiguity_id: String,
+    /// Input code/pseudorange in meters. Hatch smoothing replaces this value,
+    /// except on a new or LLI-reset state where it is returned unchanged.
     pub code_m: f64,
+    /// Carrier phase in meters used for the increment added to the previous
+    /// smoothed code.
     pub phase_m: f64,
+    /// Optional loss-of-lock indicator. Bit 0 resets Hatch state and emits the
+    /// single-frequency [`SlipReason::Lli`] reason when set.
     pub lli: Option<i64>,
 }
 
 /// One RTK epoch for base/rover code-smoothing preprocessing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CodeSmoothingEpoch {
+    /// Base observations smoothed with state independent of the rover vector.
     pub base_observations: Vec<CodeSmoothingObservation>,
+    /// Rover observations smoothed with state independent of the base vector.
     pub rover_observations: Vec<CodeSmoothingObservation>,
 }
 
@@ -57,20 +76,36 @@ pub type CycleSlipEpoch = CodeSmoothingEpoch;
 /// wide-lane RTK pre-step.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualObservation {
+    /// Per-receiver ambiguity-arc token carried into dual-frequency
+    /// single- and double-difference ids.
     pub ambiguity_id: String,
+    /// Band-1 code/pseudorange observable in meters used by the wide-lane and
+    /// ionosphere-free combinations.
     pub p1_m: f64,
+    /// Band-2 code/pseudorange observable in meters used by the wide-lane and
+    /// ionosphere-free combinations.
     pub p2_m: f64,
+    /// Band-1 carrier phase in cycles used for wide-lane estimation and the
+    /// ionosphere-free phase combination.
     pub phi1_cycles: f64,
+    /// Band-2 carrier phase in cycles used for wide-lane estimation and the
+    /// ionosphere-free phase combination.
     pub phi2_cycles: f64,
+    /// Positive band-1 carrier frequency in hertz used by both combinations.
     pub f1_hz: f64,
+    /// Positive band-2 carrier frequency in hertz used by both combinations.
     pub f2_hz: f64,
 }
 
 /// Paired base/rover dual-frequency observation for one satellite.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualSatelliteObservation {
+    /// Satellite token used to find the per-epoch reference and group
+    /// non-reference wide-lane samples.
     pub satellite_id: String,
+    /// Base receiver's dual-frequency observation for this satellite.
     pub base: DualObservation,
+    /// Rover receiver's dual-frequency observation for this satellite.
     pub rover: DualObservation,
 }
 
@@ -78,21 +113,39 @@ pub struct DualSatelliteObservation {
 /// caller's baseline epoch contract.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualEpoch {
+    /// Normalized satellite pairs scanned for the reference and for
+    /// non-reference double-difference wide-lane samples.
     pub observations: Vec<DualSatelliteObservation>,
 }
 
 /// One receiver's dual-frequency observation for cycle-slip preprocessing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualCycleSlipObservation {
+    /// Satellite token used to collect one receiver's observations into a
+    /// time-ordered carrier arc.
     pub satellite_id: String,
+    /// Ambiguity token carried through preparation and replaced when a split
+    /// or reacquisition starts a new receiver arc.
     pub ambiguity_id: String,
+    /// Band-1 code/pseudorange in meters passed to cycle-slip classification.
     pub p1_m: f64,
+    /// Band-2 code/pseudorange in meters passed to cycle-slip classification.
     pub p2_m: f64,
+    /// Band-1 carrier phase in cycles passed to geometry-free and
+    /// Melbourne-Wubbena classification.
     pub phi1_cycles: f64,
+    /// Band-2 carrier phase in cycles passed to geometry-free and
+    /// Melbourne-Wubbena classification.
     pub phi2_cycles: f64,
+    /// Positive band-1 carrier frequency in hertz used by the detector.
     pub f1_hz: f64,
+    /// Positive band-2 carrier frequency in hertz used by the detector.
     pub f2_hz: f64,
+    /// Band-1 loss-of-lock indicator copied to the detector; bit 0 contributes
+    /// [`SlipReason::Lli`].
     pub lli1: Option<i64>,
+    /// Band-2 loss-of-lock indicator copied to the detector; bit 0 contributes
+    /// [`SlipReason::Lli`].
     pub lli2: Option<i64>,
 }
 
@@ -103,7 +156,11 @@ pub struct DualCycleSlipEpoch {
     pub epoch_sort_key: String,
     /// Comparable epoch coordinate in seconds, when the caller can supply one.
     pub gap_time_s: Option<f64>,
+    /// Base observations grouped by satellite by the cycle-slip detector before
+    /// base-side events are emitted.
     pub base_observations: Vec<DualCycleSlipObservation>,
+    /// Rover observations grouped by satellite by the cycle-slip detector
+    /// before rover-side events are emitted.
     pub rover_observations: Vec<DualCycleSlipObservation>,
 }
 
@@ -111,58 +168,103 @@ pub struct DualCycleSlipEpoch {
 /// range correction removed from the ionosphere-free observable.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualIonosphereFreeObservation {
+    /// Ambiguity token preserved in the converted single-frequency
+    /// [`Observation`].
     pub ambiguity_id: String,
+    /// Band-1 code/pseudorange in meters passed to the ionosphere-free code
+    /// combination.
     pub p1_m: f64,
+    /// Band-2 code/pseudorange in meters passed to the ionosphere-free code
+    /// combination.
     pub p2_m: f64,
+    /// Band-1 carrier phase in cycles passed to the ionosphere-free phase
+    /// combination.
     pub phi1_cycles: f64,
+    /// Band-2 carrier phase in cycles passed to the ionosphere-free phase
+    /// combination.
     pub phi2_cycles: f64,
+    /// Positive band-1 carrier frequency in hertz used by both combinations.
     pub f1_hz: f64,
+    /// Positive band-2 carrier frequency in hertz used by both combinations.
     pub f2_hz: f64,
+    /// Receiver-specific slant troposphere delay in meters subtracted from
+    /// both ionosphere-free code and phase; the disabled setup path supplies
+    /// zero.
     pub tropo_m: f64,
 }
 
 /// Paired base/rover dual-frequency observation for IF/narrow-lane conversion.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualIonosphereFreeSatelliteObservation {
+    /// Satellite token used to pair the corrected base and rover records and
+    /// to locate a satellite during narrow-lane preparation.
     pub satellite_id: String,
+    /// Base receiver observation corrected by its troposphere delay before IF
+    /// conversion.
     pub base: DualIonosphereFreeObservation,
+    /// Rover receiver observation corrected by its troposphere delay before IF
+    /// conversion.
     pub rover: DualIonosphereFreeObservation,
 }
 
 /// One dual-frequency RTK epoch for IF/narrow-lane conversion.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualIonosphereFreeEpoch {
+    /// Per-satellite corrected base/rover inputs used for narrow-lane
+    /// parameters and retained IF observations.
     pub observations: Vec<DualIonosphereFreeSatelliteObservation>,
 }
 
 /// One normalized dual-frequency RTK epoch before IF/narrow-lane conversion.
 ///
-/// The core owns the optional troposphere setup, so this shape carries the
+/// The core owns the optional troposphere setup, so these fields carry the
 /// satellite positions and split Julian epoch needed to form per-receiver
 /// slant delays before the IF conversion is applied.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualIonosphereFreeSetupEpoch {
+    /// Whole part of the split Julian date passed to `JulianDateSplit::new`.
     pub jd_whole: f64,
+    /// Fractional part of the split Julian date, accepted in `-1.0..=1.0` and
+    /// passed to `JulianDateSplit::new`.
     pub jd_fraction: f64,
+    /// Normalized dual-frequency satellite pairs copied into corrected IF
+    /// inputs.
     pub observations: Vec<DualSatelliteObservation>,
+    /// Base-receiver satellite ECEF positions in meters, keyed by satellite
+    /// id, required for base slant troposphere when enabled.
     pub base_satellite_positions_m: BTreeMap<String, [f64; 3]>,
+    /// Rover-receiver satellite ECEF positions in meters, keyed by satellite
+    /// id, required for rover slant troposphere when enabled.
     pub rover_satellite_positions_m: BTreeMap<String, [f64; 3]>,
 }
 
 /// One converted single-observable epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IonosphereFreeBaselineEpoch {
+    /// Zero-based index of the input epoch retained in this converted result.
     pub epoch_index: usize,
+    /// Reference satellite followed by non-reference satellites with supplied
+    /// wide-lane integers.
     pub satellite_ids: Vec<String>,
+    /// Converted base observations for `satellite_ids`, with IF code and phase
+    /// after the troposphere subtraction.
     pub base_observations: Vec<Observation>,
+    /// Converted rover observations for `satellite_ids`, with IF code and phase
+    /// after the troposphere subtraction.
     pub rover_observations: Vec<Observation>,
 }
 
 /// Converted IF epochs plus per-DD narrow-lane ambiguity parameters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IonosphereFreeBaselineResult {
+    /// Converted epochs in input order; epochs with fewer than two retained
+    /// satellites are skipped.
     pub epochs: Vec<IonosphereFreeBaselineEpoch>,
+    /// Narrow-lane wavelengths in meters keyed by double-difference ambiguity
+    /// id.
     pub wavelengths_m: BTreeMap<String, f64>,
+    /// Narrow-lane code-to-phase offsets in meters keyed by double-difference
+    /// ambiguity id and computed from the fixed wide-lane integer.
     pub offsets_m: BTreeMap<String, f64>,
 }
 
@@ -192,6 +294,7 @@ pub struct ElevationMaskEpochResult {
 /// Elevation-mask result for a baseline arc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ElevationMaskResult {
+    /// One kept-id list per input epoch, emitted in input order.
     pub epochs: Vec<ElevationMaskEpochResult>,
     /// Satellites below the mask in any epoch, sorted by id.
     pub masked_satellite_ids: Vec<String>,
@@ -200,7 +303,11 @@ pub struct ElevationMaskResult {
 /// Wide-lane integer estimation controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct WideLaneOptions {
+    /// Positive minimum number of wide-lane samples required to fix an
+    /// ambiguity.
     pub min_epochs: usize,
+    /// Positive cycle tolerance for accepting the rounded wide-lane sample
+    /// mean as an integer.
     pub tolerance_cycles: f64,
     /// When true, short ambiguity fragments are omitted instead of failing. This
     /// is the `:split_arc` policy used by Sidereon after cycle-slip segmentation.
@@ -210,23 +317,39 @@ pub struct WideLaneOptions {
 /// Error from dual-frequency wide-lane integer estimation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WideLaneError {
+    /// A wide-lane option or observation failed validation.
     InvalidInput {
+        /// Static validation field label for the rejected input.
         field: &'static str,
+        /// Static validation reason paired with `field`.
         reason: &'static str,
     },
+    /// The requested reference satellite was absent from an epoch.
     ReferenceSatelliteMissing(String),
+    /// A base or rover wide-lane calculation failed for one satellite.
     WideLaneFailed {
+        /// Satellite whose wide-lane calculation failed.
         satellite_id: String,
+        /// Underlying carrier-phase failure.
         reason: CarrierPhaseError,
     },
+    /// One ambiguity has fewer samples than `WideLaneOptions::min_epochs`.
     TooFewWideLaneEpochs {
+        /// Ambiguity whose collected sample count was too small.
         ambiguity_id: String,
+        /// Number of collected wide-lane samples.
         count: usize,
+        /// Configured minimum sample count.
         minimum: usize,
     },
+    /// A sample mean did not lie within tolerance of its rounded integer.
     WideLaneNotInteger {
+        /// Ambiguity whose wide-lane mean could not be fixed.
         ambiguity_id: String,
+        /// Mean of the collected wide-lane double-difference samples, in
+        /// cycles.
         mean_cycles: f64,
+        /// Rounded integer candidate compared with the mean and tolerance.
         fixed_cycles: i64,
     },
 }
@@ -234,15 +357,27 @@ pub enum WideLaneError {
 /// Error from dual-frequency IF/narrow-lane conversion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IonosphereFreeBaselineError {
+    /// An IF observation, setup epoch, receiver geometry, or Julian split
+    /// failed validation.
     InvalidInput {
+        /// Static validation field label for the rejected input.
         field: &'static str,
+        /// Static validation reason paired with `field`.
         reason: &'static str,
     },
+    /// No epoch retained the reference and a non-reference satellite with a
+    /// supplied wide-lane integer.
     NoEpochs,
+    /// The four observations used for one narrow-lane DD did not share carrier
+    /// frequencies.
     InconsistentFrequencies(String),
+    /// Narrow-lane parameter derivation returned an ionosphere-free error.
     NarrowLaneFailed(IonosphereFreeError),
+    /// A code or phase ionosphere-free combination failed for one satellite.
     IonosphereFreeFailed {
+        /// Satellite whose code or phase combination failed.
         satellite_id: String,
+        /// Underlying ionosphere-free combination failure.
         reason: IonosphereFreeError,
     },
 }
@@ -250,13 +385,16 @@ pub enum IonosphereFreeBaselineError {
 /// Error from RTK code-smoothing preprocessing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodeSmoothingError {
+    /// The Hatch window cap is below the minimum accepted cap of one epoch.
     InvalidWindowCap,
 }
 
 /// Base/rover receiver side for RTK preprocessing diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CycleSlipReceiver {
+    /// The base receiver's observation vector.
     Base,
+    /// The rover receiver's observation vector.
     Rover,
 }
 
@@ -265,41 +403,66 @@ pub use crate::ambiguity::CycleSlipPolicy;
 /// Public split-arc metadata, with epoch indices for callers to remap.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CycleSlipSplitArc {
+    /// Receiver side whose satellite arc received this split ambiguity id.
     pub receiver: CycleSlipReceiver,
+    /// Satellite grouped with this receiver and ambiguity id.
     pub satellite_id: String,
+    /// Generated segment id, with `@base` or `@rover` before `#segment`.
     pub ambiguity_id: String,
+    /// First input epoch index recorded for the segment, inclusive.
     pub start_epoch_index: usize,
+    /// Last input epoch index recorded for the segment, inclusive.
     pub end_epoch_index: usize,
+    /// Number of input epoch indices recorded for the segment.
     pub n_epochs: usize,
 }
 
 /// Prepared single-frequency RTK epochs and policy metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CycleSlipPrepResult {
+    /// Single-frequency epochs after the selected policy and reacquisition
+    /// segmentation have been applied.
     pub epochs: Vec<CycleSlipEpoch>,
+    /// Unique satellite ids dropped by the drop policy, sorted by id.
     pub dropped_sats: Vec<String>,
+    /// Split metadata sorted by receiver, satellite, and ambiguity map order;
+    /// empty unless the split policy is used.
     pub split_arcs: Vec<CycleSlipSplitArc>,
 }
 
 /// Prepared dual-frequency RTK epochs and policy metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualCycleSlipPrepResult {
+    /// Dual-frequency epochs after the selected policy and reacquisition
+    /// segmentation have been applied.
     pub epochs: Vec<DualCycleSlipEpoch>,
+    /// Unique satellite ids dropped by the drop policy, sorted by id.
     pub dropped_sats: Vec<String>,
+    /// Split metadata sorted by receiver, satellite, and ambiguity map order;
+    /// empty unless the split policy is used.
     pub split_arcs: Vec<CycleSlipSplitArc>,
 }
 
 /// Error from RTK cycle-slip preprocessing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CycleSlipPrepError {
+    /// Single- or dual-frequency cycle-slip input or options failed validation.
     InvalidInput {
+        /// Static validation field label for the rejected input.
         field: &'static str,
+        /// Static validation reason paired with `field`.
         reason: &'static str,
     },
+    /// The error policy reported the first event in deterministic detector
+    /// order.
     CycleSlipDetected {
+        /// Receiver side on which the event was detected.
         receiver: CycleSlipReceiver,
+        /// Satellite whose carrier arc produced the event.
         satellite_id: String,
+        /// Zero-based input epoch index associated with the event.
         epoch_index: usize,
+        /// Detector reasons in carrier-phase classification order.
         reasons: Vec<SlipReason>,
     },
 }
@@ -316,10 +479,12 @@ pub enum ReferenceSelection {
     PerSystem(BTreeMap<String, String>),
 }
 
-/// Reference report shape matching the Sidereon public API.
+/// Reference report produced by `reference_report` for one or more systems.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReferenceReport {
+    /// One reference token was selected for the input.
     Satellite(String),
+    /// One reference token was selected for each constellation letter.
     PerSystem(BTreeMap<String, String>),
 }
 
@@ -338,37 +503,65 @@ pub enum BaselineReferenceSelection {
 /// One non-reference satellite's double-difference measurement.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DoubleDifference {
+    /// Non-reference common satellite id for this row.
     pub satellite_id: String,
+    /// Physical reference satellite used for this row's constellation.
     pub reference_satellite_id: String,
+    /// Double-difference ambiguity token derived from the satellite and
+    /// reference single-difference ids.
     pub ambiguity_id: String,
+    /// Code double difference in meters: satellite receiver difference minus
+    /// reference receiver difference.
     pub code_m: f64,
+    /// Carrier-phase double difference in meters: satellite receiver difference
+    /// minus reference receiver difference.
     pub phase_m: f64,
 }
 
 /// Result of double-difference construction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DoubleDifferenceResult {
+    /// Selected reference report, using `Satellite` for one system and
+    /// `PerSystem` for multiple systems.
     pub reference_satellite_id: ReferenceReport,
+    /// One row for each non-reference common satellite, in satellite-id order.
     pub double_differences: Vec<DoubleDifference>,
+    /// Sorted union of base-only and rover-only satellite ids excluded before
+    /// reference and double-difference construction.
     pub dropped_sats: Vec<String>,
 }
 
 /// Error from double-difference construction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DoubleDifferenceError {
+    /// An observation, receiver position, satellite position, line-of-sight
+    /// vector, or elevation score failed validation.
     InvalidInput {
+        /// Static validation field label for the rejected input.
         field: &'static str,
+        /// Static validation reason paired with `field`.
         reason: &'static str,
     },
+    /// A receiver input repeated one satellite key.
     DuplicateObservation(String),
+    /// Fewer than two common satellites were available, or a system had no
+    /// non-reference common satellite.
     TooFewCommonSatellites {
+        /// Common satellite count at the failure point.
         count: usize,
+        /// Required common count, fixed at two.
         minimum: usize,
     },
+    /// A constellation occurred in the arc but had no satellite common to all
+    /// reference-selection epochs.
     NoCommonReferenceSatellite(String),
+    /// An available satellite had no position-map entry.
     MissingSatellitePosition(String),
+    /// A requested reference id was absent from the relevant common set.
     ReferenceSatelliteMissing(String),
+    /// Fixed-satellite selection was used with more than one constellation.
     ReferenceSatelliteSingleSystem(String),
+    /// A per-system reference map omitted a constellation letter.
     ReferenceSatelliteMissingSystem(String),
     InvalidReferenceOption,
 }

--- a/crates/sidereon-core/src/rtk_filter/antenna.rs
+++ b/crates/sidereon-core/src/rtk_filter/antenna.rs
@@ -15,15 +15,37 @@ use crate::antenna::{
 /// `(azimuth_deg, zenith_deg, value_m)`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiverAntennaCalibration {
+    /// Local north/east/up phase-center offset, in meters. When mapped from
+    /// ANTEX, this is copied from [`crate::antex::Frequency::pco_m`], whose
+    /// parser converts the `NORTH / EAST / UP` millimeter record to meters;
+    /// RTK projects the components onto the local NEU basis and line of sight.
+    /// The row boundary rejects non-finite components before projection.
     pub pco_neu_m: [f64; 3],
+    /// Phase-center variation samples for a grid without azimuth dependence,
+    /// stored as `(zenith_deg, value_m)` pairs. RTK sorts this grid by zenith
+    /// and uses clamped linear interpolation when [`Self::azi_pcv_m`] is empty;
+    /// an empty grid returns [`ReceiverAntennaError::MissingPcv`].
     pub noazi_pcv_m: Vec<(f64, f64)>,
+    /// Azimuth-dependent phase-center variation samples, stored as
+    /// `(azimuth_deg, zenith_deg, value_m)` triples. A nonempty grid takes
+    /// precedence over [`Self::noazi_pcv_m`]; RTK interpolates each azimuth
+    /// node in zenith and blends the bracketing nodes, returning
+    /// [`ReceiverAntennaError::MissingPcv`] when the grid cannot supply them.
     pub azi_pcv_m: Vec<(f64, f64, f64)>,
 }
 
 /// Base and rover receiver-antenna calibrations used by the DD row builder.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiverAntennaCorrections {
+    /// Calibration applied to the base-station line of sight. The
+    /// double-difference correction evaluates it for both target and reference
+    /// satellites, and row validation labels its PCO components
+    /// `rtk.receiver_antenna.base.pco_neu_m`.
     pub base: ReceiverAntennaCalibration,
+    /// Calibration applied to the rover-station line of sight. The
+    /// double-difference correction evaluates it for both target and reference
+    /// satellites, and row validation labels its PCO components
+    /// `rtk.receiver_antenna.rover.pco_neu_m`.
     pub rover: ReceiverAntennaCalibration,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/arc.rs
+++ b/crates/sidereon-core/src/rtk_filter/arc.rs
@@ -68,7 +68,12 @@ pub struct RtkArcObservation {
     /// Ambiguity-arc id. A clean arc uses the satellite id; a cycle-slip split
     /// carries a distinct id (e.g. `"G05#2"`) so the single-difference key resets.
     pub ambiguity_id: String,
+    /// Pseudorange from the selected code observable, in meters. The arc solve
+    /// uses it in the code measurement and in the first-sighting ambiguity seed.
     pub code_m: f64,
+    /// Carrier phase from the selected phase observable, converted to meters.
+    /// The arc solve uses it in the phase measurement and in the first-sighting
+    /// ambiguity seed.
     pub phase_m: f64,
     /// Optional loss-of-lock indicator. Only consumed by the optional cycle-slip
     /// preprocessing ([`RtkArcPreprocessing::cycle_slip`]): bit 0 set marks a slip
@@ -81,7 +86,11 @@ pub struct RtkArcObservation {
 /// positions needed to form double differences.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkArcEpoch {
+    /// Base observations retained for satellites that also have a rover record
+    /// and all required shared and transmit-time position entries.
     pub base: Vec<RtkArcObservation>,
+    /// Rover observations retained for satellites that also have a base record
+    /// and all required shared and transmit-time position entries.
     pub rover: Vec<RtkArcObservation>,
     /// Shared receive-time satellite ECEF positions (metres), used for the
     /// elevation-dependent variance model and as the reference geometry.
@@ -161,12 +170,19 @@ pub struct RtkArcConfig {
     pub preprocessing: RtkArcPreprocessing,
 }
 
+/// Configuration consumed by [`solve_static_rtk_arc`] for a static batch RTK
+/// arc solve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkStaticArcConfig {
+    /// Sequential-arc settings reused for input preprocessing, geometry, and
+    /// measurement and ambiguity modeling.
     pub arc: RtkArcConfig,
+    /// Validated options for the float solve, fixed solve, and residual checks.
     pub opts: ValidatedFixedSolveOpts,
 }
 
+/// Results assembled by [`solve_static_rtk_arc`], including both batch solver
+/// outputs and metadata produced while preparing the input epochs.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkStaticArcSolution {
     /// Geometry observability and covariance-validation diagnostics for the
@@ -177,20 +193,43 @@ pub struct RtkStaticArcSolution {
     /// design diagnostics, but a full-rank propagated prior can validate
     /// zero-redundancy covariance.
     pub geometry_quality: GeometryQuality,
+    /// Per-constellation reference single-difference ambiguity ids returned by
+    /// `build_static_batch_epochs` for the batch epochs.
     pub references: BTreeMap<String, String>,
+    /// Globally ordered ambiguity-column ids returned by
+    /// `baseline_ambiguity_index_core` for the batch epochs.
     pub ambiguity_ids: Vec<String>,
+    /// Physical satellite associated with each ambiguity-column id, as returned
+    /// by `baseline_ambiguity_index_core` for scale lookup and reporting.
     pub ambiguity_satellites: BTreeMap<String, String>,
+    /// Float baseline solution returned by `solve_float_baseline` over all batch
+    /// epochs.
     pub float_solution: FloatBaselineSolution,
+    /// Validated fixed baseline solution returned by
+    /// `solve_fixed_baseline_validated` over the same batch and ambiguity set.
     pub fixed_solution: ValidatedFixedBaselineSolution,
+    /// Satellites copied from `preprocess_arc` after cycle-slip preprocessing
+    /// applies its drop policy.
     pub dropped_sats: Vec<String>,
+    /// Arc records copied from `preprocess_arc` after cycle-slip preprocessing
+    /// applies its split policy.
     pub split_cycle_slip_arcs: Vec<CycleSlipSplitArc>,
+    /// Satellites copied from `preprocess_arc` after the configured elevation
+    /// mask removes them.
     pub elevation_masked_sats: Vec<String>,
 }
 
+/// Errors that [`solve_static_rtk_arc`] can return while preparing or solving a
+/// static RTK arc.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkStaticArcError {
+    /// `solve_static_rtk_arc` failed during arc construction, reference or
+    /// filter-state setup, or enabled preprocessing before the batch solvers
+    /// completed.
     Arc(RtkArcError),
+    /// `solve_float_baseline` failed after the batch was constructed.
     Float(FloatSolveError),
+    /// `solve_fixed_baseline_validated` failed after the float solve.
     Fixed(ValidatedFixedSolveError),
 }
 
@@ -220,54 +259,121 @@ impl From<RtkArcError> for RtkStaticArcError {
     }
 }
 
+/// Dual-frequency values extracted by `dual_frequency_observations` for one
+/// receiver and one RTK satellite.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkDualFrequencyObservation {
+    /// Ambiguity-arc identifier, initialized from the satellite token by the
+    /// RINEX builder and possibly renamed by cycle-slip splitting.
     pub ambiguity_id: String,
+    /// First-frequency pseudorange in meters, copied by
+    /// `dual_frequency_observations` and passed unchanged to dual-frequency
+    /// preparation.
     pub p1_m: f64,
+    /// Second-frequency pseudorange in meters, copied by
+    /// `dual_frequency_observations` and passed unchanged to dual-frequency
+    /// preparation.
     pub p2_m: f64,
+    /// First-frequency carrier phase in cycles, copied by
+    /// `dual_frequency_observations` and retained in cycles for dual-frequency
+    /// preparation.
     pub phi1_cycles: f64,
+    /// Second-frequency carrier phase in cycles, copied by
+    /// `dual_frequency_observations` and retained in cycles for dual-frequency
+    /// preparation.
     pub phi2_cycles: f64,
+    /// First selected carrier frequency in hertz, looked up from the RINEX
+    /// phase observable by `dual_frequency_observations`.
     pub f1_hz: f64,
+    /// Second selected carrier frequency in hertz, looked up from the RINEX
+    /// phase observable by `dual_frequency_observations`.
     pub f2_hz: f64,
+    /// Optional loss-of-lock value from the first phase observable, consumed by
+    /// dual-frequency cycle-slip preprocessing.
     pub lli1: Option<i64>,
+    /// Optional loss-of-lock value from the second phase observable, consumed by
+    /// dual-frequency cycle-slip preprocessing.
     pub lli2: Option<i64>,
 }
 
+/// A base/rover dual-frequency pair emitted by
+/// `build_dual_frequency_rinex_rtk_arc` for one satellite and epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkDualFrequencySatelliteObservation {
+    /// Satellite token used to pair observations and position-map entries.
     pub satellite_id: String,
+    /// Complete selected dual-frequency observation extracted from the base
+    /// RINEX epoch.
     pub base: RtkDualFrequencyObservation,
+    /// Complete selected dual-frequency observation extracted from the rover
+    /// RINEX epoch matched to the base epoch.
     pub rover: RtkDualFrequencyObservation,
 }
 
+/// A dual-frequency RTK epoch emitted by
+/// `build_dual_frequency_rinex_rtk_arc` for wide-lane and ionosphere-free
+/// preparation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkDualFrequencyArcEpoch {
+    /// Whole part returned by `civil_to_julian_split` for the civil epoch and
+    /// passed to ionosphere-free setup.
     pub jd_whole: f64,
+    /// Fractional part returned by `civil_to_julian_split` for the civil epoch
+    /// and passed to ionosphere-free setup.
     pub jd_fraction: f64,
+    /// Fixed-width civil timestamp used to order dual cycle-slip records; absent
+    /// values fall back to the input index during preprocessing.
     pub epoch_sort_key: Option<String>,
+    /// Seconds since J2000 used by dual cycle-slip preprocessing to detect gaps.
     pub gap_time_s: Option<f64>,
+    /// Base/rover pairs retained after complete signal, ephemeris, and position
+    /// checks.
     pub observations: Vec<RtkDualFrequencySatelliteObservation>,
+    /// Shared receive-time satellite ECEF positions, in meters, used for
+    /// reference geometry.
     pub satellite_positions_m: BTreeMap<String, [f64; 3]>,
+    /// Base transmit-time satellite ECEF positions, in meters; an empty map
+    /// makes the driver use [`Self::satellite_positions_m`].
     pub base_satellite_positions_m: BTreeMap<String, [f64; 3]>,
+    /// Rover transmit-time satellite ECEF positions, in meters; an empty map
+    /// makes the driver use [`Self::satellite_positions_m`].
     pub rover_satellite_positions_m: BTreeMap<String, [f64; 3]>,
+    /// Optional rover ECEF velocity, in meters per second, preserved for a later
+    /// velocity-propagated sequential solve.
     pub velocity_mps: Option<[f64; 3]>,
+    /// Optional seconds-since-J2000 coordinate preserved for prediction deltas
+    /// in a later sequential solve.
     pub prediction_time_s: Option<f64>,
 }
 
+/// Settings forwarded by `prepare_dual_frequency_arc` to dual-frequency
+/// cycle-slip preprocessing for a wide-lane arc.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RtkDualCycleSlipConfig {
+    /// Action selected by dual-frequency preprocessing when it detects a slip.
     pub policy: CycleSlipPolicy,
+    /// Detector thresholds and gap-handling options forwarded unchanged to
+    /// `prepare_dual_cycle_slip_baseline_epochs`.
     pub options: CycleSlipOptions,
 }
 
+/// Inputs consumed by [`fix_wide_lane_rtk_arc`] for dual-frequency wide-lane
+/// ambiguity estimation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneArcConfig {
+    /// Base-station ECEF position, in meters, used for reference geometry.
     pub base_m: [f64; 3],
+    /// Policy used to select one reference satellite per constellation.
     pub reference: BaselineReferenceSelection,
+    /// Wide-lane estimator options passed to each selected constellation.
     pub options: WideLaneOptions,
+    /// Optional dual-frequency cycle-slip preparation before reference selection
+    /// and wide-lane estimation.
     pub cycle_slip: Option<RtkDualCycleSlipConfig>,
 }
 
+/// Output assembled by [`fix_wide_lane_rtk_arc`] from wide-lane estimates and
+/// the dual-frequency epochs used to obtain them.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneArcSolution {
     /// Geometry observability and covariance-validation diagnostics for the
@@ -278,18 +384,29 @@ pub struct RtkWideLaneArcSolution {
     /// Sequential filter epochs use the same instantaneous design diagnostics,
     /// but a full-rank propagated prior can validate zero-redundancy covariance.
     pub geometry_quality: GeometryQuality,
+    /// Per-constellation physical reference satellite tokens.
     pub references: BTreeMap<String, String>,
+    /// Integer wide-lane cycle estimates accumulated across the selected systems.
     pub wide_lane_cycles: BTreeMap<String, i64>,
+    /// Input epochs after optional dual cycle-slip preparation.
     pub epochs: Vec<RtkDualFrequencyArcEpoch>,
+    /// Satellites removed by dual cycle-slip preprocessing under its drop policy.
     pub dropped_sats: Vec<String>,
+    /// Split-arc records produced by dual cycle-slip preprocessing.
     pub split_cycle_slip_arcs: Vec<CycleSlipSplitArc>,
 }
 
+/// Errors that [`fix_wide_lane_rtk_arc`] can return while preparing or estimating
+/// a dual-frequency wide-lane arc.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkWideLaneArcError {
+    /// `fix_wide_lane_rtk_arc` found an empty epoch slice before preprocessing.
     EmptyEpochs,
+    /// `dual_arc_references` failed to select reference satellites.
     Reference(DoubleDifferenceError),
+    /// `prepare_dual_frequency_arc` failed during dual cycle-slip preprocessing.
     CycleSlipPrep(CycleSlipPrepError),
+    /// `estimate_wide_lane_ambiguities` failed for a selected constellation.
     WideLane(WideLaneError),
 }
 
@@ -308,81 +425,154 @@ impl core::fmt::Display for RtkWideLaneArcError {
 
 impl std::error::Error for RtkWideLaneArcError {}
 
+/// Settings consumed by [`prepare_ionosphere_free_rtk_arc`] when converting
+/// dual-frequency epochs to ionosphere-free observations.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkIonosphereFreeArcConfig {
+    /// Base-station ECEF position in meters, passed to reference selection and
+    /// ionosphere-free preparation.
     pub base_m: [f64; 3],
+    /// Initial rover-minus-base ECEF baseline guess in meters, passed to each
+    /// system's ionosphere-free setup.
     pub initial_baseline_m: [f64; 3],
+    /// Policy passed to dual reference selection for each constellation.
     pub reference: BaselineReferenceSelection,
+    /// Flag passed to the standalone preparation to select its troposphere
+    /// correction branch.
     pub apply_troposphere: bool,
 }
 
+/// Output assembled by [`prepare_ionosphere_free_rtk_arc`], including the
+/// ionosphere-free epochs and ambiguity scales needed by the final RTK solve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkIonosphereFreeArcSolution {
+    /// Per-constellation physical reference satellite tokens returned by dual
+    /// reference selection.
     pub references: BTreeMap<String, String>,
+    /// Single-frequency ionosphere-free epochs merged by original input index
+    /// from each system's setup result.
     pub epochs: Vec<RtkArcEpoch>,
+    /// Wavelength scale per resulting single-difference ambiguity id, in meters,
+    /// returned for the final fixed solve.
     pub wavelengths_m: BTreeMap<String, f64>,
+    /// Code-to-phase offset scale per resulting single-difference ambiguity id,
+    /// in meters, returned for the final fixed solve.
     pub offsets_m: BTreeMap<String, f64>,
 }
 
+/// Selects the final static or sequential solve matched by
+/// [`solve_wide_lane_fixed_rtk_arc`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkWideLaneFixedArcSolveConfig {
+    /// When selected, the combined driver calls `solve_static_rtk_arc` after
+    /// injecting the ionosphere-free reference and scale maps.
     Static(RtkStaticArcConfig),
+    /// When selected, the combined driver calls `solve_rtk_arc` after injecting
+    /// the ionosphere-free reference and scale maps.
     Sequential(RtkArcConfig),
 }
 
+/// Configuration consumed by [`solve_wide_lane_fixed_rtk_arc`] for its
+/// wide-lane, ionosphere-free, and final RTK stages.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneFixedArcConfig {
+    /// Settings consumed by the initial wide-lane preparation and estimation.
     pub wide_lane: RtkWideLaneArcConfig,
+    /// Settings consumed by ionosphere-free conversion of the prepared epochs.
     pub ionosphere_free: RtkIonosphereFreeArcConfig,
+    /// Settings and branch selection for the final static or sequential solve.
     pub solve: RtkWideLaneFixedArcSolveConfig,
 }
 
+/// Identifies the branch recorded by `wide_lane_fixed_metadata` after a combined
+/// RTK arc solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RtkWideLaneFixedArcIntegerMethod {
+    /// `solve_wide_lane_fixed_rtk_arc` selected the static branch, whose
+    /// validated LAMBDA solve consumes the wide-lane scales.
     WideLaneNarrowLaneLambda,
+    /// `solve_wide_lane_fixed_rtk_arc` selected the sequential branch, whose
+    /// per-epoch ambiguity search consumes the wide-lane scales.
     WideLaneNarrowLaneSequential,
 }
 
+/// Metadata assembled by `wide_lane_fixed_metadata` to connect wide-lane fixing
+/// with the final RTK arc result.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneFixedArcMetadata {
+    /// Final path marker set by `wide_lane_fixed_metadata` from the selected
+    /// static or sequential branch.
     pub integer_method: RtkWideLaneFixedArcIntegerMethod,
+    /// Set to `true` by `wide_lane_fixed_metadata` after wide-lane fixing has
+    /// succeeded.
     pub wide_lane_fixed: bool,
+    /// Wide-lane integer estimates filtered to satellites used by the final
+    /// static ambiguity index or sequential epoch solutions.
     pub wide_lane_ambiguities_cycles: BTreeMap<String, i64>,
+    /// Dropped-satellite list copied from the wide-lane stage's cycle-slip
+    /// preparation.
     pub dropped_cycle_slip_sats: Vec<String>,
+    /// Split-arc list copied from the wide-lane stage's cycle-slip preparation.
     pub split_cycle_slip_arcs: Vec<CycleSlipSplitArc>,
 }
 
+/// Static branch assembled by [`solve_wide_lane_fixed_rtk_arc`] from its wide-
+/// lane, ionosphere-free, and final static results.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneFixedStaticArcSolution {
+    /// Wide-lane stage result used to derive the combined metadata.
     pub wide_lane: RtkWideLaneArcSolution,
+    /// Ionosphere-free stage result whose epochs and scales feed the static solve.
     pub ionosphere_free: RtkIonosphereFreeArcSolution,
+    /// Final static batch result after reference and scale injection.
     pub solution: RtkStaticArcSolution,
+    /// Metadata identifying the static combined path and its wide-lane outcomes.
     pub metadata: RtkWideLaneFixedArcMetadata,
 }
 
+/// Sequential branch assembled by [`solve_wide_lane_fixed_rtk_arc`] from its
+/// wide-lane, ionosphere-free, and final sequential results.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkWideLaneFixedSequentialArcSolution {
+    /// Wide-lane stage result used to derive the combined metadata.
     pub wide_lane: RtkWideLaneArcSolution,
+    /// Ionosphere-free stage result whose epochs and scales feed the sequential
+    /// solve.
     pub ionosphere_free: RtkIonosphereFreeArcSolution,
+    /// Final sequential arc result after reference and scale injection.
     pub solution: RtkArcSolution,
+    /// Metadata identifying the sequential combined path and its wide-lane
+    /// outcomes.
     pub metadata: RtkWideLaneFixedArcMetadata,
 }
 
 // Returned by value once per solve, never held in bulk, so the static-vs-sequential
 // size difference is immaterial; boxing a variant would churn the public + binding API.
 #[allow(clippy::large_enum_variant)]
+/// Result returned by [`solve_wide_lane_fixed_rtk_arc`] after its wide-lane and
+/// ionosphere-free stages and selected final solve.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkWideLaneFixedArcSolution {
+    /// The selected final solver was the static batch path.
     Static(RtkWideLaneFixedStaticArcSolution),
+    /// The selected final solver was the sequential arc path.
     Sequential(RtkWideLaneFixedSequentialArcSolution),
 }
 
+/// Errors returned by [`solve_wide_lane_fixed_rtk_arc`] from its combined
+/// wide-lane, ionosphere-free, or final RTK stages.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkWideLaneFixedArcError {
+    /// `ensure_single_wide_lane_system` found multiple constellations, or
+    /// `single_reference_satellite` did not find exactly one reference.
     UnsupportedMultiGnss,
+    /// The initial wide-lane stage returned an error.
     WideLane(RtkWideLaneArcError),
+    /// Ionosphere-free preparation over the wide-lane epochs returned an error.
     IonosphereFree(RtkIonosphereFreeArcError),
+    /// The final static branch returned an `RtkStaticArcError`.
     Static(RtkStaticArcError),
+    /// The final sequential branch returned an `RtkArcError`.
     Sequential(RtkArcError),
 }
 
@@ -412,10 +602,17 @@ impl std::error::Error for RtkWideLaneFixedArcError {
     }
 }
 
+/// Errors that [`prepare_ionosphere_free_rtk_arc`] can return while preparing
+/// dual-frequency ionosphere-free epochs.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkIonosphereFreeArcError {
+    /// `prepare_ionosphere_free_rtk_arc` found an empty epoch slice before
+    /// reference selection.
     EmptyEpochs,
+    /// `dual_arc_references` failed to select reference satellites.
     Reference(DoubleDifferenceError),
+    /// The standalone ionosphere-free preparation failed, including its
+    /// `NoEpochs` result when no system produced a usable epoch.
     IonosphereFree(IonosphereFreeBaselineError),
 }
 
@@ -499,21 +696,33 @@ pub enum RtkArcError {
     /// The arc has no epochs.
     EmptyEpochs,
     /// Fewer than four satellites appear across the whole arc.
-    TooFewSatellites { count: usize, minimum: usize },
+    TooFewSatellites {
+        /// Number of distinct satellites in the normalized arc availability union.
+        count: usize,
+        /// Required number of distinct arc satellites; currently four.
+        minimum: usize,
+    },
     /// Reference-satellite selection failed.
     Reference(DoubleDifferenceError),
     /// The constructed initial filter state was invalid.
     FilterState(FilterStateValidationError),
     /// A per-epoch sequential update failed.
     Update {
+        /// Zero-based index of the epoch whose update failed.
         epoch_index: usize,
+        /// Error returned by the sequential filter for that epoch.
         source: UpdateError,
     },
     /// A strict (velocity-propagated) run hit a missing/incomparable epoch time.
-    InvalidEpochTime { epoch_index: usize },
+    InvalidEpochTime {
+        /// Zero-based index of the non-first epoch without comparable time data.
+        epoch_index: usize,
+    },
     /// A satellite in the availability set is missing a required position.
     MissingPosition {
+        /// Zero-based index of the epoch being assembled.
         epoch_index: usize,
+        /// Satellite token whose shared or receiver-specific position is missing.
         satellite_id: String,
     },
     /// Cycle-slip preprocessing rejected the input or detected a slip under
@@ -650,6 +859,16 @@ pub fn solve_rtk_arc(
     })
 }
 
+/// Solve a static RTK baseline over a raw arc as one batch.
+///
+/// Enabled preprocessing runs before batch construction. The function then
+/// derives the ambiguity columns and scale maps, calls the float and validated
+/// fixed baseline solvers, and returns their results with preprocessing metadata.
+/// The static-station wrapper uses this path after filling the arc scale maps
+/// from RINEX.
+///
+/// An empty epoch slice is returned as [`RtkStaticArcError::Arc`]. Other
+/// preparation, float, and fixed failures retain their corresponding variants.
 pub fn solve_static_rtk_arc(
     epochs: &[RtkArcEpoch],
     config: &RtkStaticArcConfig,
@@ -714,6 +933,17 @@ pub fn solve_static_rtk_arc(
     })
 }
 
+/// Estimate wide-lane integer ambiguities across a dual-frequency RTK arc.
+///
+/// The function optionally applies dual-frequency cycle-slip preparation, selects
+/// one reference satellite per constellation, runs the standalone wide-lane
+/// estimator for each selected system, and returns the prepared epochs together
+/// with geometry and cycle-slip metadata. The estimate map is accumulated across
+/// the systems in deterministic map order.
+///
+/// An empty epoch slice returns [`RtkWideLaneArcError::EmptyEpochs`]. Failures in
+/// reference selection, cycle-slip preparation, or wide-lane estimation are
+/// wrapped in the matching error variant.
 pub fn fix_wide_lane_rtk_arc(
     epochs: &[RtkDualFrequencyArcEpoch],
     config: &RtkWideLaneArcConfig,
@@ -748,6 +978,16 @@ pub fn fix_wide_lane_rtk_arc(
     })
 }
 
+/// Convert a dual-frequency RTK arc to ionosphere-free single-frequency epochs.
+///
+/// References are selected per constellation, the standalone ionosphere-free
+/// preparation runs for each system with the supplied wide-lane integers, and
+/// the resulting records are merged by their original epoch index. The returned
+/// wavelength and offset maps are intended for the subsequent fixed RTK solve.
+///
+/// Empty input returns [`RtkIonosphereFreeArcError::EmptyEpochs`]; if no system
+/// produces an epoch, the function returns its `IonosphereFree` variant with
+/// [`IonosphereFreeBaselineError::NoEpochs`].
 pub fn prepare_ionosphere_free_rtk_arc(
     epochs: &[RtkDualFrequencyArcEpoch],
     wide_lane_cycles: &BTreeMap<String, i64>,
@@ -806,6 +1046,16 @@ pub fn prepare_ionosphere_free_rtk_arc(
     })
 }
 
+/// Run the complete wide-lane, ionosphere-free, and final RTK arc pipeline.
+///
+/// The input must contain one constellation. After wide-lane fixing and
+/// ionosphere-free conversion, the function injects the sole selected reference
+/// and the derived wavelength/offset maps into either the configured static or
+/// sequential solve, then returns the corresponding composite result.
+///
+/// [`RtkWideLaneFixedArcError::UnsupportedMultiGnss`] is returned for multiple
+/// constellations or for a reference map that is not singular; failures from
+/// each pipeline stage retain their matching error variant.
 pub fn solve_wide_lane_fixed_rtk_arc(
     epochs: &[RtkDualFrequencyArcEpoch],
     config: &RtkWideLaneFixedArcConfig,

--- a/crates/sidereon-core/src/rtk_filter/fixed.rs
+++ b/crates/sidereon-core/src/rtk_filter/fixed.rs
@@ -38,11 +38,24 @@ use crate::validate;
 /// Controls for the static fixed RTK solve.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FixedSolveOpts {
+    /// Positive meters threshold for the norm of the three baseline update
+    /// components; the fixed loop requires this and the ambiguity threshold to
+    /// terminate by state tolerance.
     pub position_tol_m: f64,
+    /// Positive meters threshold for the largest absolute free-ambiguity update;
+    /// the fixed loop requires this and the baseline threshold to terminate by
+    /// state tolerance.
     pub ambiguity_tol_m: f64,
+    /// Positive upper bound for fixed re-solve iterations; reaching it without
+    /// satisfying both step thresholds returns a non-converged solution.
     pub max_iterations: usize,
+    /// Positive LAMBDA ratio threshold passed to the integer lattice resolver.
     pub ratio_threshold: f64,
+    /// Enables the partial-search fallback when the full integer search is not
+    /// fixed; the default is `false`.
     pub partial_ambiguity_resolution: bool,
+    /// Minimum subset size for partial ambiguity resolution when enabled; zero is
+    /// rejected in that mode.
     pub partial_min_ambiguities: usize,
 }
 
@@ -66,84 +79,162 @@ impl Default for FixedSolveOpts {
 /// Static batch integer-fixed RTK solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedBaselineSolution {
+    /// Final three-component fixed baseline state in meters, after updates from
+    /// the fixed normal-equation re-solve have been applied.
     pub baseline_m: [f64; 3],
+    /// The 3x3 baseline covariance in square meters from the final fixed normal
+    /// matrix's first three parameter rows and columns.
     pub baseline_covariance_m2: [[f64; 3]; 3],
+    /// Free double-difference ambiguity ids paired with their final estimated
+    /// values in meters.
     pub free_ambiguities_m: Vec<(String, f64)>,
+    /// Integer cycles returned by the ambiguity search for each fixed ambiguity
+    /// id, in id-sorted order.
     pub fixed_ambiguities_cycles: Vec<(String, i64)>,
+    /// Held ambiguity values in meters, calculated from each fixed cycle count,
+    /// wavelength, and meter offset, in id-sorted order.
     pub fixed_ambiguities_m: Vec<(String, f64)>,
+    /// Paired code and carrier-phase residual records reconstructed from the
+    /// final fixed double-difference rows.
     pub residuals: Vec<FloatResidual>,
+    /// Integer-search diagnostics, including the LAMBDA result or empty
+    /// non-fixed metadata when there are no integer-search targets.
     pub search: IntegerSearchMeta,
+    /// Number of fixed re-solve iterations, including the terminating iteration.
     pub iterations: usize,
+    /// Whether both the baseline and free-ambiguity step thresholds were met.
     pub converged: bool,
+    /// `StateTolerance` for tolerance termination or `MaxIterations` for limit
+    /// termination.
     pub status: FloatSolveStatus,
+    /// Root-mean-square of the reconstructed code residuals in meters.
     pub code_rms_m: f64,
+    /// Root-mean-square of the reconstructed carrier-phase residuals in meters.
     pub phase_rms_m: f64,
+    /// Root-mean-square of each final row's prefit residual multiplied by its row
+    /// weight.
     pub weighted_rms_m: f64,
+    /// Number of final double-difference rows retained in the solve scratch
+    /// buffer.
     pub n_observations: usize,
 }
 
 /// Code or phase component selected by the RTK residual-validation gate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResidualComponentKind {
+    /// Selects `code_m`, `code_sigma_m`, and `code_normalized` in
+    /// `residual_validation_outlier_core`.
     Code,
+    /// Selects `phase_m`, `phase_sigma_m`, and `phase_normalized` in
+    /// `residual_validation_outlier_core`.
     Phase,
 }
 
 /// Worst normalized residual selected by the RTK validation gate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResidualValidationOutlier {
+    /// Epoch index copied from the selected [`FloatResidual`].
     pub epoch_index: usize,
+    /// Rover non-reference satellite id copied from the selected residual and
+    /// used for satellite exclusion.
     pub satellite_id: String,
+    /// Reference satellite id copied from the selected double-difference
+    /// residual.
     pub reference_satellite_id: String,
+    /// Composed double-difference ambiguity id copied from the selected residual.
     pub ambiguity_id: String,
+    /// Whether the selected component is code or carrier phase.
     pub kind: ResidualComponentKind,
+    /// Selected code or carrier-phase residual in meters.
     pub residual_m: f64,
+    /// Measurement sigma for the selected component in meters.
     pub sigma_m: f64,
+    /// Signed normalized residual; outlier selection compares its absolute value
+    /// with every other code and phase component.
     pub normalized_residual: f64,
+    /// Configured positive threshold that the selected absolute normalized
+    /// residual exceeded.
     pub threshold_sigma: f64,
 }
 
 /// Optional residual-validation controls for fixed RTK baseline solving.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ResidualValidationOpts {
+    /// Optional positive finite normalized-residual threshold; `None` disables
+    /// outlier selection and validation metadata.
     pub threshold_sigma: Option<f64>,
+    /// Maximum number of satellite exclusions attempted before a remaining
+    /// outlier is returned as a validation failure.
     pub max_exclusions: usize,
 }
 
 /// Residual-validation metadata for the accepted fixed RTK solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResidualValidationMeta {
+    /// Enabled normalized-residual threshold copied by
+    /// `residual_validation_meta_core` from the validation options.
     pub threshold_sigma: f64,
+    /// Exclusion limit copied by `residual_validation_meta_core` from the
+    /// validation options.
     pub max_exclusions: usize,
+    /// Unique satellite ids from the attempted exclusions, collected by
+    /// `residual_validation_meta_core` through a `BTreeSet` in sorted order.
     pub excluded_sats: Vec<String>,
+    /// Outliers found and removed during successive float-solve attempts, in
+    /// removal order.
     pub exclusions: Vec<ResidualValidationOutlier>,
 }
 
 /// Fixed RTK solution plus the final float solve used by integer fixing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidatedFixedBaselineSolution {
+    /// Last `run_float` result produced for the accepted working epochs, before
+    /// `solve_fixed_baseline_with_normal` performs integer fixing.
     pub float_solution: FloatBaselineSolution,
+    /// `solve_fixed_baseline_with_normal` result using the accepted float
+    /// baseline, ambiguities, and covariance.
     pub fixed_solution: FixedBaselineSolution,
+    /// Result of `residual_validation_meta_core`; it is `None` when the
+    /// residual options contain no threshold.
     pub residual_validation: Option<ResidualValidationMeta>,
+    /// Ambiguity columns used by the accepted solve; after an exclusion these
+    /// are rebuilt from the remaining epochs.
     pub ambiguity_ids: Vec<String>,
+    /// Map from each accepted double-difference ambiguity id to its rover
+    /// non-reference satellite.
     pub ambiguity_satellites: BTreeMap<String, String>,
 }
 
 /// Why the residual-validated fixed RTK solve could not complete.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValidatedFixedSolveError {
+    /// `run_fixed_validated` converts a float, row-building, integer-search, or
+    /// fixed linear-algebra failure into this variant.
     Fixed(FixedSolveError),
+    /// The worst normalized residual remained above threshold after the allowed
+    /// satellite exclusions were attempted.
     ResidualValidationFailed {
+        /// Remaining worst residual that could not be accepted or excluded.
         outlier: Box<ResidualValidationOutlier>,
+        /// Earlier outliers whose satellites were excluded before this failure.
         exclusions: Vec<ResidualValidationOutlier>,
     },
+    /// One composed ambiguity id was associated with two different rover
+    /// satellites across the epochs.
     DuplicateAmbiguityId {
+        /// Composed ambiguity id found for both conflicting satellites.
         ambiguity_id: String,
+        /// Rover satellite stored when the ambiguity id was first inserted.
         first_satellite_id: String,
+        /// Later rover satellite that reused the ambiguity id.
         second_satellite_id: String,
     },
+    /// The available code/phase rows are fewer than the baseline and ambiguity
+    /// parameters required by the accepted solve.
     Underdetermined {
+        /// Number of double-difference rows available after exclusions.
         row_count: usize,
+        /// Three baseline components plus the accepted ambiguity-column count.
         unknown_count: usize,
     },
 }
@@ -209,18 +300,38 @@ impl From<FixedSolveError> for ValidatedFixedSolveError {
 /// Why a static fixed RTK solve could not complete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FixedSolveError {
+    /// `From<FloatSolveError>` wraps a float error not mapped to a more specific
+    /// fixed error.
     Float(FloatSolveError),
+    /// `search_ambiguity_ids` maps the integer lattice resolver's error here.
     Ils(crate::ils::IlsError),
+    /// A float ambiguity lookup, row builder, or search helper found no supplied
+    /// value for the required id.
     MissingAmbiguity(String),
+    /// Covariance conversion, float-cycle conversion, or fixed-meter conversion
+    /// found no wavelength for the id in the supplied scale map.
     MissingWavelength(String),
+    /// Float-cycle conversion or fixed-meter conversion found no meter offset for
+    /// the id in the supplied scale map.
     MissingOffset(String),
+    /// The flat float covariance length was not the square of the ambiguity-id
+    /// count.
     InvalidCovarianceDimensions,
+    /// `validate_fixed_solve_opts`, covariance validation, or `fixed_row_error`
+    /// rejected a fixed-solve boundary input.
     InvalidInput {
+        /// Static field name identifying the rejected input.
         field: &'static str,
+        /// Validation category explaining why the input was rejected.
         kind: super::RtkInputErrorKind,
     },
+    /// Normal-equation assembly, selected solution, or final covariance inversion
+    /// returned no result.
     SingularGeometry,
+    /// Final rows were not complete adjacent code/phase pairs for one residual.
     IncompleteResidualPair,
+    /// `fixed_row_error` mapped a receiver-antenna correction failure from row
+    /// construction.
     ReceiverAntenna(ReceiverAntennaError),
 }
 
@@ -299,9 +410,16 @@ struct FixedAmbiguities<'a> {
 /// separately.
 #[derive(Clone, Copy)]
 pub struct AmbiguitySet<'a> {
+    /// Ambiguity ids in the caller's state and covariance column order.
     pub ids: &'a [String],
+    /// Map from ambiguity ids to rover satellite ids, used for float-only
+    /// constellation filtering and rebuilding after exclusions.
     pub satellites: &'a BTreeMap<String, String>,
+    /// Per-id wavelengths and meter offsets used for cycle conversion and fixed
+    /// meter values.
     pub scale: AmbiguityScale<'a>,
+    /// Constellation tokens whose matching ambiguity ids remain free instead of
+    /// entering integer resolution.
     pub float_only_systems: &'a [String],
 }
 
@@ -311,8 +429,12 @@ pub struct AmbiguitySet<'a> {
 /// stays within a small argument list.
 #[derive(Clone, Copy)]
 pub struct FloatPrior<'a> {
+    /// Initial fixed-state baseline in meters before normal-equation updates.
     pub baseline_m: [f64; 3],
+    /// Float double-difference ambiguity estimates in meters, indexed by id.
     pub ambiguities_m: &'a [(String, f64)],
+    /// Flat row-major ambiguity covariance in square meters; its dimensions and
+    /// positive-semidefinite rows are checked before integer search.
     pub covariance_m: &'a [f64],
 }
 
@@ -320,8 +442,14 @@ pub struct FloatPrior<'a> {
 /// inner float solve, the integer-fixed solve, and the residual-validation gate.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ValidatedFixedSolveOpts {
+    /// `run_fixed_validated` passes these options to the prerequisite `run_float`
+    /// call after validation.
     pub float: FloatSolveOpts,
+    /// `run_fixed_validated` passes these options to integer search and the fixed
+    /// re-solve after validation.
     pub fixed: FixedSolveOpts,
+    /// `run_fixed_validated` passes these options to residual outlier selection
+    /// and satellite-exclusion control after validation.
     pub residual: ResidualValidationOpts,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/float.rs
+++ b/crates/sidereon-core/src/rtk_filter/float.rs
@@ -41,15 +41,32 @@ use super::{
 /// Terminal status of the static batch float RTK solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatSolveStatus {
+    /// The Euclidean baseline step and the largest absolute ambiguity step both
+    /// met their configured tolerances.
+    ///
+    /// This is the terminal status returned when the float or fixed iteration
+    /// loop stops by state tolerance.
     StateTolerance,
+    /// The iteration cap was reached before both state-step tolerances were met.
+    ///
+    /// A solution finalized with this status has `converged` set to `false`.
     MaxIterations,
 }
 
 /// Controls for the static batch float RTK solve.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FloatSolveOpts {
+    /// Finite positive threshold in meters for the Euclidean norm of the three
+    /// baseline-update components. Convergence requires the baseline step to be
+    /// no greater than this value.
     pub position_tol_m: f64,
+    /// Finite positive threshold in meters for the largest absolute update among
+    /// the float ambiguity columns. Convergence requires that maximum to be no
+    /// greater than this value.
     pub ambiguity_tol_m: f64,
+    /// Nonzero upper bound on solve iterations. Reaching it without satisfying
+    /// both step tests produces a non-converged result with
+    /// [`FloatSolveStatus::MaxIterations`].
     pub max_iterations: usize,
 }
 
@@ -70,33 +87,83 @@ impl Default for FloatSolveOpts {
 /// One public residual row from the static batch float solve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatResidual {
+    /// Zero-based input-epoch index copied from the double-difference row. A
+    /// sequential one-epoch report uses index zero.
     pub epoch_index: usize,
+    /// Non-reference rover satellite token for this double-difference residual.
     pub satellite_id: String,
+    /// Reference satellite token selected for the non-reference satellite's
+    /// constellation.
     pub reference_satellite_id: String,
+    /// Composed double-difference ambiguity id. It combines the satellite and
+    /// reference single-difference ids with `|ref=`, except for the trivial case
+    /// where both ids equal their satellite tokens, which uses the bare satellite
+    /// token.
     pub ambiguity_id: String,
+    /// Code double-difference prefit residual in meters: observed double-
+    /// difference code minus modeled geometric double difference, including any
+    /// receiver-antenna correction.
     pub code_m: f64,
+    /// Carrier-phase double-difference prefit residual in meters: observed
+    /// double-difference phase minus modeled geometry and the current ambiguity
+    /// term.
     pub phase_m: f64,
+    /// Double-difference code measurement sigma in meters, reconstructed from
+    /// the static row weight or the sequential row's single-difference variances.
     pub code_sigma_m: f64,
+    /// Double-difference carrier-phase measurement sigma in meters, reconstructed
+    /// from the static row weight or the sequential row's single-difference
+    /// variances.
     pub phase_sigma_m: f64,
+    /// Signed code residual divided by its double-difference sigma. Static rows
+    /// use the code residual times the inverse-sigma row weight.
     pub code_normalized: f64,
+    /// Signed carrier-phase residual divided by its double-difference sigma.
+    /// Static rows use the phase residual times the inverse-sigma row weight.
     pub phase_normalized: f64,
 }
 
 /// Static batch float RTK solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatBaselineSolution {
+    /// Final rover-minus-base ECEF baseline vector in meters after the last
+    /// normal-equation update.
     pub baseline_m: [f64; 3],
+    /// Top-left 3-by-3 baseline block of the inverse final normal matrix, in
+    /// square meters.
     pub baseline_covariance_m2: [[f64; 3]; 3],
+    /// Final float double-difference ambiguity estimates in meters paired with
+    /// the supplied ambiguity ids in their input order.
     pub ambiguities_m: Vec<(String, f64)>,
+    /// Row-major ambiguity covariance in square meters from the inverse Schur
+    /// complement after the three baseline parameters are eliminated.
     pub ambiguity_covariance_m: Vec<f64>,
+    /// Row-major inverse of [`Self::ambiguity_covariance_m`], computed by the
+    /// first-tie flat inversion.
     pub ambiguity_covariance_inverse_m: Vec<f64>,
+    /// One record per non-reference satellite and input epoch, formed from the
+    /// adjacent code-then-phase rows in input order.
     pub residuals: Vec<FloatResidual>,
+    /// One-based count of normal-equation iterations, including the terminating
+    /// iteration.
     pub iterations: usize,
+    /// Whether both the baseline and ambiguity step tests were satisfied before
+    /// the iteration cap was reached.
     pub converged: bool,
+    /// [`FloatSolveStatus::StateTolerance`] for threshold termination or
+    /// [`FloatSolveStatus::MaxIterations`] for cap termination.
     pub status: FloatSolveStatus,
+    /// Root-mean-square of the final residual records' code values in meters. The
+    /// shared RMS helper returns zero for an empty input.
     pub code_rms_m: f64,
+    /// Root-mean-square of the final residual records' carrier-phase values in
+    /// meters. The shared RMS helper returns zero for an empty input.
     pub phase_rms_m: f64,
+    /// Root-mean-square of every final code and phase row's prefit residual
+    /// multiplied by its static inverse-sigma row weight.
     pub weighted_rms_m: f64,
+    /// Number of final code and phase double-difference rows retained by the
+    /// solve; each non-reference satellite contributes two rows.
     pub n_observations: usize,
     /// Geometry observability and covariance-validation diagnostics for the
     /// final double-difference design. Snapshot RTK float solves pass no
@@ -111,14 +178,27 @@ pub struct FloatBaselineSolution {
 /// Why the static batch float RTK solve could not complete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FloatSolveError {
+    /// A non-reference satellite has no reference satellite in its constellation;
+    /// the payload is the constellation token.
     MissingSystemReference(String),
+    /// The composed double-difference ambiguity id is absent from the supplied
+    /// float ambiguity columns.
     MissingAmbiguityColumn(String),
+    /// A float option or RTK row-builder boundary input failed validation.
     InvalidInput {
+        /// Static field-path string naming the rejected option or RTK input.
         field: &'static str,
+        /// Validation category explaining why the input was rejected.
         kind: super::RtkInputErrorKind,
     },
+    /// Normal-equation assembly or solution, rank-deficient geometry, or final
+    /// covariance inversion produced no result.
     SingularGeometry,
+    /// Final rows were not adjacent matching code/phase pairs with equal epoch,
+    /// satellite, reference, and ambiguity identifiers.
     IncompleteResidualPair,
+    /// Receiver-antenna correction application failed; the underlying error is
+    /// retained.
     ReceiverAntenna(ReceiverAntennaError),
 }
 

--- a/crates/sidereon-core/src/rtk_filter/model.rs
+++ b/crates/sidereon-core/src/rtk_filter/model.rs
@@ -23,12 +23,23 @@ pub(crate) enum RowKind {
 /// transmit-time ECEF positions at an epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatMeas {
+    /// Physical satellite id copied from the paired base and rover observations.
+    /// Row construction uses it for same-constellation reference selection and
+    /// double-difference row labels.
     pub sat: String,
     /// Single-difference ambiguity id (gap-segmentation already applied upstream).
     pub sd_ambiguity_id: String,
+    /// Base receiver's selected code measurement in meters. Row construction
+    /// subtracts it from [`Self::rover_code_m`] to form the code single difference.
     pub base_code_m: f64,
+    /// Base receiver's carrier-phase measurement in meters. Row construction
+    /// subtracts it from [`Self::rover_phase_m`] to form the phase single difference.
     pub base_phase_m: f64,
+    /// Rover receiver's selected code measurement in meters. Row construction
+    /// subtracts [`Self::base_code_m`] to form the code single difference.
     pub rover_code_m: f64,
+    /// Rover receiver's carrier-phase measurement in meters. Row construction
+    /// subtracts [`Self::base_phase_m`] to form the phase single difference.
     pub rover_phase_m: f64,
     /// Transmit-time satellite ECEF position (metres) for the base receiver.
     pub base_tx_pos: [f64; 3],
@@ -48,7 +59,13 @@ pub struct SatMeas {
 /// the historical single-system epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Epoch {
+    /// Reference measurements present in this epoch, with one selected
+    /// satellite per constellation when that satellite is observed. Row
+    /// construction uses each entry as its constellation's single-difference reference.
     pub references: Vec<SatMeas>,
+    /// Available non-reference measurements in sorted satellite-id order. Row
+    /// construction emits one code row and one phase row for each entry, and
+    /// the sequential update considers each entry for ambiguity resolution.
     pub nonref: Vec<SatMeas>,
     /// Optional rover ECEF velocity in metres/second for the velocity-propagated
     /// predict branch. The value is an epoch input, not carried filter state.
@@ -120,7 +137,11 @@ pub(super) fn is_float_only_system(sat: &str, float_only: &[GnssSystem]) -> bool
 pub enum StochasticModel {
     /// `SD variance = 2σ²`; with `elevation_weighting`, σ is first scaled by
     /// `1/max(sin el, MIN_ELEVATION_SIN)`.
-    Simple { elevation_weighting: bool },
+    Simple {
+        /// When true, scales sigma by the floor-clamped elevation sine before
+        /// computing the variance; when false, uses the elevation-independent `2σ²`.
+        elevation_weighting: bool,
+    },
     /// RTKLIB floor-plus-elevation: `SD variance = 2(σ² + σ²/sin²el)` with the
     /// same clamped `sin el`.
     Rtklib,
@@ -132,9 +153,16 @@ pub(crate) const MIN_ELEVATION_SIN: f64 = 0.05;
 /// Measurement-model configuration.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MeasModel {
+    /// Finite positive code-measurement standard deviation in meters, used to
+    /// compute the code single-difference variance for each satellite and reference.
     pub code_sigma_m: f64,
+    /// Finite positive carrier-phase standard deviation in meters, used to
+    /// compute the phase single-difference variance for each satellite and reference.
     pub phase_sigma_m: f64,
+    /// Selects the first-order RTKLIB Sagnac correction for geometric ranges;
+    /// false selects the uncorrected Euclidean range recipe.
     pub sagnac: bool,
+    /// Variance model applied to both code and carrier-phase single differences.
     pub stochastic: StochasticModel,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/rinex_arc.rs
+++ b/crates/sidereon-core/src/rtk_filter/rinex_arc.rs
@@ -27,8 +27,15 @@ const DEFAULT_MIN_COMMON_SATELLITES: usize = 4;
 /// One single-frequency code/carrier pair to extract from RINEX observations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtkRinexSignalPair {
+    /// Constellation whose RINEX observations this pair can select. The builder
+    /// groups pairs by this [`GnssSystem`] value and skips satellites from other
+    /// constellations.
     pub system: GnssSystem,
+    /// Full RINEX code observable whose present value supplies the pseudorange in
+    /// meters and the satellite transmit-time correction.
     pub code_observable: String,
+    /// Full RINEX carrier-phase observable whose present value is read in cycles
+    /// and converted to meters using its carrier frequency; its LLI is retained.
     pub phase_observable: String,
 }
 
@@ -46,6 +53,9 @@ impl RtkRinexSignalPair {
 /// Options for building single-frequency RTK arc records from RINEX.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtkRinexArcOptions {
+    /// Signal choices grouped by constellation and tried in vector order. For
+    /// each satellite, the first pair with both values present is used; an empty
+    /// vector returns [`RtkRinexArcError::NoSignalPairs`].
     pub signal_pairs: Vec<RtkRinexSignalPair>,
     /// Optional cap on base epochs considered, in file order.
     pub max_epochs: Option<usize>,
@@ -71,21 +81,37 @@ impl RtkRinexArcOptions {
 /// sequential and static RTK arc solvers.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkRinexArc {
+    /// Output [`RtkArcEpoch`] records in considered base-RINEX order. Each retains
+    /// paired base/rover records only for satellites with receive-time,
+    /// base-transmit-time, and rover-transmit-time positions.
     pub epochs: Vec<RtkArcEpoch>,
     /// Carrier wavelength per single-difference ambiguity id, metres.
     pub wavelengths_m: BTreeMap<String, f64>,
     /// Code-to-phase metre offsets per single-difference ambiguity id.
     pub offsets_m: BTreeMap<String, f64>,
+    /// Number of considered base epochs omitted because the rover civil-time key
+    /// was absent or too few usable satellites remained.
     pub skipped_epoch_count: usize,
 }
 
 /// One dual-frequency code/carrier selection for one constellation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtkRinexDualSignalPair {
+    /// Constellation whose RINEX observations this pair can select. The builder
+    /// groups pairs by this [`GnssSystem`] value and skips satellites from other
+    /// constellations.
     pub system: GnssSystem,
+    /// Full RINEX code observable supplying the first-frequency pseudorange in
+    /// meters when its row has a value.
     pub code1_observable: String,
+    /// Full RINEX carrier-phase observable supplying the first-frequency phase in
+    /// cycles and its carrier frequency when both are available.
     pub phase1_observable: String,
+    /// Full RINEX code observable supplying the second-frequency pseudorange in
+    /// meters when its row has a value.
     pub code2_observable: String,
+    /// Full RINEX carrier-phase observable supplying the second-frequency phase
+    /// in cycles and its carrier frequency when both are available.
     pub phase2_observable: String,
 }
 
@@ -105,6 +131,9 @@ impl RtkRinexDualSignalPair {
 /// Options for building dual-frequency RTK arc records from RINEX.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtkRinexDualArcOptions {
+    /// Four-observable choices grouped by constellation and tried in vector order.
+    /// For each satellite, the first pair with all four values present is used;
+    /// an empty vector returns [`RtkRinexArcError::NoSignalPairs`].
     pub signal_pairs: Vec<RtkRinexDualSignalPair>,
     /// Optional cap on base epochs considered, in file order.
     pub max_epochs: Option<usize>,
@@ -129,27 +158,46 @@ impl RtkRinexDualArcOptions {
 /// Dual-frequency arc records for wide-lane and ionosphere-free RTK paths.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RtkRinexDualFrequencyArc {
+    /// Output [`RtkDualFrequencyArcEpoch`] records in considered base-RINEX order,
+    /// including their paired observations and receive/transmit-time satellite
+    /// positions.
     pub epochs: Vec<RtkDualFrequencyArcEpoch>,
+    /// Number of considered base epochs omitted because the rover civil-time key
+    /// was absent or too few usable dual-frequency satellites remained.
     pub skipped_epoch_count: usize,
 }
 
 /// Failure while building RTK arc records from RINEX.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RtkRinexArcError {
+    /// An option or satellite identifier failed the builder's input checks.
     InvalidInput {
+        /// Name of the rejected input: `min_common_satellites` or `satellite_id`.
         field: &'static str,
+        /// Static reason for rejection: `must be positive` or `invalid satellite token`.
         reason: &'static str,
     },
+    /// RINEX observation extraction or carrier-frequency lookup failed.
     Observation(crate::Error),
+    /// An ephemeris lookup failed for a reason other than an unavailable state
+    /// gap; gap results instead make the satellite unavailable for that epoch.
     Ephemeris {
+        /// Satellite token used in the failed state lookup.
         satellite_id: String,
+        /// Seconds since J2000 passed to the failed state lookup.
         epoch_j2000_s: f64,
+        /// Display text from the ephemeris source error.
         reason: String,
     },
+    /// No signal pair was supplied in the single- or dual-frequency options.
     NoSignalPairs,
+    /// No considered base epoch met the configured usable-satellite threshold.
     NoUsableEpochs,
+    /// A selected phase observable has no carrier frequency in its RINEX context.
     MissingFrequency {
+        /// Satellite token for the missing carrier frequency.
         satellite_id: String,
+        /// Full RINEX phase observable code whose frequency is missing.
         observable_code: String,
     },
 }

--- a/crates/sidereon-core/src/rtk_filter/search.rs
+++ b/crates/sidereon-core/src/rtk_filter/search.rs
@@ -18,52 +18,104 @@ use crate::id::GnssSystem;
 /// Integer ambiguity-fix verdict for a static fixed RTK solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerStatus {
+    /// The LAMBDA ratio test passed the requested [`FixedSolveOpts`] threshold,
+    /// so callers may use the returned integer vector as fixed.
     Fixed,
+    /// The search did not produce an accepted integer fix. This is also used
+    /// for metadata created when no ambiguity entered the search.
     NotFixed,
 }
 
 /// Diagnostic payload for one integer ambiguity search.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AmbiguitySearch {
+    /// Ambiguity ids in the order used by the float values and covariance rows
+    /// and columns.
     pub order: Vec<String>,
+    /// Float ambiguities in cycles, paired with the ids in [`Self::order`].
+    /// Each value is the meter ambiguity after its offset is removed and then
+    /// divided by its wavelength.
     pub float_cycles: Vec<(String, f64)>,
+    /// Symmetrized cycle covariance used by LAMBDA, flattened in row-major
+    /// order. Rows and columns follow [`Self::order`].
     pub covariance_cycles: Vec<f64>,
+    /// Inverse of the symmetrized cycle covariance used for the reported
+    /// quadratic scores, flattened in row-major order. Rows and columns follow
+    /// [`Self::order`].
     pub covariance_inverse_cycles: Vec<f64>,
 }
 
 /// Summary of a rejected full-set search when partial AR is enabled.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FullSetIntegerSummary {
+    /// Ratio-test verdict from the full ambiguity-set search before subset
+    /// attempts begin.
     pub integer_status: IntegerStatus,
+    /// Score ratio reported by the full ambiguity-set search.
     pub integer_ratio: Option<f64>,
+    /// Lowest quadratic score reported by the full ambiguity-set search.
     pub integer_best_score: Option<f64>,
+    /// Runner-up quadratic score from the full ambiguity-set search, when one
+    /// was returned.
     pub integer_second_best_score: Option<f64>,
+    /// Number of candidate vectors reported by the full LAMBDA search.
     pub integer_candidates: usize,
+    /// Ambiguity order used by the full ambiguity-set search.
     pub order: Vec<String>,
 }
 
 /// Partial ambiguity-resolution diagnostics for a static fixed RTK solve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PartialSearchMeta {
+    /// Whether partial resolution was entered after the full ambiguity-set
+    /// search was rejected.
     pub enabled: bool,
+    /// Whether the selected ambiguity subset passed the LAMBDA ratio test.
     pub fixed: bool,
+    /// Ids included in the fixed-cycle map for this result, in sorted order.
+    /// After a failed full-set search, these can identify the best candidate
+    /// even though [`Self::fixed`] is `false`.
     pub fixed_ambiguities: Vec<String>,
+    /// Full-search ids not selected for the subset, in sorted order.
     pub free_ambiguities: Vec<String>,
+    /// Diagnostics copied from the rejected full-set search, when partial
+    /// resolution was entered.
     pub full_set: Option<FullSetIntegerSummary>,
+    /// Number of subset combinations evaluated by the exhaustive fallback.
+    /// `None` means that fallback did not run; `Some(0)` records that a limit
+    /// prevented any combination from being evaluated.
     pub exhaustive_subsets_evaluated: Option<usize>,
 }
 
 /// Integer-search metadata for a static fixed RTK solve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntegerSearchMeta {
+    /// Ratio-test verdict from the LAMBDA search, or [`IntegerStatus::NotFixed`]
+    /// when no ambiguity entered the search.
     pub integer_status: IntegerStatus,
+    /// Integer-search method identifier; the RTK search currently stores
+    /// `"lambda"`.
     pub integer_method: &'static str,
+    /// Best-to-runner-up score ratio reported by LAMBDA. `None` means no
+    /// ambiguity search ran.
     pub integer_ratio: Option<f64>,
+    /// Lowest quadratic score `Δᵀ Q⁻¹ Δ` reported by LAMBDA, or `None` when no
+    /// ambiguity search ran.
     pub integer_best_score: Option<f64>,
+    /// Runner-up quadratic score reported by LAMBDA, when a second candidate
+    /// exists; it is also `None` when no search ran.
     pub integer_second_best_score: Option<f64>,
+    /// Number of candidate vectors reported by LAMBDA; an empty search stores
+    /// `0`.
     pub integer_candidates: usize,
+    /// Float values and covariance diagnostics retained for the search, with
+    /// the matrix data aligned to [`AmbiguitySearch::order`].
     pub ambiguity_search: AmbiguitySearch,
+    /// `(ambiguity id, meter offset)` pairs applied before converting the
+    /// float ambiguities to cycles. The static and sequential callers populate
+    /// this for the full or selected search ids.
     pub ambiguity_offsets_m: Vec<(String, f64)>,
+    /// Diagnostics for the optional partial ambiguity-resolution path.
     pub partial: PartialSearchMeta,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/state.rs
+++ b/crates/sidereon-core/src/rtk_filter/state.rs
@@ -65,18 +65,42 @@ pub struct FilterState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Classification of failures returned when [`FilterState`] construction or
+/// carried-state validation rejects input. The update layer maps these
+/// classifications to its public invalid-state error.
 pub enum FilterStateValidationKind {
-    Length { expected: usize, actual: usize },
+    /// A parallel state vector or the row-major information matrix has an
+    /// unexpected length.
+    Length {
+        /// Required length computed from the state dimension or ambiguity ids.
+        expected: usize,
+        /// Observed length of the state vector or information matrix.
+        actual: usize,
+    },
+    /// A checked floating-point value or prior-derived information value is
+    /// NaN or infinite.
     NonFinite,
+    /// A prior sigma, or its derived information value, is not positive.
     NotPositive,
+    /// An information-matrix off-diagonal pair differs beyond the matrix
+    /// tolerance.
     NotSymmetric,
+    /// The symmetrized information matrix has an eigenvalue below the allowed
+    /// negative tolerance.
     NotPositiveSemidefinite,
+    /// The state dimension cannot be squared in `usize` for the information
+    /// matrix length.
     DimensionOverflow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Validation error returned while constructing or checking a [`FilterState`].
+/// The field label identifies the failed state member and the kind records the
+/// validation rule that rejected it.
 pub struct FilterStateValidationError {
+    /// Stable state-member label supplied to the validation routine.
     pub field: &'static str,
+    /// Validation classification for [`Self::field`].
     pub kind: FilterStateValidationKind,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/update.rs
+++ b/crates/sidereon-core/src/rtk_filter/update.rs
@@ -218,6 +218,9 @@ pub struct RtkFilterScratch {
 }
 
 impl RtkFilterScratch {
+    /// Creates an empty scratch workspace for reuse across filter epochs.
+    /// Pass the workspace to [`update_epoch_with_scratch`] so its row, geometry,
+    /// hold, and solver buffers can be retained between updates.
     pub fn new() -> Self {
         Self::default()
     }
@@ -531,6 +534,10 @@ pub(crate) fn dd_covariance_cycles(
 /// Ratio-test options for the ambiguity search.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SearchOpts {
+    /// Ratio at which the LAMBDA search accepts its integer candidate, measured
+    /// as the runner-up score divided by the best score. The update boundary
+    /// requires this value to be finite and positive; the canonical default is
+    /// [`super::defaults::RATIO_THRESHOLD`].
     pub ratio_threshold: f64,
 }
 
@@ -547,9 +554,21 @@ pub enum DynamicsModel {
 /// Options for one streaming filter epoch update.
 #[derive(Debug, Clone, PartialEq)]
 pub struct UpdateOpts {
+    /// Held-ambiguity pseudo-measurement sigma in meters. The update uses
+    /// `1 / sigma²` for both fix-and-hold constraints and per-system reference
+    /// gauge pins, and rejects values whose inverse variance is not finite.
     pub hold_sigma_m: f64,
+    /// Positive meter threshold for the Euclidean norm of a baseline step in
+    /// the iterated update. Convergence also requires the ambiguity step to be
+    /// within [`Self::ambiguity_tol_m`].
     pub position_tol_m: f64,
+    /// Positive meter threshold for the largest absolute single-difference
+    /// ambiguity step in the iterated update. Convergence also requires the
+    /// baseline step to be within [`Self::position_tol_m`].
     pub ambiguity_tol_m: f64,
+    /// Nonzero maximum number of Gauss-Newton information-update iterations.
+    /// If the two step tests have not passed by this cap, the last iterate is
+    /// returned.
     pub max_iterations: usize,
     /// Kinematic process-noise sigma (metres) for the baseline. `0.0` (default)
     /// is the static filter: the carried information is propagated forward
@@ -579,6 +598,9 @@ pub struct UpdateOpts {
     /// below the gate the epoch carries its existing held set and stays float.
     /// `None` (default) keeps the always-armed behaviour.
     pub ar_arming_sigma_m: Option<f64>,
+    /// LAMBDA ratio-test settings applied after the float update to unheld,
+    /// non-float-only ambiguities. If no ambiguity is eligible for search, this
+    /// field does not produce search metadata for that epoch.
     pub search: SearchOpts,
 }
 
@@ -628,7 +650,14 @@ pub struct EpochUpdate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InvalidStateKind {
     /// A state vector or matrix length did not match the state dimension.
-    Length { expected: usize, actual: usize },
+    Length {
+        /// Required length calculated from the carried filter dimension: the
+        /// ambiguity vector matches the id count and the information vector is
+        /// `n * n` entries.
+        expected: usize,
+        /// Length observed in the state vector or matrix that failed validation.
+        actual: usize,
+    },
     /// A state dimension was too large to form the row-major information shape.
     DimensionOverflow,
     /// A floating-point state field was NaN or infinite.
@@ -661,15 +690,24 @@ impl core::fmt::Display for InvalidStateKind {
 pub enum UpdateError {
     /// The carried serialized filter state is malformed and cannot be indexed safely.
     InvalidState {
+        /// Stable validator label naming the rejected state member, such as
+        /// `state.information` or `state.sd_ambiguities_m`.
         field: &'static str,
+        /// Validation category mapped from the filter-state validator, such as
+        /// a length, finiteness, positivity, symmetry, or matrix definiteness failure.
         kind: InvalidStateKind,
     },
     /// The carried filter state is tied to one reference ambiguity arc per
     /// system; applying held DDs to a different reference would reinterpret
     /// fixed integers.
     ReferenceChanged {
+        /// Constellation identifier derived from the epoch reference satellite.
         system: String,
+        /// Reference single-difference ambiguity id stored in the carried state
+        /// for this constellation.
         expected: String,
+        /// Reference single-difference ambiguity id supplied by the current
+        /// epoch for this constellation.
         actual: String,
     },
     /// The epoch carries a reference for a constellation the state does not
@@ -687,7 +725,10 @@ pub enum UpdateError {
     /// A row-builder boundary input was malformed, non-finite, or outside its
     /// physical domain.
     InvalidInput {
+        /// Stable field label for the option or row-boundary input rejected
+        /// before the numerical update proceeds.
         field: &'static str,
+        /// Public RTK validation category for the rejected input.
         kind: super::RtkInputErrorKind,
     },
     /// The measurement/update normal equations or posterior covariance were singular.

--- a/crates/sidereon-core/src/sbas/format.rs
+++ b/crates/sidereon-core/src/sbas/format.rs
@@ -7,13 +7,38 @@ use super::message::SbasWireForm;
 use super::store::sbas_prn_to_sat;
 
 #[derive(Clone, Debug, PartialEq)]
+/// One SBAS block recovered from an EMS or RTKLIB log line.
+///
+/// The line parsers retain recognized records in input order and store the
+/// converted satellite, GPST epoch, wire-form classification, and decoded
+/// bytes.
 pub struct SbasLogBlock {
+    /// SBAS satellite returned by [`sbas_prn_to_sat`] for a supported broadcast
+    /// PRN (120 through 158, inclusive).
     pub satellite_id: GnssSatelliteId,
+    /// GPST week and seconds-of-week associated with the logged block.
+    ///
+    /// EMS calendar fields are converted using the Sunday-origin GPST week;
+    /// RTKLIB lines provide the week and time-of-week directly.
     pub epoch: GnssWeekTow,
+    /// Wire representation inferred from the decoded byte count: 29 bytes use
+    /// [`SbasWireForm::Body226`] and 32 bytes use [`SbasWireForm::Framed250`].
     pub form: SbasWireForm,
+    /// Hex-decoded bytes from the source line, with whitespace removed before
+    /// decoding. An odd number of hexadecimal digits is completed with a zero
+    /// digit before byte pairs are formed.
     pub bytes: Vec<u8>,
 }
 
+/// Parse newline-separated EMS records into [`SbasLogBlock`] values.
+///
+/// For each line, the first seven non-empty comma-separated fields provide the
+/// broadcast PRN and calendar components, and the last non-empty field
+/// provides the hexadecimal block. Years numerically below 100 are increased
+/// by 2000 before the calendar time is converted to GPST. Lines that fail the
+/// field, PRN, calendar-week, or hexadecimal-character checks are ignored; the
+/// result preserves input order, while block-length and epoch-construction
+/// errors are returned.
 pub fn parse_ems_lines(text: &str) -> Result<Vec<SbasLogBlock>> {
     let mut out = Vec::new();
     for line in text.lines() {
@@ -24,6 +49,14 @@ pub fn parse_ems_lines(text: &str) -> Result<Vec<SbasLogBlock>> {
     Ok(out)
 }
 
+/// Parse newline-separated RTKLIB records into [`SbasLogBlock`] values.
+///
+/// Each recognized record has at least four whitespace-separated header fields
+/// before a colon: week, seconds-of-week, broadcast PRN, and an additional
+/// header field. The text after the first colon is decoded as the block's
+/// hexadecimal bytes. Lines without the required delimiter or parseable,
+/// supported fields are ignored, recognized records retain input order, and
+/// block-length or epoch-construction errors are returned.
 pub fn parse_rtklib_lines(text: &str) -> Result<Vec<SbasLogBlock>> {
     let mut out = Vec::new();
     for line in text.lines() {

--- a/crates/sidereon-core/src/sbas/message.rs
+++ b/crates/sidereon-core/src/sbas/message.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use crate::rtcm::bits::{BitReader, BitWriter};
 use crate::rtcm::crc::crc24q_bits;
 
+/// The six-bit SBAS message-type field carried as an unsigned byte.
 pub type SbasMessageType = u8;
 
 const FRAMED_LEN: usize = 32;
@@ -14,195 +15,327 @@ const FRAMED_BITS: usize = BODY_BITS + CRC_BITS;
 const PREAMBLES: [u8; 3] = [0x53, 0x9A, 0xC6];
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
+/// Raw reserved segments retained from an SBAS message payload.
+///
+/// Each tuple stores a segment's value and width in bits, in wire order, so
+/// the encoder can replay reserved fields whose layout is known.
 pub struct SpareBits(pub Vec<(u64, u8)>);
 
 impl SpareBits {
+    /// Create an empty collection of reserved wire segments.
     pub fn new() -> Self {
         Self(Vec::new())
     }
 
+    /// Append one reserved segment with its raw value and bit width.
     pub fn push(&mut self, value: u64, width: u8) {
         self.0.push((value, width));
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// A decoded SBAS payload selected by its six-bit message type.
+///
+/// The decoder maps recognized phase-A IDs to typed records and retains
+/// unsupported IDs with their raw payload bits.
 pub enum SbasMessage {
+    /// Message type 0; ingesting it disables the selected GEO for 60 seconds.
     DoNotUse(SbasDoNotUse),
+    /// Message type 1; supplies the active 210-position satellite mask.
     PrnMask(SbasPrnMask),
+    /// Message types 2 through 5; supplies fast pseudorange corrections.
     FastCorrections(SbasFastCorrections),
+    /// Message type 6; supplies integrity indices for fast corrections.
     Integrity(SbasIntegrity),
+    /// Message type 7; supplies fast-correction degradation information.
     FastDegradation(SbasFastDegradation),
+    /// Message type 9; supplies raw GEO navigation state coefficients.
     GeoNav(SbasGeoNav),
+    /// Message type 12, retained as an uninterpreted 212-bit payload.
     NetworkTime(SbasNetworkTime),
+    /// Message type 17, retained as an uninterpreted 212-bit payload.
     GeoAlmanac(SbasGeoAlmanac),
+    /// Message type 18; supplies a band- and IODI-qualified IGP mask.
     IgpMask(SbasIgpMask),
+    /// Message type 24; combines six fast slots with one long-term half.
     MixedCorrections(SbasMixedCorrections),
+    /// Message type 25; supplies two long-term correction halves.
     LongTermCorrections(SbasLongTermCorrections),
+    /// Message type 26; supplies fifteen ionospheric delay entries.
     IonoDelays(SbasIonoDelays),
+    /// A message ID outside the phase-A classification, retained as raw data.
     Unsupported(SbasUnsupported),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The raw payload carried by SBAS message type 0.
 pub struct SbasDoNotUse {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// Raw payload bits; encoding uses at most 212 bits and pads short input.
     pub data: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The 210-position satellite mask and issue fields from message type 1.
 pub struct SbasPrnMask {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The two-bit issue used by the correction store to select this mask.
     pub iodp: u8,
+    /// Mask flags in wire order; true positions are resolved to monitored satellites.
     pub mask: [bool; 210],
+    /// Empty for decoded message type 1 values because its fields fill the payload.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The thirteen fast-correction slots in message types 2 through 5.
 pub struct SbasFastCorrections {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The original message ID, in the inclusive range 2 through 5.
     pub message_type: SbasMessageType,
+    /// The two-bit issue matched against integrity blocks.
     pub iodf: u8,
+    /// The two-bit issue matched against the active PRN mask.
     pub iodp: u8,
+    /// Signed 12-bit pseudorange correction counts, scaled by the store at 0.125 meters.
     pub prc: [i16; 13],
+    /// Four-bit integrity indices for the thirteen correction slots.
     pub udrei: [u8; 13],
+    /// Empty because the typed fields fill all 212 data bits.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The integrity blocks and UDREI values from message type 6.
 pub struct SbasIntegrity {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// Four two-bit issue values, one for each group of thirteen UDREIs.
     pub iodf: [u8; 4],
+    /// Fifty-one four-bit integrity indices applied to matching fast slots.
     pub udrei: [u8; 51],
+    /// Empty because the typed fields fill all 212 data bits.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The latency and degradation indicators from message type 7.
 pub struct SbasFastDegradation {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// Four-bit latency, interpreted directly as seconds by the correction store.
     pub system_latency_s: u8,
+    /// The two-bit issue that gates acceptance of the latency value.
     pub iodp: u8,
+    /// Fifty-one four-bit degradation indicators preserved by the codec.
     pub ai: [u8; 51],
+    /// The two trailing reserved bits from the payload.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The raw GEO navigation coefficients from message type 9.
 pub struct SbasGeoNav {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// A 13-bit time-of-day count in 16-second units.
     pub time_of_day_s: u16,
+    /// The four-bit URA index retained with the navigation coefficients.
     pub ura: u8,
+    /// Signed 30-bit raw X ECEF coordinate, scaled by the store at 0.08 meters.
     pub x_m: i32,
+    /// Signed 30-bit raw Y ECEF coordinate, scaled by the store at 0.08 meters.
     pub y_m: i32,
+    /// Signed 25-bit raw Z ECEF coordinate, scaled by the store at 0.4 meters.
     pub z_m: i32,
+    /// Signed 17-bit raw X ECEF velocity, scaled by the store at 0.000625 meters per second.
     pub x_rate_m_s: i32,
+    /// Signed 17-bit raw Y ECEF velocity, scaled by the store at 0.000625 meters per second.
     pub y_rate_m_s: i32,
+    /// Signed 18-bit raw Z ECEF velocity, scaled by the store at 0.004 meters per second.
     pub z_rate_m_s: i32,
+    /// Signed 10-bit raw X ECEF acceleration, scaled by the store at 0.0000125 meters per second squared.
     pub x_accel_m_s2: i16,
+    /// Signed 10-bit raw Y ECEF acceleration, scaled by the store at 0.0000125 meters per second squared.
     pub y_accel_m_s2: i16,
+    /// Signed 10-bit raw Z ECEF acceleration, scaled by the store at 0.0000625 meters per second squared.
     pub z_accel_m_s2: i16,
+    /// Signed 12-bit raw GEO clock offset coefficient, scaled by the store at 1/2^31 seconds.
     pub a_gf0_s: i16,
+    /// Signed 8-bit raw GEO clock drift coefficient, scaled by the store at 1/2^40 seconds per second.
     pub a_gf1_s_s: i16,
+    /// The eight reserved bits before the time-of-day field.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The uninterpreted raw payload carried by message type 12.
 pub struct SbasNetworkTime {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// Raw payload bits normalized to 212 bits when encoded.
     pub data: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The uninterpreted raw payload carried by message type 17.
 pub struct SbasGeoAlmanac {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// Raw payload bits normalized to 212 bits when encoded.
     pub data: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The combined fast and long-term payload from message type 24.
 pub struct SbasMixedCorrections {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The first 106 data bits, containing six fast slots and their issues.
     pub fast: SbasMixedFastCorrections,
+    /// The second 106 data bits, containing one long-term half.
     pub long_term: SbasLongTermHalf,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The six-slot fast portion of message type 24.
 pub struct SbasMixedFastCorrections {
+    /// The two-bit issue passed to the fast-correction ingest path.
     pub iodf: u8,
+    /// The two-bit issue matched against the active PRN mask.
     pub iodp: u8,
+    /// The two-bit block selector mapped to message types 2 through 5.
     pub block_id: u8,
+    /// Signed 12-bit pseudorange correction counts, scaled at 0.125 meters by the store.
     pub prc: [i16; 6],
+    /// Four-bit integrity indices for the six correction slots.
     pub udrei: [u8; 6],
+    /// The four reserved bits between the fast and long-term portions.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The two long-term halves carried by message type 25.
 pub struct SbasLongTermCorrections {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The two 106-bit halves, visited in order by correction-store ingest.
     pub halves: [SbasLongTermHalf; 2],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One 106-bit long-term correction half.
 pub struct SbasLongTermHalf {
+    /// Selects one velocity record when true, or two non-velocity records when false.
     pub velocity_code: bool,
+    /// The two-bit issue matched against the active PRN mask.
     pub iodp: u8,
+    /// One record in velocity mode, or two records in non-velocity mode.
     pub records: Vec<SbasLongTermRecord>,
+    /// The trailing reserved bit available in non-velocity mode.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Raw orbit and clock deltas for one monitored satellite.
 pub struct SbasLongTermRecord {
+    /// A six-bit one-based index into the active monitored-satellite mask.
     pub monitored_index: u8,
+    /// The eight-bit issue used to select the broadcast ephemeris.
     pub iode: u8,
+    /// Signed raw X ECEF delta, scaled at 0.125 meters by the store.
     pub delta_x: i32,
+    /// Signed raw Y ECEF delta, scaled at 0.125 meters by the store.
     pub delta_y: i32,
+    /// Signed raw Z ECEF delta, scaled at 0.125 meters by the store.
     pub delta_z: i32,
+    /// Signed raw X ECEF rate, scaled at 0.000625 meters per second in velocity mode.
     pub delta_x_rate: i32,
+    /// Signed raw Y ECEF rate, scaled at 0.000625 meters per second in velocity mode.
     pub delta_y_rate: i32,
+    /// Signed raw Z ECEF rate, scaled at 0.000625 meters per second in velocity mode.
     pub delta_z_rate: i32,
+    /// Signed raw clock-offset delta, scaled at 1/2^31 seconds.
     pub delta_a_f0: i32,
+    /// Signed raw clock-drift delta, scaled at 1/2^39 seconds per second in velocity mode.
     pub delta_a_f1: i32,
+    /// A velocity-mode time-of-day count in 16-second units, or `None` in non-velocity mode.
     pub time_of_day_s: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The band- and IODI-qualified 201-position mask from message type 18.
 pub struct SbasIgpMask {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The four-bit ionospheric band selector.
     pub band_number: u8,
+    /// The two-bit ionospheric issue used to match delay blocks.
     pub iodi: u8,
+    /// Mask flags in wire order; active positions receive delay entries.
     pub mask: [bool; 201],
+    /// The four-bit prefix and optional one-bit trailing reserved segments.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Fifteen ionospheric delay/GIVE entries from message type 26.
 pub struct SbasIonoDelays {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The four-bit ionospheric band selector.
     pub band_number: u8,
+    /// The four-bit block selector, with fifteen entries per block.
     pub block_id: u8,
+    /// The two-bit ionospheric issue matched against the IGP mask.
     pub iodi: u8,
+    /// Fifteen entries assigned to consecutive active IGP positions.
     pub entries: [SbasIgpDelay; 15],
+    /// The seven trailing reserved bits, when present.
     pub reserved: SpareBits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
+/// One raw vertical-delay and GIVE pair from an ionospheric delay block.
 pub struct SbasIgpDelay {
+    /// A nine-bit delay count scaled at 0.125 meters by the store.
     pub vertical_delay: u16,
+    /// A four-bit GIVE index; 15 marks an unusable entry.
     pub givei: u8,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// A non-phase-A SBAS message retained without a typed payload decoder.
 pub struct SbasUnsupported {
+    /// An SBAS preamble accepted by [`SbasBlock::decode`].
     pub preamble: u8,
+    /// The original six-bit message ID.
     pub message_type: SbasMessageType,
+    /// Raw payload bits normalized to 212 bits when encoded.
     pub data: Vec<u8>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The wire representation that controls block length and CRC handling.
 pub enum SbasWireForm {
+    /// A 32-byte block carrying 226 body bits, 24 CRC bits, and six pad bits.
     Framed250,
+    /// A 29-byte body carrying 226 bits and six unused trailing bits.
     Body226,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// The decoded message and wire representation needed for re-encoding.
+///
+/// [`SbasBlock::decode`] fills both fields, and [`SbasBlock::encode`] uses
+/// them to select body-only or CRC-framed output.
 pub struct SbasBlock {
+    /// The body-only or CRC-framed representation selected for this block.
     pub form: SbasWireForm,
+    /// The typed or raw message decoded from the block body.
     pub message: SbasMessage,
 }
 
@@ -252,6 +385,12 @@ impl CountedBitWriter {
 }
 
 impl SbasBlock {
+    /// Decode a body or CRC-framed SBAS block.
+    ///
+    /// Body input must be 29 bytes. Framed input must be 32 bytes and must
+    /// contain a CRC-24Q matching the first 226 bits. Both forms require one
+    /// of the three recognized SBAS preambles; invalid lengths, CRCs,
+    /// preambles, and bit reads are returned as parse errors.
     pub fn decode(bytes: &[u8], form: SbasWireForm) -> Result<Self> {
         match form {
             SbasWireForm::Framed250 => {
@@ -282,6 +421,11 @@ impl SbasBlock {
         Ok(Self { form, message })
     }
 
+    /// Encode the message as the block's selected body or framed wire form.
+    ///
+    /// The body contains the preamble, six-bit message ID, and a normalized
+    /// 212-bit data payload. Framed output appends CRC-24Q over those 226 body
+    /// bits and six zero pad bits.
     pub fn encode(&self) -> Vec<u8> {
         let mut body = CountedBitWriter::new();
         body.push_u(u64::from(self.message.preamble()), 8);
@@ -306,6 +450,10 @@ impl SbasBlock {
 }
 
 impl SbasMessage {
+    /// Return the six-bit SBAS message ID represented by this value.
+    ///
+    /// Typed variants use their protocol IDs; fast corrections and unsupported
+    /// messages return the ID stored in their records.
     pub fn message_type(&self) -> SbasMessageType {
         match self {
             Self::DoNotUse(_) => 0,

--- a/crates/sidereon-core/src/sbas/source.rs
+++ b/crates/sidereon-core/src/sbas/source.rs
@@ -7,7 +7,17 @@ use crate::spp::EphemerisSource;
 
 use super::store::{SbasCorrectionStore, SbasIonoGrid};
 
+/// An [`EphemerisSource`] that can select a broadcast state by issue of data.
+///
+/// [`SbasCorrectedEphemeris`] calls the issue-specific lookup when a fresh GPS
+/// long-term correction supplies the broadcast IODE. A failed lookup prevents
+/// that correction branch from producing a state.
 pub trait IssueAwareBroadcast: EphemerisSource {
+    /// Return the ECEF position in meters and satellite clock offset in seconds
+    /// for the requested broadcast IODE at seconds since J2000.
+    ///
+    /// Return `None` when no usable record for `sat` has the requested IODE at
+    /// the query epoch.
     fn state_by_iode_at(
         &self,
         sat: GnssSatelliteId,
@@ -16,13 +26,25 @@ pub trait IssueAwareBroadcast: EphemerisSource {
     ) -> Option<([f64; 3], f64)>;
 }
 
+/// Selects the branch used when no complete or permitted partial SBAS
+/// correction is available.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum SbasSolveMode {
+    /// Use the underlying broadcast state when correction data cannot be applied.
     #[default]
     MixedAugmentation,
+    /// Return no state when correction data cannot be applied.
     SbasOnly,
 }
 
+/// Borrowed SBAS correction inputs and the resulting fallback behavior for one
+/// source GEO.
+///
+/// `corrected_state` rejects a disabled source GEO or withdrawn satellite. GPS
+/// states use fast and long-term corrections when both are fresh, or one
+/// correction when the store permits partial use. The selected GEO uses fresh
+/// GEO navigation plus its fast clock delta; other unresolved queries follow
+/// [`SbasSolveMode`].
 pub struct SbasCorrectedEphemeris<'a> {
     broadcast: &'a dyn IssueAwareBroadcast,
     store: &'a SbasCorrectionStore,
@@ -31,6 +53,8 @@ pub struct SbasCorrectedEphemeris<'a> {
 }
 
 impl<'a> SbasCorrectedEphemeris<'a> {
+    /// Retain `broadcast`, `store`, and `geo` by reference and initialize the
+    /// fallback mode to [`SbasSolveMode::MixedAugmentation`].
     pub fn new(
         broadcast: &'a dyn IssueAwareBroadcast,
         store: &'a SbasCorrectionStore,
@@ -44,6 +68,11 @@ impl<'a> SbasCorrectedEphemeris<'a> {
         }
     }
 
+    /// Call [`SbasCorrectionStore::ready_geos`] at `t_j2000_s` and select its
+    /// first GEO.
+    ///
+    /// The store orders ready GEOs by newest partition update, so this returns
+    /// the newest eligible source or `None` when no GEO is ready.
     pub fn with_preferred_geo(
         broadcast: &'a dyn IssueAwareBroadcast,
         store: &'a SbasCorrectionStore,
@@ -53,11 +82,17 @@ impl<'a> SbasCorrectedEphemeris<'a> {
         Some(Self::new(broadcast, store, geo))
     }
 
+    /// Replace the fallback mode used when a complete or permitted partial
+    /// correction is unavailable.
     pub fn with_mode(mut self, mode: SbasSolveMode) -> Self {
         self.mode = mode;
         self
     }
 
+    /// Delegate to [`SbasCorrectionStore::iono_grid`] for the selected GEO.
+    ///
+    /// `None` indicates that the GEO partition is absent or that its latest
+    /// update has disabled the grid.
     pub fn iono_grid(&self) -> Option<&SbasIonoGrid> {
         self.store.iono_grid(self.geo)
     }
@@ -148,6 +183,11 @@ impl ObservableEphemerisSource for SbasCorrectedEphemeris<'_> {
     }
 }
 
+/// Owns thread-safe SBAS correction inputs for one source GEO.
+///
+/// The [`EphemerisSource`] and [`ObservableEphemerisSource`] implementations
+/// delegate to a borrowed [`SbasCorrectedEphemeris`] with the same GEO and
+/// fallback mode.
 pub struct SbasCorrectedEphemerisOwned {
     broadcast: Arc<dyn IssueAwareBroadcast + Send + Sync>,
     store: Arc<SbasCorrectionStore>,
@@ -156,6 +196,8 @@ pub struct SbasCorrectedEphemerisOwned {
 }
 
 impl SbasCorrectedEphemerisOwned {
+    /// Store the supplied reference-counted inputs and `geo`, initializing the
+    /// fallback mode to [`SbasSolveMode::MixedAugmentation`].
     pub fn new(
         broadcast: Arc<dyn IssueAwareBroadcast + Send + Sync>,
         store: Arc<SbasCorrectionStore>,
@@ -169,11 +211,15 @@ impl SbasCorrectedEphemerisOwned {
         }
     }
 
+    /// Replace the fallback mode used when a complete or permitted partial
+    /// correction is unavailable.
     pub fn with_mode(mut self, mode: SbasSolveMode) -> Self {
         self.mode = mode;
         self
     }
 
+    /// Delegate to the owned correction store's [`SbasCorrectionStore::iono_grid`]
+    /// lookup for the selected GEO.
     pub fn iono_grid(&self) -> Option<&SbasIonoGrid> {
         self.store.iono_grid(self.geo)
     }

--- a/crates/sidereon-core/src/sbas/store.rs
+++ b/crates/sidereon-core/src/sbas/store.rs
@@ -54,11 +54,22 @@ pub fn give_variance_m2_for_givei(givei: u8) -> Option<f64> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Fast SBAS range correction retained for one monitored satellite.
+///
+/// [`SbasCorrectionStore::ingest`] derives the rate term from consecutive
+/// corrections, and the corrected ephemeris uses both terms to extrapolate the
+/// range correction into the satellite clock.
 pub struct SbasFastCorrection {
+    /// Current fast range correction in meters, after the signed message value
+    /// is multiplied by the 0.125-meter scale factor.
     pub prc_m: f64,
+    /// Rate derived from consecutive same-issue range corrections, in meters per second.
     pub rrc_m_s: f64,
+    /// Current four-bit fast-correction integrity index; values at or above 14 withdraw the satellite.
     pub udrei: u8,
+    /// Correction application epoch, including system latency, in seconds since J2000.
     pub t_of_j2000_s: f64,
+    /// Fast-correction issue used for rate derivation and integrity matching.
     pub iodf: u8,
 }
 
@@ -70,26 +81,55 @@ impl SbasFastCorrection {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Long-term SBAS correction retained for a GPS satellite.
+///
+/// The store uses `iode` to select the broadcast state and advances the
+/// position and clock deltas from [`SbasLongTermCorrection::t0_j2000_s`].
 pub struct SbasLongTermCorrection {
+    /// Broadcast ephemeris issue selected before applying this correction.
     pub iode: u8,
+    /// ECEF position delta in meters at [`SbasLongTermCorrection::t0_j2000_s`],
+    /// from the signed record coordinates multiplied by 0.125.
     pub delta_ecef_m: [f64; 3],
+    /// ECEF position-delta rate in meters per second, from signed record rates
+    /// multiplied by 0.000625.
     pub delta_ecef_rate_m_s: [f64; 3],
+    /// Clock offset delta at the reference epoch, in seconds, from the signed
+    /// record value multiplied by 1/2^31.
     pub delta_af0_s: f64,
+    /// Clock-drift delta, in seconds per second, from the signed record value
+    /// multiplied by 1/2^39.
     pub delta_af1_s_s: f64,
+    /// Reference epoch for the position and clock deltas, in seconds since J2000.
     pub t0_j2000_s: f64,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// One accepted SBAS ionospheric grid point.
+///
+/// [`SbasCorrectionStore::ingest`] obtains the coordinates from the DO-229
+/// band table and omits entries whose GIVEI is 15.
 pub struct SbasIgp {
+    /// Grid latitude in degrees from the DO-229 band table, matched with the
+    /// IGP coordinate tolerance during interpolation.
     pub lat_deg: f64,
+    /// Grid longitude in degrees; lookup normalizes it to the [-180, 180] interval.
     pub lon_deg: f64,
+    /// Vertical ionospheric delay in meters, from the message value multiplied
+    /// by the 0.125-meter scale factor; interpolation uses this value.
     pub vertical_delay_m: f64,
+    /// DO-229 GIVE variance in square meters, or None when no usable variance was supplied.
     pub give_variance_m2: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+/// IGP records associated with one SBAS ionospheric delay issue.
+///
+/// Ingestion replaces an existing coordinate match or appends a new point, so
+/// the returned slice preserves the grid's update order.
 pub struct SbasIonoGrid {
     igps: Vec<SbasIgp>,
+    /// IODI associated with the stored IGP records.
     pub iodi: u8,
 }
 
@@ -207,16 +247,35 @@ impl SbasIonoGrid {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Propagated-state parameters decoded from an SBAS GEO navigation message.
+///
+/// The state is expressed in ECEF meters and seconds relative to its J2000
+/// reference epoch; [`SbasGeoState::state_at`] applies the stored rates.
 pub struct SbasGeoState {
+    /// GEO ECEF position at [`SbasGeoState::t0_j2000_s`], in meters, after X/Y
+    /// message values are scaled by 0.08 and Z by 0.4.
     pub position_ecef_m: [f64; 3],
+    /// GEO ECEF velocity at the reference epoch, in meters per second, after
+    /// X/Y message rates are scaled by 0.000625 and Z by 0.004.
     pub velocity_ecef_m_s: [f64; 3],
+    /// GEO ECEF acceleration, in meters per second squared, after X/Y message
+    /// accelerations are scaled by 0.0000125 and Z by 0.0000625.
     pub acceleration_ecef_m_s2: [f64; 3],
+    /// GEO clock offset at the reference epoch, in seconds, after the message
+    /// value is scaled by 1/2^31.
     pub clock_offset_s: f64,
+    /// GEO clock drift, in seconds per second, after the message value is
+    /// scaled by 1/2^40.
     pub clock_drift_s_s: f64,
+    /// Reference epoch for position and clock propagation, in seconds since J2000.
     pub t0_j2000_s: f64,
 }
 
 impl SbasGeoState {
+    /// Propagate the ECEF position and clock to a J2000-seconds epoch.
+    ///
+    /// Position uses the stored velocity and half the stored acceleration times
+    /// elapsed time squared; clock uses offset plus drift times elapsed time.
     pub fn state_at(&self, t_j2000_s: f64) -> ([f64; 3], f64) {
         let dt = t_j2000_s - self.t0_j2000_s;
         let dt2 = dt * dt;
@@ -237,6 +296,10 @@ impl SbasGeoState {
 }
 
 #[derive(Debug)]
+/// In-memory SBAS correction state partitioned by source GEO.
+///
+/// The store retains the latest masks, corrections, navigation, ionospheric
+/// data, withdrawal state, and policies used by the corrected-source lookups.
 pub struct SbasCorrectionStore {
     partitions: BTreeMap<GnssSatelliteId, GeoPartition>,
     policy: StalenessPolicy,
@@ -250,6 +313,10 @@ impl Default for SbasCorrectionStore {
 }
 
 impl SbasCorrectionStore {
+    /// Create an empty correction store.
+    ///
+    /// The initial freshness cap is 360 seconds and partial corrections are
+    /// disabled until [`SbasCorrectionStore::allow_partial`] is enabled.
     pub fn new() -> Self {
         Self {
             partitions: BTreeMap::new(),
@@ -258,6 +325,11 @@ impl SbasCorrectionStore {
         }
     }
 
+    /// Ingest one decoded [`SbasMessage`] for a source GEO at a GNSS epoch.
+    ///
+    /// A non-SBAS `geo` returns [`Error::InvalidInput`]. Supported messages
+    /// update their corresponding masks, corrections, navigation, ionosphere,
+    /// disable interval, or withdrawal state; unsupported variants are ignored.
     pub fn ingest(
         &mut self,
         message: &SbasMessage,
@@ -330,6 +402,11 @@ impl SbasCorrectionStore {
         Ok(())
     }
 
+    /// List source GEOs eligible for corrected-ephemeris selection at an epoch.
+    ///
+    /// A GEO must be enabled, have an active PRN mask, and contain fast
+    /// corrections, an ionospheric grid, or GEO navigation. Results are ordered
+    /// by newest partition update first.
     pub fn ready_geos(&self, t_j2000_s: f64) -> Vec<GnssSatelliteId> {
         let mut geos: Vec<(GnssSatelliteId, f64)> = self
             .partitions
@@ -343,10 +420,18 @@ impl SbasCorrectionStore {
         geos.into_iter().map(|(geo, _)| geo).collect()
     }
 
+    /// Return the latest stored fast correction for a source GEO and satellite.
+    ///
+    /// `None` means that the partition or satellite has no fast correction; this
+    /// public getter does not apply the internal freshness check.
     pub fn fast(&self, geo: GnssSatelliteId, sat: GnssSatelliteId) -> Option<&SbasFastCorrection> {
         self.partitions.get(&geo)?.fast.get(&sat).map(|t| &t.value)
     }
 
+    /// Return the latest stored long-term correction for a source GEO and satellite.
+    ///
+    /// `None` means that no correction is stored for the pair; this public
+    /// getter does not apply the internal freshness check.
     pub fn long_term(
         &self,
         geo: GnssSatelliteId,
@@ -359,6 +444,10 @@ impl SbasCorrectionStore {
             .map(|t| &t.value)
     }
 
+    /// Return the stored ionospheric grid unless the GEO is currently disabled.
+    ///
+    /// The disable check evaluates the partition's latest ingested epoch, so a
+    /// grid is hidden immediately after a `DoNotUse` message.
     pub fn iono_grid(&self, geo: GnssSatelliteId) -> Option<&SbasIonoGrid> {
         let partition = self.partitions.get(&geo)?;
         if partition.is_disabled(partition.last_update_j2000_s) {
@@ -367,6 +456,10 @@ impl SbasCorrectionStore {
         partition.iono_grid.as_ref().map(|t| &t.value)
     }
 
+    /// Return the latest stored GEO navigation state for a source GEO.
+    ///
+    /// `None` means that no GEO navigation message has been ingested; this
+    /// public getter does not apply freshness filtering.
     pub fn geo_nav(&self, geo: GnssSatelliteId) -> Option<&SbasGeoState> {
         self.partitions
             .get(&geo)?
@@ -375,11 +468,19 @@ impl SbasCorrectionStore {
             .map(|t| &t.value)
     }
 
+    /// Replace the freshness policy used by internal correction lookups.
+    ///
+    /// A source is accepted when the absolute query/source epoch difference is
+    /// no greater than the policy's `max_staleness_s` value.
     pub fn with_policy(mut self, policy: StalenessPolicy) -> Self {
         self.policy = policy;
         self
     }
 
+    /// Set whether corrected ephemeris may use only one available correction.
+    ///
+    /// When enabled, the corrected source may use a fast-only or long-term-only
+    /// correction; the default is disabled.
     pub fn allow_partial(mut self, yes: bool) -> Self {
         self.allow_partial = yes;
         self
@@ -744,6 +845,10 @@ fn mask_position_to_sat(position: usize) -> Option<GnssSatelliteId> {
     }
 }
 
+/// Convert an SBAS broadcast PRN to the library's slot-form satellite id.
+///
+/// Broadcast PRNs 120 through 158 map to SBAS slots 20 through 58; values
+/// outside that interval return `None`.
 pub fn sbas_prn_to_sat(broadcast_prn: u16) -> Option<GnssSatelliteId> {
     let slot = broadcast_prn.checked_sub(100)?;
     if (20..=58).contains(&slot) {
@@ -753,6 +858,10 @@ pub fn sbas_prn_to_sat(broadcast_prn: u16) -> Option<GnssSatelliteId> {
     }
 }
 
+/// Convert an SBAS slot-form satellite id to its broadcast PRN.
+///
+/// An SBAS id maps to its stored PRN plus 100; ids from other GNSS systems
+/// return `None`.
 pub fn sat_to_sbas_prn(sat: GnssSatelliteId) -> Option<u16> {
     (sat.system == GnssSystem::Sbas).then_some(u16::from(sat.prn) + 100)
 }

--- a/crates/sidereon-core/src/tides/mod.rs
+++ b/crates/sidereon-core/src/tides/mod.rs
@@ -61,47 +61,85 @@ use crate::frame::{geodetic_to_itrf, ItrfPositionM, Wgs84Geodetic};
 use crate::validate::{self, FieldError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Validation categories carried by [`TideError::InvalidInput`].
+///
+/// The categories are converted from shared field and time-scale validation
+/// errors before they are exposed by the tide APIs.
 pub enum TideInputErrorKind {
+    /// A required input was not supplied.
     Missing,
+    /// An input value or component was not finite.
     NonFinite,
+    /// A value required to be positive was zero or negative.
     NotPositive,
+    /// A value failed a negative-value check.
     Negative,
+    /// A finite input was outside its permitted domain.
     OutOfRange,
+    /// Text could not be parsed as a floating-point value.
     FloatParse,
+    /// Text could not be parsed as an integer value.
     IntParse,
+    /// A calendar date failed civil-date validation.
     InvalidCivilDate,
+    /// A clock value failed civil-time validation.
     InvalidCivilTime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Failure details produced while parsing a BLQ station block.
+///
+/// Numeric rows and constituent headers use these variants to retain the
+/// offending count, token, station, or constituent label.
 pub enum BlqParseErrorKind {
+    /// The input contained no non-whitespace content.
     Empty,
+    /// A numeric coefficient row appeared before a station identifier.
     MissingStation,
+    /// A station ended before its six coefficient rows were complete.
     MissingCoefficientRows {
+        /// Trimmed station identifier for the incomplete block.
         station: String,
+        /// Required number of coefficient rows, which is six.
         expected: usize,
+        /// Number of coefficient rows collected before end of input.
         found: usize,
     },
+    /// The active station accumulated more than six coefficient rows.
     TooManyCoefficientRows {
+        /// Active station identifier when the extra row was read.
         station: String,
     },
+    /// A numeric row or recognized header did not contain eleven columns.
     WrongColumnCount {
+        /// Required ARG2 column count, equal to `NUM_OCEAN_CONSTITUENTS`.
         expected: usize,
+        /// Number of tokens or constituent labels found on the line.
         found: usize,
     },
+    /// A coefficient token could not be parsed as an `f64`.
     InvalidNumber {
+        /// Original token, or the trimmed line reported as a numeric candidate.
         token: String,
     },
+    /// A token parsed as an `f64` but produced a non-finite value.
     NonFiniteNumber {
+        /// Original token that produced the non-finite value.
         token: String,
     },
+    /// A constituent-like header label is absent from the supported table.
     UnsupportedConstituent {
+        /// Normalized uppercase label rejected by the constituent lookup.
         constituent: String,
     },
+    /// A supported constituent occurred more than once in a header.
     DuplicateConstituent {
+        /// Canonical label of the repeated constituent.
         constituent: String,
     },
+    /// The single-block parser found more than one complete station block.
     MultipleBlocks {
+        /// Number of complete station blocks found.
         found: usize,
     },
 }
@@ -176,23 +214,40 @@ impl From<&FieldError> for TideInputErrorKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+/// Errors returned by station displacement evaluators and BLQ parsers.
+///
+/// Validation failures carry normalized field and reason data; other variants
+/// preserve the underlying time-scale, frame, ephemeris, or parser failure.
 pub enum TideError {
+    /// A tide input failed validation.
     #[error("invalid solid-earth tide input {field}: {kind}")]
     InvalidInput {
+        /// Field label supplied by the originating validator or constructor.
         field: &'static str,
+        /// Normalized validation category for the field.
         kind: TideInputErrorKind,
     },
+    /// Time-scale conversion failed for a non-input coverage or conversion reason.
     #[error("station displacement time-scale conversion failed: {0}")]
     TimeScale(#[from] CoverageError),
+    /// Geodetic, ECEF, or polar-motion frame conversion failed.
     #[error("station displacement frame transform failed: {0}")]
     FrameTransform(#[from] FrameTransformError),
+    /// Polar-motion-aware Sun/Moon evaluation failed.
     #[error("station displacement Sun/Moon evaluation failed: {0}")]
     SunMoon(#[from] SunMoonError),
+    /// A required high-level station-displacement input was not supplied.
     #[error("missing station displacement input {field}")]
-    MissingInput { field: &'static str },
+    MissingInput {
+        /// Missing-input label; the dispatcher uses `"polar motion"` here.
+        field: &'static str,
+    },
+    /// A BLQ parser rejected an input line or whole-input condition.
     #[error("invalid BLQ block at line {line}: {kind}")]
     BlqParse {
+        /// One-based offending line number, or zero for whole-input failures.
         line: usize,
+        /// Detailed BLQ parsing failure and its source payload.
         kind: BlqParseErrorKind,
     },
 }
@@ -278,11 +333,17 @@ impl StationDisplacementPosition {
 /// IERS polar-motion coordinates of the epoch, in arcseconds.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StationPolarMotion {
+    /// IERS x-pole coordinate supplied in arcseconds.
     pub xp_arcsec: f64,
+    /// IERS y-pole coordinate supplied in arcseconds.
     pub yp_arcsec: f64,
 }
 
 impl StationPolarMotion {
+    /// Construct from the IERS x- and y-pole coordinates in arcseconds.
+    ///
+    /// The coordinates are stored as supplied; tide evaluation performs the
+    /// conversion and validation required by its downstream model.
     pub const fn from_arcseconds(xp_arcsec: f64, yp_arcsec: f64) -> Self {
         Self {
             xp_arcsec,
@@ -301,11 +362,17 @@ impl StationPolarMotion {
 /// UTC epoch for station displacement evaluation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StationDisplacementEpoch {
+    /// UTC calendar year passed to validation and tide models.
     pub year: i32,
+    /// UTC calendar month passed to validation and tide models.
     pub month: u8,
+    /// UTC calendar day passed to validation and tide models.
     pub day: u8,
+    /// UTC hour used by the `fractional_hour` calculation.
     pub hour: u8,
+    /// UTC minute used by the `fractional_hour` calculation.
     pub minute: u8,
+    /// UTC seconds, including a fractional part, used in time conversion and fractional-hour calculation.
     pub second: f64,
     /// Optional IERS polar motion for pole tide and polar-motion-aware Sun/Moon
     /// rotation.
@@ -313,6 +380,10 @@ pub struct StationDisplacementEpoch {
 }
 
 impl StationDisplacementEpoch {
+    /// Construct an epoch from UTC calendar and clock components.
+    ///
+    /// The returned epoch has no polar motion until a caller adds it with
+    /// [`StationDisplacementEpoch::with_polar_motion_arcsec`].
     pub const fn from_utc(
         year: i32,
         month: u8,
@@ -332,6 +403,7 @@ impl StationDisplacementEpoch {
         }
     }
 
+    /// Return this epoch with the supplied IERS polar motion in arcseconds.
     pub const fn with_polar_motion_arcsec(mut self, xp_arcsec: f64, yp_arcsec: f64) -> Self {
         self.polar_motion = Some(StationPolarMotion::from_arcseconds(xp_arcsec, yp_arcsec));
         self
@@ -395,8 +467,11 @@ impl Default for StationDisplacementOptions<'_> {
 pub struct StationDisplacement {
     /// Sum of all enabled component displacements, in ITRF/ECEF metres.
     pub ecef_m: [f64; 3],
+    /// Solid-Earth tide component, or `None` when that correction is disabled.
     pub solid_earth_tide_ecef_m: Option<[f64; 3]>,
+    /// Pole-tide component, or `None` when that correction is disabled.
     pub pole_tide_ecef_m: Option<[f64; 3]>,
+    /// Ocean-loading component, or `None` when no BLQ coefficients are supplied.
     pub ocean_loading_ecef_m: Option<[f64; 3]>,
 }
 

--- a/crates/sidereon-core/src/tides/ocean.rs
+++ b/crates/sidereon-core/src/tides/ocean.rs
@@ -86,16 +86,39 @@ const TWO_PI: f64 = 2.0 * std::f64::consts::PI;
 /// BLQ tidal constituents supported by the ARG2 evaluator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OceanTideConstituent {
+    /// First BLQ/ARG2 slot (index 0), labeled `M2`; its ARG2 speed is
+    /// `1.40519e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (2, -2, 0, 0)`.
     M2,
+    /// Second BLQ/ARG2 slot (index 1), labeled `S2`; its ARG2 speed is
+    /// `1.45444e-4` rad/s and its multiplier row is all zero, so its argument
+    /// advances with the fractional hour alone.
     S2,
+    /// Third BLQ/ARG2 slot (index 2), labeled `N2`; its ARG2 speed is
+    /// `1.37880e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (2, -3, 1, 0)`.
     N2,
+    /// Fourth BLQ/ARG2 slot (index 3), labeled `K2`; its ARG2 speed is
+    /// `1.45842e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (2, 0, 0, 0)`.
     K2,
+    /// Fifth BLQ/ARG2 slot (index 4), labeled `K1`; its ARG2 speed is
+    /// `0.72921e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (1, 0, 0, 0.25)`.
     K1,
+    /// Sixth BLQ/ARG2 slot (index 5), labeled `O1`; its ARG2 speed is
+    /// `0.67598e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (1, -2, 0, -0.25)`.
     O1,
+    /// Seventh BLQ/ARG2 slot (index 6), labeled `P1`; its ARG2 speed is
+    /// `0.72523e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (-1, 0, 0, -0.25)`.
     P1,
+    /// Eighth BLQ/ARG2 slot (index 7), labeled `Q1`; its ARG2 speed is
+    /// `0.64959e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (1, -3, 1, -0.25)`.
     Q1,
+    /// Ninth BLQ/ARG2 slot (index 8), labeled `Mf`; its ARG2 speed is
+    /// `0.053234e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (0, 2, 0, 0)`.
     Mf,
+    /// Tenth BLQ/ARG2 slot (index 9), labeled `Mm`; its ARG2 speed is
+    /// `0.026392e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (0, 1, -1, 0)`.
     Mm,
+    /// Eleventh BLQ/ARG2 slot (index 10), labeled `Ssa`; its ARG2 speed is
+    /// `0.003982e-4` rad/s with multipliers `(h0, s0, p0, 2pi) = (2, 0, 0, 0)`.
     Ssa,
 }
 

--- a/crates/sidereon-core/src/velocity.rs
+++ b/crates/sidereon-core/src/velocity.rs
@@ -92,20 +92,40 @@ pub enum VelocityError {
     /// No observation entries were supplied.
     NoObservations,
     /// Fewer than four usable satellites remained after geometry lookup.
-    TooFewSatellites { used: usize, required: usize },
+    TooFewSatellites {
+        /// Number of rows retained by [`solve`] after unusable geometry was dropped.
+        used: usize,
+        /// Fixed at four for the three ECEF velocity components and one receiver
+        /// clock-drift state.
+        required: usize,
+    },
     /// The 4x4 normal matrix is singular.
     SingularGeometry,
     /// A satellite appears more than once in the input observations.
-    DuplicateObservation { satellite_id: GnssSatelliteId },
+    DuplicateObservation {
+        /// Satellite ID of the repeated entry found while scanning input order.
+        satellite_id: GnssSatelliteId,
+    },
     /// Doppler conversion needs a positive finite carrier frequency.
-    InvalidCarrier { satellite_id: GnssSatelliteId },
+    InvalidCarrier {
+        /// Satellite ID whose Doppler observation supplied the invalid carrier.
+        satellite_id: GnssSatelliteId,
+    },
     /// A scalar conversion helper received a malformed input.
     InvalidInput {
+        /// Label supplied by the failing helper: `doppler_hz`, `range_rate_m_s`,
+        /// `carrier_hz`, `velocity row`, or `velocity solution`.
         field: &'static str,
+        /// Stable validation reason: `not finite`, `not positive`, or
+        /// `out of range`.
         reason: &'static str,
     },
     /// An observation carries a non-finite measurement or satellite-clock drift.
-    InvalidObservation { satellite_id: GnssSatelliteId },
+    InvalidObservation {
+        /// Satellite ID associated with a non-finite measurement or clock drift,
+        /// or with a Doppler conversion failure other than carrier validation.
+        satellite_id: GnssSatelliteId,
+    },
     /// The receiver state or receive epoch is non-finite.
     InvalidReceiverState,
 }


### PR DESCRIPTION
Reference documentation for 74 modules, one commit per file, written from the code rather than from identifiers.

Method, after two earlier bulk passes were rejected for producing name-derived filler: for each file, read the whole module and every producer and consumer of each undocumented item, record a ledger of code-established facts (`item: function that establishes it -> the fact`), then write the doc comment from the ledger only. An item with no fact after that reading is left undocumented and recorded rather than papered over. One such item exists here: a `DoubleDifferenceError` variant in `rtk.rs` that no code constructs or matches.

What the docs say, per item: units and frames, bit widths and scale factors for raw protocol fields, the header record or function each value comes from, the ordering of collections, when an `Option` is `None`, and the condition under which each error variant is returned.

Coverage: 2,106 items documented; 522 items in 41 modules remain, led by `precise_positioning/types.rs` (171), `astro/sgp4/fit.rs` (64), and `precise_positioning/prep.rs` (58). `#![warn(missing_docs)]` stays off until those are covered, so the lint cannot be satisfied by filler.

No code changes: the only non-comment edits are the field reformatting rustfmt applies when a struct field gains a doc comment. Gates run on this branch: fmt, clippy (workspace and mmap), `RUSTDOCFLAGS='-D warnings' cargo doc` (which catches broken intra-doc links), doctests, `cargo nextest run --workspace` (3,048 passed), and the mmap suite (2,859 passed).