### PR TITLE
core: make the public input structs extensible

### DIFF
--- a/crates/sidereon-cli/src/mcp.rs
+++ b/crates/sidereon-cli/src/mcp.rs
@@ -1170,10 +1170,9 @@ fn predict_passes_invocation(raw: Value) -> Result<Value> {
         longitude_deg: params.lon_deg,
         altitude_m: params.height_m,
     };
-    let options = PassPredictionOptions {
-        min_elevation_deg: 0.0,
-        step_seconds: 20,
-    };
+    let mut options = PassPredictionOptions::default();
+    options.min_elevation_deg = 0.0;
+    options.step_seconds = 20;
 
     let mut satellites = Vec::new();
     for (index, (line1, line2)) in tle_pairs_from_text(&text).into_iter().enumerate() {

--- a/crates/sidereon-cli/src/tui.rs
+++ b/crates/sidereon-cli/src/tui.rs
@@ -591,15 +591,15 @@ impl LiveDriver {
                 password: pass,
             })
         };
-        let mut machine = NtripClientMachine::new(NtripConfig {
-            host,
-            port,
-            mountpoint: mount,
-            version: NtripVersion::Rev2,
-            credentials,
-            user_agent_product: format!("sidereon/{}", env!("CARGO_PKG_VERSION")),
-            gga_interval_s: Some(NTRIP_GGA_INTERVAL_S),
-        });
+        let mut ntrip_config = NtripConfig::default();
+        ntrip_config.host = host;
+        ntrip_config.port = port;
+        ntrip_config.mountpoint = mount;
+        ntrip_config.version = NtripVersion::Rev2;
+        ntrip_config.credentials = credentials;
+        ntrip_config.user_agent_product = format!("sidereon/{}", env!("CARGO_PKG_VERSION"));
+        ntrip_config.gga_interval_s = Some(NTRIP_GGA_INTERVAL_S);
+        let mut machine = NtripClientMachine::new(ntrip_config);
         machine.reset();
         Ok(Self {
             nav,
@@ -1247,10 +1247,12 @@ fn satellite_snapshots(
                 observation.satellite_id,
                 receiver_ecef,
                 inputs.t_rx_j2000_s,
-                PredictOptions {
-                    carrier_hz: F_L1_HZ,
-                    light_time: true,
-                    sagnac: true,
+                {
+                    let mut options = PredictOptions::default();
+                    options.carrier_hz = F_L1_HZ;
+                    options.light_time = true;
+                    options.sagnac = true;
+                    options
                 },
             )
             .map_or((None, None), |prediction| {

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Changed
 
+- **Breaking:** Public input structs are now `#[non_exhaustive]`; external
+  construction goes through `Default`/`new` plus field assignment, so adding
+  an option to these structs is no longer a breaking change.
 - Portable dynamic matrix and matrix-vector products are pinned to nalgebra's
   fixed-order scalar path by a randomized bit-identity test (normal-equation
   orders through 500 and a 2000x200 Jacobian). CI benchmarks every

--- a/crates/sidereon-core/benches/hotpath.rs
+++ b/crates/sidereon-core/benches/hotpath.rs
@@ -87,21 +87,21 @@ fn receiver_ecef_m() -> [f64; 3] {
 }
 
 fn media_options(ionex: &Ionex) -> ObservableMediaOptions<'_> {
-    ObservableMediaOptions {
-        troposphere: Some(Default::default()),
-        ionosphere: Some(ObservableIonosphereCorrection::IonexWithPolicy(
-            ionex,
-            IonexCoveragePolicy::Hold,
-        )),
-    }
+    let mut options = ObservableMediaOptions::default();
+    options.troposphere = Some(Default::default());
+    options.ionosphere = Some(ObservableIonosphereCorrection::IonexWithPolicy(
+        ionex,
+        IonexCoveragePolicy::Hold,
+    ));
+    options
 }
 
 fn bundle_options(ionex: &Ionex) -> EmissionMediaBatchOptions<'_> {
-    EmissionMediaBatchOptions {
-        carrier_hz: F_L1_HZ,
-        media: media_options(ionex),
-        min_elevation_rad: None,
-    }
+    let mut options = EmissionMediaBatchOptions::default();
+    options.carrier_hz = F_L1_HZ;
+    options.media = media_options(ionex);
+    options.min_elevation_rad = None;
+    options
 }
 
 fn next_index(index: &mut usize, len: usize) -> usize {

--- a/crates/sidereon-core/src/araim/reliability.rs
+++ b/crates/sidereon-core/src/araim/reliability.rs
@@ -31,6 +31,7 @@ pub struct RangeReliabilityRow {
 
 /// Options for Baarda/Teunissen reliability design.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct ReliabilityOptions {
     /// Two-sided false-alarm probability for the one-dimensional data-snooping w-test.
     pub alpha: f64,

--- a/crates/sidereon-core/src/astro/bodies/observe.rs
+++ b/crates/sidereon-core/src/astro/bodies/observe.rs
@@ -153,6 +153,7 @@ pub struct Refraction {
 
 /// Options for general ground-site observation.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ObserveOptions {
     /// Optional polar-motion coordinates. `None` uses zero pole coordinates.
     pub polar_motion: Option<PolarMotion>,

--- a/crates/sidereon-core/src/astro/bodies/rise_set.rs
+++ b/crates/sidereon-core/src/astro/bodies/rise_set.rs
@@ -22,6 +22,7 @@ use crate::validate;
 
 /// Options for Sun elevation threshold crossings.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct SunElevationOptions {
     /// Topocentric Sun elevation threshold, degrees. Use `0.0` for geometric
     /// sunrise/sunset, or e.g. `-6.0` for civil twilight.
@@ -129,6 +130,7 @@ pub fn sun_elevation_deg(station: &GeodeticStationKm, time: UtcInstant) -> f64 {
 
 /// Options for Moon elevation threshold crossings (moonrise / moonset).
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct MoonElevationOptions {
     /// Topocentric Moon (disk-center) elevation threshold, degrees. The default
     /// `-0.833` is the standard upper-limb-on-the-horizon convention (about

--- a/crates/sidereon-core/src/astro/forces/geopotential.rs
+++ b/crates/sidereon-core/src/astro/forces/geopotential.rs
@@ -54,6 +54,7 @@ pub struct SphericalHarmonicCoefficient {
 
 /// Copyable embedded-table selector for propagation force composition.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct SphericalHarmonicGravityConfig {
     /// Gravitational parameter, km^3/s^2.
     pub mu_km3_s2: f64,
@@ -66,6 +67,32 @@ pub struct SphericalHarmonicGravityConfig {
 }
 
 impl SphericalHarmonicGravityConfig {
+    /// Build a selector from explicit gravity constants and degree/order limits.
+    ///
+    /// All four fields are required because the constants and active harmonic
+    /// limits directly determine the resulting perturbation.
+    pub fn new(
+        mu_km3_s2: f64,
+        reference_radius_km: f64,
+        max_degree: u16,
+        max_order: u16,
+    ) -> Result<Self, PropagationError> {
+        validate_finite_positive(mu_km3_s2, "mu_km3_s2")?;
+        validate_finite_positive(reference_radius_km, "reference_radius_km")?;
+        validate_degree_order(max_degree, max_order)?;
+        if max_degree > EGM96_EMBEDDED_MAX_DEGREE || max_order > EGM96_EMBEDDED_MAX_ORDER {
+            return Err(PropagationError::InvalidInput(
+                "EGM96 embedded degree/order must not exceed 36".to_string(),
+            ));
+        }
+        Ok(Self {
+            mu_km3_s2,
+            reference_radius_km,
+            max_degree,
+            max_order,
+        })
+    }
+
     /// Build an EGM96 embedded-table selector.
     pub fn egm96(max_degree: u16, max_order: u16) -> Result<Self, PropagationError> {
         validate_degree_order(max_degree, max_order)?;

--- a/crates/sidereon-core/src/astro/math/least_squares.rs
+++ b/crates/sidereon-core/src/astro/math/least_squares.rs
@@ -244,6 +244,7 @@ pub enum Status {
 
 /// Stopping tolerances and evaluation budget for [`solve_trf`].
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct SolveOptions {
     /// First-order optimality tolerance on `||J^T r||_inf`.
     pub gtol: f64,

--- a/crates/sidereon-core/src/astro/passes.rs
+++ b/crates/sidereon-core/src/astro/passes.rs
@@ -207,6 +207,7 @@ pub struct GroundStation {
 
 /// Pass-prediction options.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PassPredictionOptions {
     /// Elevation threshold in degrees applied after each horizon-bounded pass's
     /// maximum elevation is found. The value must be finite and in `[-90, 90]`.
@@ -902,6 +903,7 @@ const CULMINATION_RATE_HALF_STEP_US: i64 = 1_000_000;
 
 /// Options for the event-finder-backed pass finder [`find_passes`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PassFinderOptions {
     /// Elevation mask (degrees). AOS/LOS are the times the satellite crosses
     /// this elevation, not merely the geometric horizon.

--- a/crates/sidereon-core/src/astro/propagator/api.rs
+++ b/crates/sidereon-core/src/astro/propagator/api.rs
@@ -55,6 +55,7 @@ impl PropagationContext {
 /// point-output flag; [`crate::astro::integrators::DP54`] also uses the
 /// tolerance and adaptive step fields.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct IntegratorOptions {
     /// Additive error scale used by DP54 for the position and velocity error
     /// estimates. The adaptive validator requires a finite positive value;

--- a/crates/sidereon-core/src/astro/propagator/covariance.rs
+++ b/crates/sidereon-core/src/astro/propagator/covariance.rs
@@ -63,6 +63,7 @@ pub enum ProcessNoise {
 
 /// Options for a covariance propagation run.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct CovariancePropagationOptions {
     /// Process-noise model validated and applied by
     /// [`StatePropagator::propagate_covariance`] and

--- a/crates/sidereon-core/src/astro/propagator/decay.rs
+++ b/crates/sidereon-core/src/astro/propagator/decay.rs
@@ -31,6 +31,7 @@ pub struct DecayEstimate {
 
 /// Configuration for a decay run.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct DecayConfig {
     /// Gravity choice layered under drag.
     pub force_model: PropagationForceModel,

--- a/crates/sidereon-core/src/astro/propagator/driver.rs
+++ b/crates/sidereon-core/src/astro/propagator/driver.rs
@@ -44,6 +44,7 @@ pub enum PropagationForceModel {
 /// integrator, the canonical [`MU_EARTH`] gravitational parameter, and the
 /// engine-default [`IntegratorOptions`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PropagationConfig {
     /// Initial ECI Cartesian state; its epoch is the propagation start epoch.
     pub initial: CartesianState,

--- a/crates/sidereon-core/src/astro/sgp4/fit.rs
+++ b/crates/sidereon-core/src/astro/sgp4/fit.rs
@@ -107,6 +107,7 @@ impl Default for TleMetadata {
 
 /// Configuration for [`fit_tle`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FitConfig {
     pub epoch: FitEpoch,
     pub fit_bstar: bool,

--- a/crates/sidereon-core/src/astro/tca.rs
+++ b/crates/sidereon-core/src/astro/tca.rs
@@ -41,6 +41,7 @@ pub const DEFAULT_TCA_POSITION_COVARIANCE_KM2: [[f64; 3]; 3] =
 
 /// Options for [`find_tca_candidates`] and [`find_tca_candidates_from_tles`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TcaFinderOptions {
     /// Coarse sampling step used to bracket local range minima.
     pub coarse_step_seconds: f64,
@@ -172,6 +173,7 @@ impl Default for TcaPcCovariances {
 
 /// Collision-probability options for evaluating a TCA candidate.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TcaPcOptions {
     /// Hard-body radius passed to the conjunction Pc module, km.
     pub hard_body_radius_km: f64,
@@ -182,6 +184,14 @@ pub struct TcaPcOptions {
 }
 
 impl TcaPcOptions {
+    /// Build Pc options with the documented fallback position covariance.
+    ///
+    /// The hard-body radius and probability method are required; covariances
+    /// default to [`DEFAULT_TCA_POSITION_COVARIANCE_KM2`].
+    pub fn new(hard_body_radius_km: f64, method: PcMethod) -> Self {
+        Self::with_default_covariance(hard_body_radius_km, method)
+    }
+
     /// Build Pc options using the fallback TCA position covariance.
     pub fn with_default_covariance(hard_body_radius_km: f64, method: PcMethod) -> Self {
         Self {
@@ -212,6 +222,7 @@ impl TcaPcOptions {
 /// Collision-probability and covariance-transport settings for screening
 /// helpers whose primary/secondary covariances vary by catalog object.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TcaPropagatedCovarianceOptions {
     /// Hard-body radius passed to the conjunction Pc module, km.
     pub hard_body_radius_km: f64,
@@ -280,6 +291,7 @@ impl TcaPropagatedCovarianceOptions {
 
 /// Collision-probability options for propagating state covariances to a TCA.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TcaPropagatedCovariancePcOptions {
     /// Hard-body radius passed to the conjunction Pc module, km.
     pub hard_body_radius_km: f64,
@@ -383,6 +395,7 @@ pub struct CatalogStateVector {
 
 /// Options for [`screen_state_vector_catalog`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct CatalogScreeningOptions {
     /// Coarse position-pair filter threshold, km.
     pub miss_threshold_km: f64,

--- a/crates/sidereon-core/src/bias/mod.rs
+++ b/crates/sidereon-core/src/bias/mod.rs
@@ -390,6 +390,7 @@ pub struct BiasSet {
 ///
 /// The pair and month control observable mapping and the generated validity
 /// interval, while `receiver_system` supplies missing system columns.
+#[non_exhaustive]
 pub struct CodeDcbOptions {
     /// Legacy observable labels, such as `P1` and `C1`, to map per system.
     pub pair: (String, String),
@@ -403,6 +404,30 @@ pub struct CodeDcbOptions {
     /// Optional system used to recognize and target receiver rows whose first
     /// column does not contain a system letter.
     pub receiver_system: Option<GnssSystem>,
+}
+
+impl CodeDcbOptions {
+    /// Build DCB options from the required product identity fields.
+    ///
+    /// `receiver_system` defaults to `None`; assign it when the receiver rows
+    /// use a system-less legacy format.
+    #[must_use]
+    pub fn new(pair: (String, String), year: i32, month: u8, time_scale: TimeScale) -> Self {
+        Self {
+            pair,
+            year,
+            month,
+            time_scale,
+            receiver_system: None,
+        }
+    }
+
+    /// Set the optional receiver constellation.
+    #[must_use]
+    pub const fn with_receiver_system(mut self, receiver_system: GnssSystem) -> Self {
+        self.receiver_system = Some(receiver_system);
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]

--- a/crates/sidereon-core/src/carrier_phase.rs
+++ b/crates/sidereon-core/src/carrier_phase.rs
@@ -90,6 +90,7 @@ pub struct ArcEpoch {
 
 /// Options controlling cycle-slip classification.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct CycleSlipOptions {
     /// Geometry-free step threshold, meters.
     pub gf_threshold_m: f64,

--- a/crates/sidereon-core/src/clock_stability/mod.rs
+++ b/crates/sidereon-core/src/clock_stability/mod.rs
@@ -113,6 +113,7 @@ impl Default for AllanEstimatorSet {
 
 /// Options for the combined Allan-family driver.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct AllanOptions {
     /// Which estimators to compute.
     pub estimators: AllanEstimatorSet,
@@ -257,6 +258,7 @@ pub fn allan_variance_power_law_tau_exponent(noise_type: PowerLawNoiseType) -> i
 
 /// Options for per-octave power-law identification and coefficient fitting.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PowerLawNoiseOptions {
     /// Minimum tau points required before an octave can be classified.
     pub min_points_per_octave: usize,

--- a/crates/sidereon-core/src/data.rs
+++ b/crates/sidereon-core/src/data.rs
@@ -2127,6 +2127,7 @@ pub struct DistributionLocation {
 
 /// Exact product request with an ordered, caller-controlled distributor list.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ProductRequest {
     /// Exact requested identity.
     pub identity: ProductIdentity,

--- a/crates/sidereon-core/src/estimation/strategies.rs
+++ b/crates/sidereon-core/src/estimation/strategies.rs
@@ -58,6 +58,7 @@ use crate::spp::{EphemerisSource, ReceiverSolution, SolveInputs, SolvePolicy, So
 /// Runtime selection options for [`estimate`]. Defaults to the SPP reference
 /// strategy ([`StrategyId::default`]), matching the per-stage recipe defaults.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub struct EstimateOptions {
     /// Strategy identity resolved by [`estimate`] before it checks the input
     /// technique. The default is the SPP/Skyfield reference strategy.

--- a/crates/sidereon-core/src/estimation/track.rs
+++ b/crates/sidereon-core/src/estimation/track.rs
@@ -95,6 +95,7 @@ pub enum TrackError {
 /// `[position_m, velocity_m_s]`. Its blocks have units `m^2`, `m^2/s`, and
 /// `m^2/s^2`.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct TrackFilterConfig {
     /// Cartesian frame of the state, observations, and covariances.
     pub frame: TrackCoordinateFrame,
@@ -111,6 +112,25 @@ pub struct TrackFilterConfig {
 }
 
 impl TrackFilterConfig {
+    /// Build and validate a configuration from every state field.
+    pub fn new(
+        frame: TrackCoordinateFrame,
+        initial_t_s: f64,
+        initial_position_m: Vec<f64>,
+        initial_velocity_m_s: Vec<f64>,
+        initial_covariance: Vec<Vec<f64>>,
+        acceleration_variance_spectral_density_m2_s3: f64,
+    ) -> Result<Self, TrackError> {
+        Self::from_position_velocity(
+            frame,
+            initial_t_s,
+            initial_position_m,
+            initial_velocity_m_s,
+            initial_covariance,
+            acceleration_variance_spectral_density_m2_s3,
+        )
+    }
+
     /// Build a configuration from a position fix and uncertain initial velocity.
     ///
     /// This is the position-only entry point. The velocity starts at zero and

--- a/crates/sidereon-core/src/exact_cache.rs
+++ b/crates/sidereon-core/src/exact_cache.rs
@@ -97,6 +97,7 @@ pub struct VerifiedExactCacheCommit {
 
 /// Bounded timing policy for exact-cache single-flight coordination.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ExactCacheSingleFlightOptions {
     /// Interval between committed-entry and heartbeat observations.
     pub poll_interval: Duration,

--- a/crates/sidereon-core/src/fusion/ekf.rs
+++ b/crates/sidereon-core/src/fusion/ekf.rs
@@ -91,6 +91,7 @@ impl InnovationGate {
 
 /// EKF correction options.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub struct EkfUpdateOptions {
     /// Optional normalized-innovation screen applied before correction.
     pub innovation_gate: Option<InnovationGate>,

--- a/crates/sidereon-core/src/fusion/loose.rs
+++ b/crates/sidereon-core/src/fusion/loose.rs
@@ -159,6 +159,7 @@ pub enum GnssFixStatus {
 
 /// Configuration for loose-coupled GNSS updates.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct LooseCouplingConfig {
     /// Body-frame vector from IMU origin to GNSS antenna phase center, in meters.
     pub lever_arm_body_m: [f64; 3],
@@ -255,6 +256,7 @@ impl GnssFixStatusWeighting {
 
 /// Stationarity detector and pseudo-measurement sigmas for ZUPT/ZARU.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct StationaryUpdateConfig {
     /// Detector thresholds over a trailing IMU epoch window.
     pub detector: StationaryDetectorConfig,
@@ -265,6 +267,21 @@ pub struct StationaryUpdateConfig {
 }
 
 impl StationaryUpdateConfig {
+    /// Build stationary-update settings from the detector and both required
+    /// pseudo-measurement sigmas.
+    #[must_use]
+    pub const fn new(
+        detector: StationaryDetectorConfig,
+        zero_velocity_sigma_mps: f64,
+        zero_angular_rate_sigma_rps: f64,
+    ) -> Self {
+        Self {
+            detector,
+            zero_velocity_sigma_mps,
+            zero_angular_rate_sigma_rps,
+        }
+    }
+
     /// Validate detector settings and pseudo-measurement sigmas.
     pub fn validate(&self) -> Result<(), FusionError> {
         self.detector.validate()?;
@@ -278,6 +295,7 @@ impl StationaryUpdateConfig {
 
 /// Windowed accel and gyro magnitude detector for stationary updates.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct StationaryDetectorConfig {
     /// Number of propagated IMU epochs required before the detector can fire.
     pub window_len: usize,
@@ -288,6 +306,20 @@ pub struct StationaryDetectorConfig {
 }
 
 impl StationaryDetectorConfig {
+    /// Build detector settings from all required window and threshold values.
+    #[must_use]
+    pub const fn new(
+        window_len: usize,
+        max_specific_force_norm_error_mps2: f64,
+        max_body_rate_wrt_ecef_norm_rps: f64,
+    ) -> Self {
+        Self {
+            window_len,
+            max_specific_force_norm_error_mps2,
+            max_body_rate_wrt_ecef_norm_rps,
+        }
+    }
+
     /// Validate finite, non-negative thresholds and non-empty window length.
     pub fn validate(&self) -> Result<(), FusionError> {
         if self.window_len == 0 {
@@ -306,6 +338,7 @@ impl StationaryDetectorConfig {
 
 /// Non-holonomic wheeled-vehicle velocity constraint settings.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct NonHolonomicConstraintConfig {
     /// One-sigma lateral body velocity pseudo-measurement noise in m/s.
     pub lateral_velocity_sigma_mps: f64,
@@ -318,6 +351,22 @@ pub struct NonHolonomicConstraintConfig {
 }
 
 impl NonHolonomicConstraintConfig {
+    /// Build non-holonomic settings from all required sigmas and motion gates.
+    #[must_use]
+    pub const fn new(
+        lateral_velocity_sigma_mps: f64,
+        vertical_velocity_sigma_mps: f64,
+        min_speed_mps: f64,
+        max_body_rate_wrt_ecef_norm_rps: f64,
+    ) -> Self {
+        Self {
+            lateral_velocity_sigma_mps,
+            vertical_velocity_sigma_mps,
+            min_speed_mps,
+            max_body_rate_wrt_ecef_norm_rps,
+        }
+    }
+
     /// Validate sigmas and motion gates.
     pub fn validate(&self) -> Result<(), FusionError> {
         validate_positive(
@@ -343,12 +392,21 @@ impl NonHolonomicConstraintConfig {
 /// outage entry. It is not an RTS smoother because it does not recurse through
 /// covariance, dynamics transitions, or later measurements.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct VelocityMatchingConfig {
     /// Maximum outage interval accepted by the matcher.
     pub max_outage_duration_s: f64,
 }
 
 impl VelocityMatchingConfig {
+    /// Build endpoint-matching settings from the required outage limit.
+    #[must_use]
+    pub const fn new(max_outage_duration_s: f64) -> Self {
+        Self {
+            max_outage_duration_s,
+        }
+    }
+
     /// Validate finite, positive duration bound.
     pub fn validate(&self) -> Result<(), FusionError> {
         validate_positive(self.max_outage_duration_s, "max_outage_duration_s")
@@ -456,6 +514,7 @@ impl YangPredictionAdaptiveFactor {
 
 /// Configuration for an [`InertialFilter`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct InertialFilterConfig {
     /// IMU stochastic model used for covariance prediction.
     pub imu_spec: ImuSpec,

--- a/crates/sidereon-core/src/fusion/serial.rs
+++ b/crates/sidereon-core/src/fusion/serial.rs
@@ -214,6 +214,7 @@ impl SerializableTightFilterState {
 
 /// Serializable retained-history capacity settings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct SerializableTimeSyncHistoryConfig {
     /// Number of retained IMU samples.
     pub imu_capacity: u32,
@@ -222,6 +223,15 @@ pub struct SerializableTimeSyncHistoryConfig {
 }
 
 impl SerializableTimeSyncHistoryConfig {
+    /// Build serialized history capacities from both required limits.
+    #[must_use]
+    pub const fn new(imu_capacity: u32, checkpoint_capacity: u32) -> Self {
+        Self {
+            imu_capacity,
+            checkpoint_capacity,
+        }
+    }
+
     /// Convert native time-sync capacity settings into the serialized form.
     pub fn from_native(config: TimeSyncHistoryConfig) -> Result<Self, FusionStateCodecError> {
         Ok(Self {

--- a/crates/sidereon-core/src/fusion/tight.rs
+++ b/crates/sidereon-core/src/fusion/tight.rs
@@ -189,6 +189,7 @@ impl TightGnssEpoch {
 
 /// Configuration for tightly coupled raw GNSS updates.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TightCouplingConfig {
     /// Body-frame vector from IMU origin to GNSS antenna phase center, in meters.
     pub lever_arm_body_m: [f64; 3],

--- a/crates/sidereon-core/src/fusion/timesync.rs
+++ b/crates/sidereon-core/src/fusion/timesync.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_TIME_SYNC_CHECKPOINT_CAPACITY: usize = 64;
 
 /// Retained history limits for bounded-latency time synchronization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct TimeSyncHistoryConfig {
     /// Number of recent IMU samples retained for fractional replay.
     pub imu_capacity: usize,

--- a/crates/sidereon-core/src/fusion/ukf.rs
+++ b/crates/sidereon-core/src/fusion/ukf.rs
@@ -21,6 +21,7 @@ use super::state::{
 /// `alpha`, `beta`, and `kappa` produce Wan/van der Merwe sigma-point weights
 /// with `lambda = alpha^2 * (n + kappa) - n`.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct UnscentedTransformOptions {
     /// Sigma-point spread around the mean.
     pub alpha: f64,
@@ -68,6 +69,7 @@ impl UnscentedTransformOptions {
 
 /// UKF measurement-correction options.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub struct UkfUpdateOptions {
     /// Scaled unscented-transform parameters.
     pub transform: UnscentedTransformOptions,

--- a/crates/sidereon-core/src/geodetic_time_series.rs
+++ b/crates/sidereon-core/src/geodetic_time_series.rs
@@ -70,6 +70,7 @@ pub struct PositionSeries<'a> {
 
 /// Options for [`velocity_midas`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct MidasOptions {
     /// Dominant period used for pair selection, in years.
     pub dominant_period_years: f64,
@@ -183,6 +184,7 @@ impl Default for TrajectoryModel {
 
 /// Least-squares controls for [`fit_trajectory`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TrajectoryFitOptions {
     /// Robust loss passed to the trust-region least-squares solver.
     pub loss: Loss,
@@ -253,6 +255,7 @@ pub struct Trajectory {
 
 /// Controls for [`detect_steps`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct StepDetectionOptions {
     /// Half-window around a candidate epoch, in years.
     pub window_years: f64,

--- a/crates/sidereon-core/src/geofence.rs
+++ b/crates/sidereon-core/src/geofence.rs
@@ -319,6 +319,7 @@ pub enum ProbabilityMethod {
 
 /// Options for [`containment_probability_with_options`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ProbabilityOptions {
     /// Probability integration method.
     pub method: ProbabilityMethod,

--- a/crates/sidereon-core/src/geometry.rs
+++ b/crates/sidereon-core/src/geometry.rs
@@ -89,6 +89,7 @@ pub fn sagnac_range_first_order_m_with_rate(
 
 /// Visibility planning options for SP3-derived GNSS geometry.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct VisibilityOptions {
     /// Minimum topocentric elevation, degrees.
     pub elevation_mask_deg: f64,
@@ -117,6 +118,7 @@ pub enum DopWeighting {
 
 /// DOP planning options.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct DopOptions {
     /// Visibility scan options used when no explicit satellite list is supplied.
     pub visibility: VisibilityOptions,

--- a/crates/sidereon-core/src/inertial/config.rs
+++ b/crates/sidereon-core/src/inertial/config.rs
@@ -168,6 +168,7 @@ pub enum ConingCorrection {
 
 /// Configuration for ECEF strapdown mechanization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct MechanizationConfig {
     /// Coning correction mode. The default is off.
     pub coning_correction: ConingCorrection,

--- a/crates/sidereon-core/src/inertial/sim.rs
+++ b/crates/sidereon-core/src/inertial/sim.rs
@@ -56,6 +56,7 @@ impl ImuRateRandomWalk {
 
 /// Options for synthetic IMU generation.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ImuSimulationOptions {
     /// Sample representation returned by the simulator.
     pub output: ImuSimulationOutput,

--- a/crates/sidereon-core/src/ionex/mod.rs
+++ b/crates/sidereon-core/src/ionex/mod.rs
@@ -510,6 +510,7 @@ pub fn ionex_slant_delay_with_policy(
 
 /// One IONEX slant-delay query for [`ionex_slant_delays`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct IonexSlantRequest {
     /// Receiver geodetic position.
     pub receiver: Wgs84Geodetic,
@@ -521,6 +522,27 @@ pub struct IonexSlantRequest {
     pub epoch_j2000_s: i64,
     /// Carrier frequency on which to report the delay, hertz.
     pub frequency_hz: f64,
+}
+
+impl IonexSlantRequest {
+    /// Build a slant-delay query from its receiver, geometry, epoch, and
+    /// carrier-frequency inputs.
+    #[must_use]
+    pub const fn new(
+        receiver: Wgs84Geodetic,
+        elevation_rad: f64,
+        azimuth_rad: f64,
+        epoch_j2000_s: i64,
+        frequency_hz: f64,
+    ) -> Self {
+        Self {
+            receiver,
+            elevation_rad,
+            azimuth_rad,
+            epoch_j2000_s,
+            frequency_hz,
+        }
+    }
 }
 
 /// Batch IONEX vertical-TEC-grid slant ionospheric group delays.

--- a/crates/sidereon-core/src/ionex/tec_grid.rs
+++ b/crates/sidereon-core/src/ionex/tec_grid.rs
@@ -164,6 +164,7 @@ impl Default for TecGridShellGeometry {
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// [`tec_xyz`] consumes the epoch, elevation floor, fallback altitude, and
 /// shell geometry; [`iono_delay_xyz`] additionally uses the carrier frequency.
+#[non_exhaustive]
 pub struct TecGridEvalOptions {
     /// Epoch passed to [`TecGrid::vtec_at_pierce_point`].
     pub epoch: TecGridEpoch,
@@ -178,6 +179,21 @@ pub struct TecGridEvalOptions {
 }
 
 impl TecGridEvalOptions {
+    /// Build evaluation options for an explicit carrier frequency.
+    ///
+    /// The minimum elevation, NaN fallback height, and shell geometry use the
+    /// engine defaults; assign those fields when a different shell is needed.
+    #[must_use]
+    pub fn new(epoch: TecGridEpoch, frequency_hz: f64) -> Self {
+        Self {
+            epoch,
+            min_elevation_rad: 5.0 * DEG_TO_RAD,
+            nan_pierce_point_height_m: IONOSPHERE_HEIGHT_M,
+            frequency_hz,
+            shell_geometry: TecGridShellGeometry::default(),
+        }
+    }
+
     /// Creates options for the canonical GPS L1 frequency.
     ///
     /// The result uses a 5-degree minimum elevation, the default 450,000-meter
@@ -187,13 +203,7 @@ impl TecGridEvalOptions {
         #[allow(clippy::expect_used)]
         let frequency_hz = frequencies::frequency_hz(GnssSystem::Gps, CarrierBand::L1)
             .expect("canonical GPS L1 carrier exists");
-        Self {
-            epoch,
-            min_elevation_rad: 5.0 * DEG_TO_RAD,
-            nan_pierce_point_height_m: IONOSPHERE_HEIGHT_M,
-            frequency_hz,
-            shell_geometry: TecGridShellGeometry::default(),
-        }
+        Self::new(epoch, frequency_hz)
     }
 
     /// Returns a copy using `shell_geometry` and its height as the NaN fallback altitude.

--- a/crates/sidereon-core/src/navigation/lnav.rs
+++ b/crates/sidereon-core/src/navigation/lnav.rs
@@ -298,6 +298,7 @@ pub struct LnavParams {
 
 /// TLM/HOW options accompanying an [`encode`] (defaults applied by the caller).
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub struct LnavOptions {
     /// Integer time-of-week count placed in the 17-bit HOW field of each subframe.
     pub tow: LnavNumber,
@@ -309,6 +310,26 @@ pub struct LnavOptions {
     pub integrity: LnavNumber,
     /// Integer 14-bit TLM message placed after the preamble in each subframe.
     pub tlm_message: LnavNumber,
+}
+
+impl LnavOptions {
+    /// Build TLM/HOW options from every encoded-word input.
+    #[must_use]
+    pub const fn new(
+        tow: LnavNumber,
+        alert: LnavNumber,
+        anti_spoof: LnavNumber,
+        integrity: LnavNumber,
+        tlm_message: LnavNumber,
+    ) -> Self {
+        Self {
+            tow,
+            alert,
+            anti_spoof,
+            integrity,
+            tlm_message,
+        }
+    }
 }
 
 /// Decoded clock and ephemeris parameters (the typed output of [`decode`]). The

--- a/crates/sidereon-core/src/ntrip/request.rs
+++ b/crates/sidereon-core/src/ntrip/request.rs
@@ -25,6 +25,7 @@ pub struct NtripCredentials {
 #[derive(Clone, Debug, PartialEq)]
 /// Inputs retained by the NTRIP client machine for request construction and optional GGA pacing.
 /// The default uses port 2101 and [`NtripVersion::Rev2`], leaves the host and mountpoint empty, uses `sidereon/<package version>` as the product, and disables credentials and GGA pacing.
+#[non_exhaustive]
 pub struct NtripConfig {
     /// Caster host text, paired with [`NtripConfig::port`] in the Rev2 `Host` header.
     /// CR/LF in this value causes request validation to fail.

--- a/crates/sidereon-core/src/observables.rs
+++ b/crates/sidereon-core/src/observables.rs
@@ -92,6 +92,7 @@ pub enum EmissionMediaStatus {
 
 /// Options for [`emission_media_batch_at_j2000_s`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct EmissionMediaBatchOptions<'a> {
     /// Carrier frequency used for ionospheric group delay, hertz.
     pub carrier_hz: f64,
@@ -515,6 +516,7 @@ pub fn is_observable_state_gap(error: &ObservablesError) -> bool {
 
 /// Options controlling observable prediction.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PredictOptions {
     /// Carrier frequency used to scale Doppler, hertz.
     pub carrier_hz: f64,
@@ -526,6 +528,7 @@ pub struct PredictOptions {
 
 /// Options controlling transmit-time satellite-state evaluation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct TransmitTimeOptions {
     /// Apply fixed-point light-time / transmit-time correction.
     pub light_time: bool,
@@ -583,6 +586,7 @@ pub enum ObservableIonosphereCorrection<'a> {
 
 /// Optional media corrections for one predicted tracking observable.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub struct ObservableMediaOptions<'a> {
     /// Neutral-atmosphere slant delay to add to the range, if present.
     pub troposphere: Option<ObservableTroposphereCorrection>,
@@ -620,6 +624,7 @@ impl ObservableMediaOptions<'_> {
 
 /// Prediction options plus optional media corrections.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub struct MediaPredictOptions<'a> {
     /// Geometry, light-time, Sagnac, and carrier options.
     pub prediction: PredictOptions,
@@ -1321,6 +1326,7 @@ pub fn predict_batch_with_media_parallel(
 /// One batch range-prediction request: the satellite, the static receiver ECEF
 /// position in meters, and the receive epoch in seconds since J2000.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct RangePredictionRequest {
     /// The satellite to range against.
     pub sat: GnssSatelliteId,
@@ -1328,6 +1334,18 @@ pub struct RangePredictionRequest {
     pub receiver_ecef_m: [f64; 3],
     /// Receive epoch, seconds since J2000.
     pub t_rx_j2000_s: f64,
+}
+
+impl RangePredictionRequest {
+    /// Build a range request from its satellite, receiver position, and epoch.
+    #[must_use]
+    pub const fn new(sat: GnssSatelliteId, receiver_ecef_m: [f64; 3], t_rx_j2000_s: f64) -> Self {
+        Self {
+            sat,
+            receiver_ecef_m,
+            t_rx_j2000_s,
+        }
+    }
 }
 
 /// The geometry-only result of one [`predict_ranges`] request.

--- a/crates/sidereon-core/src/observation_qc/mod.rs
+++ b/crates/sidereon-core/src/observation_qc/mod.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_CLOCK_JUMP_THRESHOLD_S: f64 = 0.0005;
 
 /// Options controlling RINEX observation QC aggregation.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ObservationQcOptions {
     /// Override the header `INTERVAL` value when detecting missing epochs.
     pub interval_override_s: Option<f64>,

--- a/crates/sidereon-core/src/orbit_determination.rs
+++ b/crates/sidereon-core/src/orbit_determination.rs
@@ -50,6 +50,7 @@ const ORBIT_FD_MIN_VELOCITY_STEP_KM_S: f64 = 1.0e-6;
 
 /// Options controlling a precise-orbit fit.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct OrbitFitOptions {
     /// Force model used by the numerical propagator.
     pub force_model: ForceModelKind,

--- a/crates/sidereon-core/src/positioning.rs
+++ b/crates/sidereon-core/src/positioning.rs
@@ -203,6 +203,7 @@ impl<E: EphemerisSource + ?Sized> RinexSppAssemblySource for RinexSppSource<'_, 
 
 /// Options for assembling RINEX observation epochs into SPP [`SolveInputs`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RinexSppOptions {
     /// Per-constellation pseudorange-code selection policy.
     pub signal_policy: SignalPolicy,

--- a/crates/sidereon-core/src/ppp_corrections.rs
+++ b/crates/sidereon-core/src/ppp_corrections.rs
@@ -125,6 +125,7 @@ pub struct SatelliteAntenna {
 
 /// Satellite antenna correction options.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct SatelliteAntennaOptions {
     /// Trimmed label selecting the first signal's PCO and PCV records.
     pub freq1_label: String,
@@ -142,8 +143,30 @@ pub struct SatelliteAntennaOptions {
     pub antennas: Vec<SatelliteAntenna>,
 }
 
+impl SatelliteAntennaOptions {
+    /// Build satellite-antenna options from both carrier definitions and the
+    /// supplied antenna records.
+    #[must_use]
+    pub fn new(
+        freq1_label: String,
+        freq1_hz: f64,
+        freq2_label: String,
+        freq2_hz: f64,
+        antennas: Vec<SatelliteAntenna>,
+    ) -> Self {
+        Self {
+            freq1_label,
+            freq1_hz,
+            freq2_label,
+            freq2_hz,
+            antennas,
+        }
+    }
+}
+
 /// Offline code-bias correction options.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct CodeBiasOptions {
     /// Bias-SINEX or DCB model queried for the selected satellite and epoch.
     pub bias_set: BiasSet,
@@ -158,6 +181,22 @@ pub struct CodeBiasOptions {
     pub clock_reference: Option<ClockReferenceObservables>,
 }
 
+impl CodeBiasOptions {
+    /// Build code-bias options for a bias set with no observable overrides.
+    ///
+    /// Both override maps are empty and `clock_reference` is `None`; assign
+    /// those fields when the observation mapping needs to be configured.
+    #[must_use]
+    pub fn new(bias_set: BiasSet) -> Self {
+        Self {
+            bias_set,
+            used_observables_per_sat: BTreeMap::new(),
+            used_observables_default: BTreeMap::new(),
+            clock_reference: None,
+        }
+    }
+}
+
 /// Solid-Earth pole tide correction options.
 ///
 /// The pole tide needs the epoch's IERS polar motion, which the engine's
@@ -166,6 +205,7 @@ pub struct CodeBiasOptions {
 /// Earth-orientation inputs. Polar motion drifts only a few mas/day, so a single
 /// daily value is representative across a static arc.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PoleTideOptions {
     /// IERS polar motion x of the date (arcsec).
     pub xp_arcsec: f64,
@@ -173,8 +213,20 @@ pub struct PoleTideOptions {
     pub yp_arcsec: f64,
 }
 
+impl PoleTideOptions {
+    /// Build pole-tide options from the date's required IERS polar motion.
+    #[must_use]
+    pub const fn new(xp_arcsec: f64, yp_arcsec: f64) -> Self {
+        Self {
+            xp_arcsec,
+            yp_arcsec,
+        }
+    }
+}
+
 /// PPP correction precompute switches.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct PppCorrectionsOptions {
     /// Enables one Sun/Moon-driven solid-earth displacement per input epoch.
     pub solid_earth_tide: bool,
@@ -194,6 +246,25 @@ pub struct PppCorrectionsOptions {
     /// Enables clock-datum code-bias corrections for observations with a used
     /// observable mapping.
     pub code_bias: Option<CodeBiasOptions>,
+}
+
+impl PppCorrectionsOptions {
+    /// Build options with every optional PPP correction disabled.
+    ///
+    /// The two boolean switches are `false` and each optional correction is
+    /// `None`; assign a field to enable that correction explicitly.
+    #[allow(clippy::new_without_default)]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            solid_earth_tide: false,
+            pole_tide: None,
+            ocean_loading: None,
+            phase_windup: false,
+            satellite_antenna: None,
+            code_bias: None,
+        }
+    }
 }
 
 /// Indexed vector result. The epoch index refers to the input epoch slice.

--- a/crates/sidereon-core/src/precise_positioning/auto_init.rs
+++ b/crates/sidereon-core/src/precise_positioning/auto_init.rs
@@ -59,6 +59,7 @@ pub struct PppInitialGuess {
 
 /// Auto-initialization policy for the raw-epochs PPP driver.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PppAutoInitOptions {
     /// Explicit seed. `Some` skips the SPP/mean stages entirely (the Elixir
     /// `:initial_guess`); `None` runs the per-epoch SPP auto-init.

--- a/crates/sidereon-core/src/precise_positioning/cycle_slip.rs
+++ b/crates/sidereon-core/src/precise_positioning/cycle_slip.rs
@@ -34,12 +34,10 @@
 //!         observations: vec![observation(epoch, if epoch >= 2 { 9.0 } else { 5.0 })],
 //!     })
 //!     .collect::<Vec<_>>();
-//! let config = CycleSlipConfig {
-//!     melbourne_wubbena_threshold_cycles: 2.0,
-//!     geometry_free_threshold_m: 0.05,
-//!     maximum_gap_s: 120.0,
-//!     ..CycleSlipConfig::default()
-//! };
+//! let mut config = CycleSlipConfig::default();
+//! config.melbourne_wubbena_threshold_cycles = 2.0;
+//! config.geometry_free_threshold_m = 0.05;
+//! config.maximum_gap_s = 120.0;
 //!
 //! let flags = detect_cycle_slips(&epochs, config)?;
 //! assert!(!flags[1].observations[0].slip);
@@ -69,6 +67,7 @@ pub const DEFAULT_RUNNING_STATISTIC_K_FACTOR: f64 = 4.0;
 
 /// Configuration for dual-frequency PPP cycle-slip detection.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct CycleSlipConfig {
     /// Melbourne-Wubbena absolute slip threshold, in wide-lane cycles.
     pub melbourne_wubbena_threshold_cycles: f64,

--- a/crates/sidereon-core/src/precise_positioning/kinematic.rs
+++ b/crates/sidereon-core/src/precise_positioning/kinematic.rs
@@ -123,6 +123,7 @@ impl Default for KinematicProcessNoise {
 
 /// Configuration for a sequential kinematic PPP EKF solve.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct KinematicConfig {
     /// Initial receiver state estimate.
     pub initial_state: KinematicState,

--- a/crates/sidereon-core/src/precise_positioning/mod.rs
+++ b/crates/sidereon-core/src/precise_positioning/mod.rs
@@ -72,16 +72,16 @@
 //! # let observations = ids
 //! #     .iter()
 //! #     .map(|id| {
+//! #         let mut predict_options = PredictOptions::default();
+//! #         predict_options.carrier_hz = F_L1_HZ;
+//! #         predict_options.light_time = true;
+//! #         predict_options.sagnac = true;
 //! #         let prediction = predict(
 //! #             &source,
 //! #             *id,
 //! #             truth,
 //! #             0.0,
-//! #             PredictOptions {
-//! #                 carrier_hz: F_L1_HZ,
-//! #                 light_time: true,
-//! #                 sagnac: true,
-//! #             },
+//! #             predict_options,
 //! #         )?;
 //! #         let code_m = prediction.geometric_range_m + clock_m;
 //! #         let ambiguity_m = ambiguities_m.get(&id.to_string()).copied().unwrap();
@@ -117,11 +117,9 @@
 //! #     ztd_residual_m: 0.0,
 //! #     ambiguities_m,
 //! # };
-//! # let config = KinematicConfig {
-//! #     initial_covariance_m2: diagonal_covariance(initial_state.dimension(), 1.0e8),
-//! #     initial_state,
-//! #     ..KinematicConfig::default()
-//! # };
+//! # let mut config = KinematicConfig::default();
+//! # config.initial_covariance_m2 = diagonal_covariance(initial_state.dimension(), 1.0e8);
+//! # config.initial_state = initial_state;
 //! let solutions = solve_kinematic_ppp(&source, &[epoch], config)?;
 //! assert_eq!(solutions.len(), 1);
 //! assert!(solutions[0].innovation_rms_m.is_finite());

--- a/crates/sidereon-core/src/precise_positioning/prep.rs
+++ b/crates/sidereon-core/src/precise_positioning/prep.rs
@@ -57,9 +57,21 @@ pub struct PreparedFloatEpoch {
 
 /// Wide-lane and narrow-lane prep controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct WideLanePrepOptions {
     pub min_epochs: usize,
     pub tolerance_cycles: f64,
+}
+
+impl WideLanePrepOptions {
+    /// Build wide-lane preparation controls from both required thresholds.
+    #[must_use]
+    pub const fn new(min_epochs: usize, tolerance_cycles: f64) -> Self {
+        Self {
+            min_epochs,
+            tolerance_cycles,
+        }
+    }
 }
 
 /// Public split-arc metadata for PPP ambiguity segmentation.

--- a/crates/sidereon-core/src/precise_positioning/raim.rs
+++ b/crates/sidereon-core/src/precise_positioning/raim.rs
@@ -63,16 +63,16 @@
 //! #     .iter()
 //! #     .map(|id| {
 //! #         let satellite_id = id.to_string();
+//! #         let mut predict_options = PredictOptions::default();
+//! #         predict_options.carrier_hz = F_L1_HZ;
+//! #         predict_options.light_time = true;
+//! #         predict_options.sagnac = true;
 //! #         let prediction = predict(
 //! #             &source,
 //! #             *id,
 //! #             truth,
 //! #             0.0,
-//! #             PredictOptions {
-//! #                 carrier_hz: F_L1_HZ,
-//! #                 light_time: true,
-//! #                 sagnac: true,
-//! #             },
+//! #             predict_options,
 //! #         )?;
 //! #         let code_bias_m = if satellite_id == "G05" { 50.0 } else { 0.0 };
 //! #         let code_m = prediction.geometric_range_m + clock_m + code_bias_m;
@@ -116,33 +116,35 @@
 //! #     tropo_gradient_east_m: 0.0,
 //! #     residual_ionosphere_m: BTreeMap::new(),
 //! # };
-//! # let solve_config = FloatSolveConfig {
-//! #     weights: MeasurementWeights {
-//! #         code: 1.0,
-//! #         phase: 1.0,
-//! #         elevation_weighting: false,
-//! #     },
-//! #     tropo: TroposphereOptions::disabled(),
-//! #     corrections: RangeCorrections::disabled(),
-//! #     opts: FloatSolveOptions {
-//! #         max_iterations: 50,
-//! #         position_tolerance_m: 1.0e-7,
-//! #         clock_tolerance_m: 1.0e-7,
-//! #         ambiguity_tolerance_m: 1.0e-7,
-//! #         ztd_tolerance_m: 1.0e-7,
-//! #     },
-//! #     residual_screen: false,
-//! #     elevation_cutoff_deg: None,
-//! #     estimate_residual_ionosphere: false,
+//! # let weights = MeasurementWeights {
+//! #     code: 1.0,
+//! #     phase: 1.0,
+//! #     elevation_weighting: false,
 //! # };
+//! # let mut solve_options = FloatSolveOptions::default();
+//! # solve_options.max_iterations = 50;
+//! # solve_options.position_tolerance_m = 1.0e-7;
+//! # solve_options.clock_tolerance_m = 1.0e-7;
+//! # solve_options.ambiguity_tolerance_m = 1.0e-7;
+//! # solve_options.ztd_tolerance_m = 1.0e-7;
+//! # let solve_config = FloatSolveConfig::new(
+//! #     weights,
+//! #     TroposphereOptions::disabled(),
+//! #     RangeCorrections::disabled(),
+//! #     solve_options,
+//! #     None,
+//! #     false,
+//! #     false,
+//! # );
 //! let result = solve_float_epoch_with_raim(
 //! #   &source,
 //! #   epoch,
 //! #   initial_state,
 //! #   solve_config,
-//!     RaimConfig {
-//!         chi_square_threshold: Some(10.0),
-//!         ..RaimConfig::default()
+//!     {
+//!         let mut config = RaimConfig::default();
+//!         config.chi_square_threshold = Some(10.0);
+//!         config
 //!     },
 //! )?;
 //! assert_eq!(result.excluded_sats, vec!["G05".to_string()]);
@@ -177,6 +179,7 @@ const DEG_TO_RAD: f64 = std::f64::consts::PI / 180.0;
 
 /// Configuration for PPP snapshot RAIM.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct RaimConfig {
     /// False-alarm probability used to derive the chi-square threshold.
     pub false_alarm_probability: f64,

--- a/crates/sidereon-core/src/precise_positioning/tec.rs
+++ b/crates/sidereon-core/src/precise_positioning/tec.rs
@@ -74,6 +74,7 @@ pub const TEC_GROUP_DELAY_COEFFICIENT: f64 = 40.308 * ELECTRONS_PER_TECU_M2;
 
 /// Configuration for thin-shell TEC estimation.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TecConfig {
     /// Ionospheric shell height above the spherical Earth, in meters.
     pub shell_height_m: f64,

--- a/crates/sidereon-core/src/precise_positioning/types.rs
+++ b/crates/sidereon-core/src/precise_positioning/types.rs
@@ -72,6 +72,7 @@ pub struct MeasurementWeights {
 
 /// Iteration and convergence controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct FloatSolveOptions {
     pub max_iterations: usize,
     pub position_tolerance_m: f64,
@@ -98,6 +99,7 @@ impl Default for FloatSolveOptions {
 
 /// Troposphere controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct TroposphereOptions {
     pub enabled: bool,
     pub estimate_ztd: bool,
@@ -111,6 +113,21 @@ pub struct TroposphereOptions {
 }
 
 impl TroposphereOptions {
+    /// Build disabled troposphere controls using the supplied meteorology.
+    ///
+    /// Estimation is disabled and the Niell mapping is selected; assign the
+    /// boolean fields or mapping when a different model is required.
+    #[must_use]
+    pub const fn new(met: Met) -> Self {
+        Self {
+            enabled: false,
+            estimate_ztd: false,
+            estimate_tropo_gradients: false,
+            met,
+            mapping: TropoMapping::Niell,
+        }
+    }
+
     pub fn disabled() -> Self {
         Self {
             enabled: false,
@@ -295,12 +312,34 @@ pub struct ReceiverAntennaFrequency {
 
 /// Receiver antenna correction options.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct ReceiverAntennaOptions {
     pub freq1_label: String,
     pub freq1_hz: f64,
     pub freq2_label: String,
     pub freq2_hz: f64,
     pub frequencies: Vec<ReceiverAntennaFrequency>,
+}
+
+impl ReceiverAntennaOptions {
+    /// Build receiver-antenna options from both carrier definitions and the
+    /// supplied frequency calibrations.
+    #[must_use]
+    pub fn new(
+        freq1_label: String,
+        freq1_hz: f64,
+        freq2_label: String,
+        freq2_hz: f64,
+        frequencies: Vec<ReceiverAntennaFrequency>,
+    ) -> Self {
+        Self {
+            freq1_label,
+            freq1_hz,
+            freq2_label,
+            freq2_hz,
+            frequencies,
+        }
+    }
 }
 
 /// Fine satellite clock series, keyed by GPS seconds.
@@ -341,6 +380,7 @@ impl RangeCorrections {
 
 /// Static float solve controls.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FloatSolveConfig {
     pub weights: MeasurementWeights,
     pub tropo: TroposphereOptions,
@@ -360,6 +400,30 @@ pub struct FloatSolveConfig {
     /// for diagnosing residual dispersive error after ionosphere-free
     /// combination.
     pub estimate_residual_ionosphere: bool,
+}
+
+impl FloatSolveConfig {
+    /// Build static float controls from all required model and solve settings.
+    #[must_use]
+    pub const fn new(
+        weights: MeasurementWeights,
+        tropo: TroposphereOptions,
+        corrections: RangeCorrections,
+        opts: FloatSolveOptions,
+        elevation_cutoff_deg: Option<f64>,
+        residual_screen: bool,
+        estimate_residual_ionosphere: bool,
+    ) -> Self {
+        Self {
+            weights,
+            tropo,
+            corrections,
+            opts,
+            elevation_cutoff_deg,
+            residual_screen,
+            estimate_residual_ionosphere,
+        }
+    }
 }
 
 /// Indexed static PPP correction lookup tables.
@@ -397,6 +461,7 @@ pub struct SsrPppBiasSignalPair {
 
 /// Per-satellite and per-system default signal mapping for SSR/HAS PPP biases.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct SsrPppBiasOptions {
     pub per_satellite: BTreeMap<GnssSatelliteId, SsrPppBiasSignalPair>,
     pub per_system: BTreeMap<GnssSystem, SsrPppBiasSignalPair>,
@@ -807,14 +872,31 @@ impl core::fmt::Display for NoEphemerisReason {
 
 /// Integer ambiguity resolution controls for fixed PPP.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FixedAmbiguityOptions {
     pub wavelengths_m: BTreeMap<String, f64>,
     pub offsets_m: BTreeMap<String, f64>,
     pub ratio_threshold: f64,
 }
 
+impl FixedAmbiguityOptions {
+    /// Build ambiguity controls with an explicit ratio threshold.
+    ///
+    /// The wavelength and offset maps start empty because their values are
+    /// signal-specific; assign them before a fixed solve.
+    #[must_use]
+    pub fn new(ratio_threshold: f64) -> Self {
+        Self {
+            wavelengths_m: BTreeMap::new(),
+            offsets_m: BTreeMap::new(),
+            ratio_threshold,
+        }
+    }
+}
+
 /// Static fixed-ambiguity PPP solve controls.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FixedSolveConfig {
     pub weights: MeasurementWeights,
     pub tropo: TroposphereOptions,
@@ -830,6 +912,30 @@ pub struct FixedSolveConfig {
     /// Estimate one post-combination residual ionosphere state per ambiguity
     /// arc during the fixed re-solve.
     pub estimate_residual_ionosphere: bool,
+}
+
+impl FixedSolveConfig {
+    /// Build static fixed-solve controls from all model and ambiguity settings.
+    #[must_use]
+    pub const fn new(
+        weights: MeasurementWeights,
+        tropo: TroposphereOptions,
+        corrections: RangeCorrections,
+        opts: FloatSolveOptions,
+        elevation_cutoff_deg: Option<f64>,
+        ambiguity: FixedAmbiguityOptions,
+        estimate_residual_ionosphere: bool,
+    ) -> Self {
+        Self {
+            weights,
+            tropo,
+            corrections,
+            opts,
+            elevation_cutoff_deg,
+            ambiguity,
+            estimate_residual_ionosphere,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sidereon-core/src/precise_positioning/velocity.rs
+++ b/crates/sidereon-core/src/precise_positioning/velocity.rs
@@ -79,6 +79,7 @@ const VELOCITY_NORMAL_ASSEMBLER: NormalAssembler =
 
 /// Configuration for a single-epoch Doppler/range-rate velocity solve.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct VelocityConfig {
     /// Minimum number of observations required for the four velocity unknowns.
     pub minimum_observations: usize,
@@ -103,6 +104,7 @@ impl Default for VelocityConfig {
 /// `sqrt(huber(residual / scale))`, where `scale` is a floored MAD estimate.
 /// The default velocity solve leaves this disabled.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct VelocityRobustConfig {
     /// Huber tuning constant `k`; scaled residuals below this keep full weight.
     pub huber_k: f64,

--- a/crates/sidereon-core/src/quality.rs
+++ b/crates/sidereon-core/src/quality.rs
@@ -38,6 +38,7 @@ pub enum PseudorangeVarianceModel {
 
 /// Options for [`pseudorange_variance`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PseudorangeVarianceOptions {
     /// Zenith-floor term, meters.
     pub a_m: f64,
@@ -270,6 +271,7 @@ impl RaimWeights {
 
 /// Options for [`raim`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RaimOptions {
     /// False-alarm probability.
     pub p_fa: f64,
@@ -564,11 +566,23 @@ pub enum FdeError<E> {
 
 /// Options for [`fde`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FdeOptions {
     /// RAIM options used after each solve.
     pub raim: RaimOptions,
     /// Maximum number of exclusions to attempt.
     pub max_iterations: usize,
+}
+
+impl FdeOptions {
+    /// Build FDE options from the RAIM policy and exclusion budget.
+    #[must_use]
+    pub const fn new(raim: RaimOptions, max_iterations: usize) -> Self {
+        Self {
+            raim,
+            max_iterations,
+        }
+    }
 }
 
 /// Fault detection and exclusion over a caller-supplied SPP solver.
@@ -638,12 +652,21 @@ impl std::error::Error for FdeSppError {}
 /// Options for [`fde_spp`]: the RAIM-gated exclusion loop plus the per-iteration
 /// solution-validation gates applied to each candidate solve.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct FdeSppOptions {
     /// FDE loop options: the RAIM configuration and the exclusion budget.
     pub fde: FdeOptions,
     /// Per-iteration solution-validation gates (PDOP ceiling and plausibility
     /// band) applied to each candidate solution.
     pub validation: SolutionValidationOptions,
+}
+
+impl FdeSppOptions {
+    /// Build SPP FDE options from the exclusion and validation policies.
+    #[must_use]
+    pub const fn new(fde: FdeOptions, validation: SolutionValidationOptions) -> Self {
+        Self { fde, validation }
+    }
 }
 
 /// Run single-point positioning with RAIM fault detection and exclusion.
@@ -723,6 +746,7 @@ pub struct RangeFdeRow {
 
 /// Options for [`raim_fde_design`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct RangeFdeOptions {
     /// False-alarm probability for the global chi-square test. The detection
     /// threshold is the `1 - p_fa` chi-square quantile at the redundancy
@@ -1057,6 +1081,7 @@ fn validate_range_rows(rows: &[RangeFdeRow]) -> Result<usize, QualityError> {
 
 /// Validation policy for receiver solutions returned by SPP.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct SolutionValidationOptions {
     /// Optional PDOP ceiling.
     pub max_pdop: Option<f64>,

--- a/crates/sidereon-core/src/reduced_orbit/mod.rs
+++ b/crates/sidereon-core/src/reduced_orbit/mod.rs
@@ -292,24 +292,59 @@ impl ReducedOrbitSourceSampling {
 
 /// Options for [`fit_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ReducedOrbitSourceFitOptions {
     pub sampling: ReducedOrbitSourceSampling,
     pub model: Model,
 }
 
+impl ReducedOrbitSourceFitOptions {
+    /// Build reduced-orbit fit options from the sampling and model choices.
+    #[must_use]
+    pub const fn new(sampling: ReducedOrbitSourceSampling, model: Model) -> Self {
+        Self { sampling, model }
+    }
+}
+
 /// Options for [`drift_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ReducedOrbitSourceDriftOptions {
     pub sampling: ReducedOrbitSourceSampling,
     pub threshold_m: f64,
 }
 
+impl ReducedOrbitSourceDriftOptions {
+    /// Build reduced-orbit drift options from the sampling and required error
+    /// threshold.
+    #[must_use]
+    pub const fn new(sampling: ReducedOrbitSourceSampling, threshold_m: f64) -> Self {
+        Self {
+            sampling,
+            threshold_m,
+        }
+    }
+}
+
 /// Options for [`fit_piecewise_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct PiecewiseOrbitSourceFitOptions {
     pub sampling: ReducedOrbitSourceSampling,
     pub model: Model,
     pub segment_s: f64,
+}
+
+impl PiecewiseOrbitSourceFitOptions {
+    /// Build piecewise-fit options from the sampling, model, and segment length.
+    #[must_use]
+    pub const fn new(sampling: ReducedOrbitSourceSampling, model: Model, segment_s: f64) -> Self {
+        Self {
+            sampling,
+            model,
+            segment_s,
+        }
+    }
 }
 
 /// A source-backed single-model fit and its sampling metadata.

--- a/crates/sidereon-core/src/rinex_qc/mod.rs
+++ b/crates/sidereon-core/src/rinex_qc/mod.rs
@@ -642,6 +642,7 @@ impl LintReport {
 
 /// Repair options for the first core slice.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RepairOptions {
     /// Caller-supplied PGM/RUN BY/DATE stamp for A8.
     pub file_stamp: Option<PgmRunByDate>,

--- a/crates/sidereon-core/src/rtk.rs
+++ b/crates/sidereon-core/src/rtk.rs
@@ -302,6 +302,7 @@ pub struct ElevationMaskResult {
 
 /// Wide-lane integer estimation controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct WideLaneOptions {
     /// Positive minimum number of wide-lane samples required to fix an
     /// ambiguity.
@@ -312,6 +313,21 @@ pub struct WideLaneOptions {
     /// When true, short ambiguity fragments are omitted instead of failing. This
     /// is the `:split_arc` policy used by Sidereon after cycle-slip segmentation.
     pub skip_short_fragments: bool,
+}
+
+impl WideLaneOptions {
+    /// Build wide-lane controls from the required sample count and tolerance.
+    ///
+    /// Short fragments are retained by default; assign `skip_short_fragments`
+    /// when the split-arc policy is desired.
+    #[must_use]
+    pub const fn new(min_epochs: usize, tolerance_cycles: f64) -> Self {
+        Self {
+            min_epochs,
+            tolerance_cycles,
+            skip_short_fragments: false,
+        }
+    }
 }
 
 /// Error from dual-frequency wide-lane integer estimation.

--- a/crates/sidereon-core/src/rtk_filter/arc.rs
+++ b/crates/sidereon-core/src/rtk_filter/arc.rs
@@ -142,6 +142,7 @@ impl RtkArcPreprocessing {
 
 /// Sequential RTK arc driver configuration.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RtkArcConfig {
     /// Base-station ECEF position (metres).
     pub base_m: [f64; 3],
@@ -170,15 +171,56 @@ pub struct RtkArcConfig {
     pub preprocessing: RtkArcPreprocessing,
 }
 
+impl RtkArcConfig {
+    /// Build sequential RTK settings from every required arc configuration.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        base_m: [f64; 3],
+        reference: BaselineReferenceSelection,
+        model: MeasModel,
+        baseline_prior_sigma_m: f64,
+        ambiguity_prior_sigma_m: f64,
+        initial_baseline_m: [f64; 3],
+        wavelengths_m: BTreeMap<String, f64>,
+        offsets_m: BTreeMap<String, f64>,
+        update_opts: UpdateOpts,
+        preprocessing: RtkArcPreprocessing,
+    ) -> Self {
+        Self {
+            base_m,
+            reference,
+            model,
+            baseline_prior_sigma_m,
+            ambiguity_prior_sigma_m,
+            initial_baseline_m,
+            wavelengths_m,
+            offsets_m,
+            update_opts,
+            preprocessing,
+        }
+    }
+}
+
 /// Configuration consumed by [`solve_static_rtk_arc`] for a static batch RTK
 /// arc solve.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RtkStaticArcConfig {
     /// Sequential-arc settings reused for input preprocessing, geometry, and
     /// measurement and ambiguity modeling.
     pub arc: RtkArcConfig,
     /// Validated options for the float solve, fixed solve, and residual checks.
     pub opts: ValidatedFixedSolveOpts,
+}
+
+impl RtkStaticArcConfig {
+    /// Build static RTK settings from the sequential arc and validated solve
+    /// options.
+    #[must_use]
+    pub const fn new(arc: RtkArcConfig, opts: ValidatedFixedSolveOpts) -> Self {
+        Self { arc, opts }
+    }
 }
 
 /// Results assembled by [`solve_static_rtk_arc`], including both batch solver
@@ -349,6 +391,7 @@ pub struct RtkDualFrequencyArcEpoch {
 /// Settings forwarded by `prepare_dual_frequency_arc` to dual-frequency
 /// cycle-slip preprocessing for a wide-lane arc.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct RtkDualCycleSlipConfig {
     /// Action selected by dual-frequency preprocessing when it detects a slip.
     pub policy: CycleSlipPolicy,
@@ -357,9 +400,18 @@ pub struct RtkDualCycleSlipConfig {
     pub options: CycleSlipOptions,
 }
 
+impl RtkDualCycleSlipConfig {
+    /// Build dual-frequency cycle-slip settings from both required policies.
+    #[must_use]
+    pub const fn new(policy: CycleSlipPolicy, options: CycleSlipOptions) -> Self {
+        Self { policy, options }
+    }
+}
+
 /// Inputs consumed by [`fix_wide_lane_rtk_arc`] for dual-frequency wide-lane
 /// ambiguity estimation.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RtkWideLaneArcConfig {
     /// Base-station ECEF position, in meters, used for reference geometry.
     pub base_m: [f64; 3],
@@ -370,6 +422,25 @@ pub struct RtkWideLaneArcConfig {
     /// Optional dual-frequency cycle-slip preparation before reference selection
     /// and wide-lane estimation.
     pub cycle_slip: Option<RtkDualCycleSlipConfig>,
+}
+
+impl RtkWideLaneArcConfig {
+    /// Build wide-lane arc settings from the base position, reference policy,
+    /// estimator options, and optional cycle-slip policy.
+    #[must_use]
+    pub const fn new(
+        base_m: [f64; 3],
+        reference: BaselineReferenceSelection,
+        options: WideLaneOptions,
+        cycle_slip: Option<RtkDualCycleSlipConfig>,
+    ) -> Self {
+        Self {
+            base_m,
+            reference,
+            options,
+            cycle_slip,
+        }
+    }
 }
 
 /// Output assembled by [`fix_wide_lane_rtk_arc`] from wide-lane estimates and
@@ -428,6 +499,7 @@ impl std::error::Error for RtkWideLaneArcError {}
 /// Settings consumed by [`prepare_ionosphere_free_rtk_arc`] when converting
 /// dual-frequency epochs to ionosphere-free observations.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RtkIonosphereFreeArcConfig {
     /// Base-station ECEF position in meters, passed to reference selection and
     /// ionosphere-free preparation.
@@ -440,6 +512,25 @@ pub struct RtkIonosphereFreeArcConfig {
     /// Flag passed to the standalone preparation to select its troposphere
     /// correction branch.
     pub apply_troposphere: bool,
+}
+
+impl RtkIonosphereFreeArcConfig {
+    /// Build ionosphere-free settings from both baseline states and the
+    /// reference/troposphere policies.
+    #[must_use]
+    pub const fn new(
+        base_m: [f64; 3],
+        initial_baseline_m: [f64; 3],
+        reference: BaselineReferenceSelection,
+        apply_troposphere: bool,
+    ) -> Self {
+        Self {
+            base_m,
+            initial_baseline_m,
+            reference,
+            apply_troposphere,
+        }
+    }
 }
 
 /// Output assembled by [`prepare_ionosphere_free_rtk_arc`], including the
@@ -475,6 +566,7 @@ pub enum RtkWideLaneFixedArcSolveConfig {
 /// Configuration consumed by [`solve_wide_lane_fixed_rtk_arc`] for its
 /// wide-lane, ionosphere-free, and final RTK stages.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RtkWideLaneFixedArcConfig {
     /// Settings consumed by the initial wide-lane preparation and estimation.
     pub wide_lane: RtkWideLaneArcConfig,
@@ -482,6 +574,22 @@ pub struct RtkWideLaneFixedArcConfig {
     pub ionosphere_free: RtkIonosphereFreeArcConfig,
     /// Settings and branch selection for the final static or sequential solve.
     pub solve: RtkWideLaneFixedArcSolveConfig,
+}
+
+impl RtkWideLaneFixedArcConfig {
+    /// Build the combined wide-lane, ionosphere-free, and final-solve settings.
+    #[must_use]
+    pub const fn new(
+        wide_lane: RtkWideLaneArcConfig,
+        ionosphere_free: RtkIonosphereFreeArcConfig,
+        solve: RtkWideLaneFixedArcSolveConfig,
+    ) -> Self {
+        Self {
+            wide_lane,
+            ionosphere_free,
+            solve,
+        }
+    }
 }
 
 /// Identifies the branch recorded by `wide_lane_fixed_metadata` after a combined

--- a/crates/sidereon-core/src/rtk_filter/rinex_arc.rs
+++ b/crates/sidereon-core/src/rtk_filter/rinex_arc.rs
@@ -52,6 +52,7 @@ impl RtkRinexSignalPair {
 
 /// Options for building single-frequency RTK arc records from RINEX.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RtkRinexArcOptions {
     /// Signal choices grouped by constellation and tried in vector order. For
     /// each satellite, the first pair with both values present is used; an empty
@@ -66,6 +67,22 @@ pub struct RtkRinexArcOptions {
 }
 
 impl RtkRinexArcOptions {
+    /// Build single-frequency RINEX arc options from every selection and limit.
+    #[must_use]
+    pub fn new(
+        signal_pairs: Vec<RtkRinexSignalPair>,
+        max_epochs: Option<usize>,
+        min_common_satellites: usize,
+        include_prediction_time: bool,
+    ) -> Self {
+        Self {
+            signal_pairs,
+            max_epochs,
+            min_common_satellites,
+            include_prediction_time,
+        }
+    }
+
     /// Defaults for the GPS L1 C/A code and carrier path.
     pub fn gps_l1_c() -> Self {
         Self {
@@ -130,6 +147,7 @@ impl RtkRinexDualSignalPair {
 
 /// Options for building dual-frequency RTK arc records from RINEX.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RtkRinexDualArcOptions {
     /// Four-observable choices grouped by constellation and tried in vector order.
     /// For each satellite, the first pair with all four values present is used;
@@ -144,6 +162,22 @@ pub struct RtkRinexDualArcOptions {
 }
 
 impl RtkRinexDualArcOptions {
+    /// Build dual-frequency RINEX arc options from every selection and limit.
+    #[must_use]
+    pub fn new(
+        signal_pairs: Vec<RtkRinexDualSignalPair>,
+        max_epochs: Option<usize>,
+        min_common_satellites: usize,
+        include_prediction_time: bool,
+    ) -> Self {
+        Self {
+            signal_pairs,
+            max_epochs,
+            min_common_satellites,
+            include_prediction_time,
+        }
+    }
+
     /// Defaults for the GPS L1/L2 path used by the real arc fixtures.
     pub fn gps_l1_l2_cw() -> Self {
         Self {

--- a/crates/sidereon-core/src/sidereal.rs
+++ b/crates/sidereon-core/src/sidereal.rs
@@ -64,6 +64,7 @@ pub enum SiderealTemplateMethod {
 
 /// Options controlling residual template stacking.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct SiderealFilterOptions {
     /// Sampling interval of the residual array.
     pub sample_interval: Duration,

--- a/crates/sidereon-core/src/signal.rs
+++ b/crates/sidereon-core/src/signal.rs
@@ -81,6 +81,7 @@ impl IqSample {
 
 /// Options for [`replica`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct ReplicaOptions {
     /// Sampling rate in hertz.
     pub sample_rate_hz: f64,
@@ -93,6 +94,22 @@ pub struct ReplicaOptions {
 }
 
 impl ReplicaOptions {
+    /// Build replica options from every sampling and code-state input.
+    #[must_use]
+    pub const fn new(
+        sample_rate_hz: f64,
+        num_samples: usize,
+        code_phase_chips: f64,
+        code_doppler_hz: f64,
+    ) -> Self {
+        Self {
+            sample_rate_hz,
+            num_samples,
+            code_phase_chips,
+            code_doppler_hz,
+        }
+    }
+
     /// One C/A-code period at 2.046 MHz (two samples per chip).
     pub fn one_code_period() -> Self {
         let sample_rate_hz = DEFAULT_SAMPLE_RATE_HZ;
@@ -108,6 +125,7 @@ impl ReplicaOptions {
 
 /// Options for [`correlate`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct CorrelateOptions {
     /// Sampling rate in hertz.
     pub sample_rate_hz: f64,
@@ -143,6 +161,7 @@ pub struct CorrelationResult {
 
 /// Options for [`acquire`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct AcquisitionOptions {
     /// Sampling rate in hertz.
     pub sample_rate_hz: f64,

--- a/crates/sidereon-core/src/signal/analysis.rs
+++ b/crates/sidereon-core/src/signal/analysis.rs
@@ -176,6 +176,7 @@ pub enum DllProcessing {
 
 /// Inputs for code-tracking thermal-noise figures.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct DllTrackingOptions {
     /// Carrier-to-noise-density ratio, in decibel-hertz.
     pub cn0_db_hz: f64,
@@ -187,6 +188,26 @@ pub struct DllTrackingOptions {
     pub correlator_spacing_chips: f64,
     /// Two-sided receiver bandwidth, in hertz.
     pub receiver_bandwidth_hz: f64,
+}
+
+impl DllTrackingOptions {
+    /// Build DLL thermal-noise inputs from all required signal parameters.
+    #[must_use]
+    pub const fn new(
+        cn0_db_hz: f64,
+        loop_bandwidth_hz: f64,
+        integration_time_s: f64,
+        correlator_spacing_chips: f64,
+        receiver_bandwidth_hz: f64,
+    ) -> Self {
+        Self {
+            cn0_db_hz,
+            loop_bandwidth_hz,
+            integration_time_s,
+            correlator_spacing_chips,
+            receiver_bandwidth_hz,
+        }
+    }
 }
 
 /// Code-tracking thermal-noise result.
@@ -204,6 +225,7 @@ pub struct DllJitter {
 
 /// Inputs for one-path specular multipath envelope metrics.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct MultipathOptions {
     /// Reflected-path amplitude divided by direct-path amplitude, in `[0, 1)`.
     pub multipath_to_direct_ratio: f64,
@@ -211,6 +233,22 @@ pub struct MultipathOptions {
     pub correlator_spacing_chips: f64,
     /// Two-sided receiver bandwidth, in hertz.
     pub receiver_bandwidth_hz: f64,
+}
+
+impl MultipathOptions {
+    /// Build multipath inputs from the path ratio and receiver parameters.
+    #[must_use]
+    pub const fn new(
+        multipath_to_direct_ratio: f64,
+        correlator_spacing_chips: f64,
+        receiver_bandwidth_hz: f64,
+    ) -> Self {
+        Self {
+            multipath_to_direct_ratio,
+            correlator_spacing_chips,
+            receiver_bandwidth_hz,
+        }
+    }
 }
 
 /// Multipath envelope value at one reflected-path delay.

--- a/crates/sidereon-core/src/source_localization.rs
+++ b/crates/sidereon-core/src/source_localization.rs
@@ -70,10 +70,8 @@
 //!     })
 //!     .collect::<Vec<_>>();
 //!
-//! let options = SourceLocateOptions {
-//!     mode: SourceSolveMode::Toa,
-//!     ..SourceLocateOptions::default()
-//! };
+//! let mut options = SourceLocateOptions::default();
+//! options.mode = SourceSolveMode::Toa;
 //! let mut config = SourceLocateConfig::from(options);
 //! config.include_influence = false;
 //! let solution = locate_source_with(
@@ -163,6 +161,7 @@ pub enum SourceSolveMode {
 /// after 1.0 live on [`SourceLocateConfig`] and are passed through
 /// [`locate_source_with`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct SourceLocateOptions {
     /// ToA or TDOA residual form.
     pub mode: SourceSolveMode,

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -184,11 +184,23 @@ pub enum MergePrecedenceScope {
 /// deterministic largest cluster replaces it and the rejected source is
 /// recorded in the merge report.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct OutlierRejectOptions {
     /// Maximum 3D position separation inside the accepted cluster, meters.
     pub position_tolerance_m: f64,
     /// Maximum aligned-clock separation inside the accepted cluster, seconds.
     pub clock_tolerance_s: f64,
+}
+
+impl OutlierRejectOptions {
+    /// Build outlier-rejection settings from both required tolerances.
+    #[must_use]
+    pub const fn new(position_tolerance_m: f64, clock_tolerance_s: f64) -> Self {
+        Self {
+            position_tolerance_m,
+            clock_tolerance_s,
+        }
+    }
 }
 
 /// Options for [`merge`].
@@ -274,6 +286,7 @@ impl Default for MergeOptions {
 
 /// Explicit opt-in rules for reconciling mismatched SP3 coordinate labels.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Sp3FrameReconciliationOptions {
     /// Caller-asserted label sets that may be treated as physically equivalent
     /// without applying any coordinate transform.

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -287,6 +287,7 @@ impl OrbitClass {
 
 /// Which checks to run, and with what bounds.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct ContinuityOptions {
     /// Earth-fixed speed bound for the adjacent-pair gate. `None` disables the
     /// gate.
@@ -320,6 +321,18 @@ impl SpeedBound {
 }
 
 impl ContinuityOptions {
+    /// Build continuity settings from the optional speed and residual checks.
+    ///
+    /// `None` disables the corresponding check; assign `Some` bounds when the
+    /// check is required.
+    #[must_use]
+    pub const fn new(speed_bound: Option<SpeedBound>, residual_tolerance_m: Option<f64>) -> Self {
+        Self {
+            speed_bound,
+            residual_tolerance_m,
+        }
+    }
+
     /// Both checks, with the class bound and a 1 m residual tolerance.
     pub fn for_orbit_class(class: OrbitClass) -> Self {
         Self {

--- a/crates/sidereon-core/src/spp/mod.rs
+++ b/crates/sidereon-core/src/spp/mod.rs
@@ -441,6 +441,7 @@ impl Default for SurfaceMet {
 /// `robust = None` the solve is byte-identical to the static elevation-weighted
 /// solve. `Default` matches the `DEFAULT_*` config constants.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct RobustConfig {
     /// Huber tuning constant `k`; residuals scaled below this keep full weight.
     pub huber_k: f64,

--- a/crates/sidereon-core/src/static_positioning.rs
+++ b/crates/sidereon-core/src/static_positioning.rs
@@ -131,6 +131,7 @@ impl StaticEpoch {
 
 /// Options for [`solve_static`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct StaticSolveOptions {
     /// Initial shared receiver ECEF position in meters.
     pub initial_position_m: [f64; 3],

--- a/crates/sidereon-core/src/static_reference_station.rs
+++ b/crates/sidereon-core/src/static_reference_station.rs
@@ -266,6 +266,7 @@ pub struct StaticReferenceStationSolution {
 
 /// Carrier RTK options for the RINEX station wrapper.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct StaticReferenceCarrierRinexOptions {
     /// RINEX-to-RTK arc extraction options.
     pub arc_options: RtkRinexArcOptions,
@@ -274,8 +275,21 @@ pub struct StaticReferenceCarrierRinexOptions {
     pub static_config: RtkStaticArcConfig,
 }
 
+impl StaticReferenceCarrierRinexOptions {
+    /// Build carrier RINEX options from the arc extraction and static solve
+    /// configurations.
+    #[must_use]
+    pub const fn new(arc_options: RtkRinexArcOptions, static_config: RtkStaticArcConfig) -> Self {
+        Self {
+            arc_options,
+            static_config,
+        }
+    }
+}
+
 /// RINEX wrapper options. `None` disables that mode.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct StaticReferenceStationRinexOptions {
     /// Code-DGNSS RINEX/SPP assembly options.
     pub code_options: Option<RinexSppOptions>,
@@ -286,6 +300,22 @@ pub struct StaticReferenceStationRinexOptions {
 }
 
 impl StaticReferenceStationRinexOptions {
+    /// Build RINEX wrapper options from the optionally enabled modes.
+    ///
+    /// `None` disables the corresponding code or carrier mode.
+    #[must_use]
+    pub const fn new(
+        code_options: Option<RinexSppOptions>,
+        carrier_options: Option<StaticReferenceCarrierRinexOptions>,
+        with_geodetic: bool,
+    ) -> Self {
+        Self {
+            code_options,
+            carrier_options,
+            with_geodetic,
+        }
+    }
+
     /// Build options with both code-DGNSS and carrier RTK enabled.
     #[must_use]
     pub const fn code_and_carrier(

--- a/crates/sidereon-core/src/terrain.rs
+++ b/crates/sidereon-core/src/terrain.rs
@@ -204,6 +204,7 @@ pub enum DtedInterpolation {
 
 /// Lookup options for DTED terrain queries.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct DtedLookupOptions {
     /// Interpolation mode used for each orthometric height query.
     pub interpolation: DtedInterpolation,

--- a/crates/sidereon-core/src/tides/mod.rs
+++ b/crates/sidereon-core/src/tides/mod.rs
@@ -442,6 +442,7 @@ impl StationDisplacementEpoch {
 
 /// Switches for the high-level station displacement entry.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct StationDisplacementOptions<'a> {
     /// Apply the IERS solid Earth tide station displacement.
     pub solid_earth_tide: bool,

--- a/crates/sidereon-core/src/tropo/zwd.rs
+++ b/crates/sidereon-core/src/tropo/zwd.rs
@@ -62,6 +62,7 @@ impl ZwdEpoch {
 
 /// Inputs controlling the XYZ ZWD slant-delay helper.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub struct ZwdSlantOptions {
     pub epoch: ZwdEpoch,
     pub profile: ZwdProfile,

--- a/crates/sidereon-core/src/velocity.rs
+++ b/crates/sidereon-core/src/velocity.rs
@@ -43,6 +43,7 @@ pub struct VelocityObservation {
 
 /// Options controlling the velocity solve.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub struct VelocitySolveOptions {
     /// Observation value convention.
     pub observable: VelocityObservable,

--- a/crates/sidereon-core/tests/anomaly_kepler_oracle.rs
+++ b/crates/sidereon-core/tests/anomaly_kepler_oracle.rs
@@ -57,14 +57,12 @@ fn propagate_kepler_matches_dp54_two_body() {
     let dynamics = OrbitalDynamics {
         force_model: &force,
     };
-    let opts = IntegratorOptions {
-        abs_tol: 1.0e-12,
-        rel_tol: 1.0e-12,
-        initial_step: 10.0,
-        max_step: 60.0,
-        min_step: 1.0e-12,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1.0e-12;
+    opts.rel_tol = 1.0e-12;
+    opts.initial_step = 10.0;
+    opts.max_step = 60.0;
+    opts.min_step = 1.0e-12;
     let numerical = DP54
         .propagate(
             initial,

--- a/crates/sidereon-core/tests/bias.rs
+++ b/crates/sidereon-core/tests/bias.rs
@@ -36,13 +36,14 @@ fn epoch(year: i32, doy: u16, sod: u32) -> sidereon_core::astro::time::model::In
 }
 
 fn dcb_options() -> CodeDcbOptions {
-    CodeDcbOptions {
-        pair: ("P1".to_string(), "C1".to_string()),
-        year: 2026,
-        month: 6,
-        time_scale: TimeScale::Gpst,
-        receiver_system: None,
-    }
+    let mut options = CodeDcbOptions::new(
+        ("P1".to_string(), "C1".to_string()),
+        2026,
+        6,
+        TimeScale::Gpst,
+    );
+    options.receiver_system = None;
+    options
 }
 
 fn ns(value: f64) -> f64 {

--- a/crates/sidereon-core/tests/bodies_observe.rs
+++ b/crates/sidereon-core/tests/bodies_observe.rs
@@ -495,9 +495,10 @@ fn correction_toggles_have_expected_scales() {
             kernel: &kernel,
             naif_id: 4,
         },
-        ObserveOptions {
-            aberration: false,
-            ..ObserveOptions::default()
+        {
+            let mut options = ObserveOptions::default();
+            options.aberration = false;
+            options
         },
     )
     .expect("observation without aberration");
@@ -519,9 +520,10 @@ fn correction_toggles_have_expected_scales() {
             kernel: &kernel,
             naif_id: 4,
         },
-        ObserveOptions {
-            deflection: false,
-            ..ObserveOptions::default()
+        {
+            let mut options = ObserveOptions::default();
+            options.deflection = false;
+            options
         },
     )
     .expect("conjunction without deflection");
@@ -556,12 +558,13 @@ fn refraction_matches_skyfield_bennett_reference() {
             kernel: &kernel,
             naif_id: 4,
         },
-        ObserveOptions {
-            refraction: Some(Refraction {
+        {
+            let mut options = ObserveOptions::default();
+            options.refraction = Some(Refraction {
                 pressure_mbar: 1013.25,
                 temperature_c: 10.0,
-            }),
-            ..ObserveOptions::default()
+            });
+            options
         },
     )
     .expect("refracted observation");

--- a/crates/sidereon-core/tests/clock_stability.rs
+++ b/crates/sidereon-core/tests/clock_stability.rs
@@ -200,13 +200,15 @@ fn gapped_phase_series_omits_only_cross_gap_terms() {
     let rejected = compute_allan_deviations(&AllanInput {
         series: AllanSeries::PhaseSecondsWithGaps(&phase),
         tau0_s: 1.0,
-        options: AllanOptions {
-            estimators: AllanEstimatorSet {
+        options: {
+            let mut options = AllanOptions::default();
+            options.estimators = AllanEstimatorSet {
                 overlapping_adev: true,
                 ..AllanEstimatorSet::none()
-            },
-            tau_grid: TauGrid::Explicit(vec![1]),
-            gap_policy: GapPolicy::Reject,
+            };
+            options.tau_grid = TauGrid::Explicit(vec![1]);
+            options.gap_policy = GapPolicy::Reject;
+            options
         },
     });
     assert!(rejected.is_err());
@@ -214,13 +216,15 @@ fn gapped_phase_series_omits_only_cross_gap_terms() {
     let omitted = compute_allan_deviations(&AllanInput {
         series: AllanSeries::PhaseSecondsWithGaps(&phase),
         tau0_s: 1.0,
-        options: AllanOptions {
-            estimators: AllanEstimatorSet {
+        options: {
+            let mut options = AllanOptions::default();
+            options.estimators = AllanEstimatorSet {
                 overlapping_adev: true,
                 ..AllanEstimatorSet::none()
-            },
-            tau_grid: TauGrid::Explicit(vec![1]),
-            gap_policy: GapPolicy::OmitTerms,
+            };
+            options.tau_grid = TauGrid::Explicit(vec![1]);
+            options.gap_policy = GapPolicy::OmitTerms;
+            options
         },
     })
     .expect("gap omission");

--- a/crates/sidereon-core/tests/dense_output.rs
+++ b/crates/sidereon-core/tests/dense_output.rs
@@ -25,12 +25,10 @@ fn test_dense_output_endpoint_exactness() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-12,
-        rel_tol: 1e-12,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-12;
+    opts.rel_tol = 1e-12;
+    opts.dense_output = true;
 
     let result = integrator
         .propagate(initial_state, SECONDS_PER_HOUR, &dynamics, &ctx, &opts)
@@ -93,12 +91,10 @@ fn test_dense_output_circular_orbit_parity() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-12,
-        rel_tol: 1e-12,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-12;
+    opts.rel_tol = 1e-12;
+    opts.dense_output = true;
 
     let t_end = SECONDS_PER_HOUR;
     let result = integrator
@@ -154,12 +150,10 @@ fn test_dense_output_elliptic_orbit_invariants() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-12,
-        rel_tol: 1e-12,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-12;
+    opts.rel_tol = 1e-12;
+    opts.dense_output = true;
 
     let t_end = 5000.0;
     let result = integrator
@@ -203,12 +197,10 @@ fn test_dense_output_monotonic_continuity() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-10,
-        rel_tol: 1e-10,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-10;
+    opts.rel_tol = 1e-10;
+    opts.dense_output = true;
 
     let t_end = 10000.0;
     let result = integrator
@@ -259,10 +251,8 @@ fn test_dense_output_range_rejection() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.dense_output = true;
 
     let result = integrator
         .propagate(initial_state, 200.0, &dynamics, &ctx, &opts)

--- a/crates/sidereon-core/tests/earth_orientation.rs
+++ b/crates/sidereon-core/tests/earth_orientation.rs
@@ -132,24 +132,22 @@ fn instant_at(scale: TimeScale, epoch_j2000_s: i64) -> Instant {
 }
 
 fn fit_options(force_model: ForceModelKind) -> OrbitFitOptions {
-    OrbitFitOptions {
-        force_model,
-        integrator: IntegratorKind::Dp54,
-        integrator_options: IntegratorOptions {
-            abs_tol: 1.0e-12,
-            rel_tol: 1.0e-13,
-            initial_step: 10.0,
-            max_step: 60.0,
-            ..IntegratorOptions::default()
-        },
-        solver_options: SolveOptions {
-            gtol: 1.0e-15,
-            ftol: 1.0e-15,
-            xtol: 1.0e-15,
-            max_nfev: 1200,
-        },
-        ..OrbitFitOptions::default()
-    }
+    let mut integrator_options = IntegratorOptions::default();
+    integrator_options.abs_tol = 1.0e-12;
+    integrator_options.rel_tol = 1.0e-13;
+    integrator_options.initial_step = 10.0;
+    integrator_options.max_step = 60.0;
+    let mut solver_options = SolveOptions::default();
+    solver_options.gtol = 1.0e-15;
+    solver_options.ftol = 1.0e-15;
+    solver_options.xtol = 1.0e-15;
+    solver_options.max_nfev = 1200;
+    let mut options = OrbitFitOptions::default();
+    options.force_model = force_model;
+    options.integrator = IntegratorKind::Dp54;
+    options.integrator_options = integrator_options;
+    options.solver_options = solver_options;
+    options
 }
 
 fn assert_matrix_near(label: &str, actual: &Mat3, expected: &Mat3, tolerance: f64) {
@@ -363,9 +361,10 @@ fn propagation_default_bits_are_unchanged_with_unused_frame_provider() {
         initial: state,
         force_model: ForceModelKind::two_body(),
         integrator: IntegratorKind::Rk4,
-        options: IntegratorOptions {
-            initial_step: 10.0,
-            ..IntegratorOptions::default()
+        options: {
+            let mut options = IntegratorOptions::default();
+            options.initial_step = 10.0;
+            options
         },
         drag: None,
         space_weather: None,

--- a/crates/sidereon-core/tests/emission_media_batch.rs
+++ b/crates/sidereon-core/tests/emission_media_batch.rs
@@ -32,32 +32,32 @@ fn receiver_ecef_m() -> [f64; 3] {
 }
 
 fn media_options<'a>(ionex: &'a Ionex) -> ObservableMediaOptions<'a> {
-    ObservableMediaOptions {
-        troposphere: Some(Default::default()),
-        ionosphere: Some(ObservableIonosphereCorrection::IonexWithPolicy(
-            ionex,
-            IonexCoveragePolicy::Hold,
-        )),
-    }
+    let mut options = ObservableMediaOptions::default();
+    options.troposphere = Some(Default::default());
+    options.ionosphere = Some(ObservableIonosphereCorrection::IonexWithPolicy(
+        ionex,
+        IonexCoveragePolicy::Hold,
+    ));
+    options
 }
 
 fn scalar_options<'a>(ionex: &'a Ionex) -> MediaPredictOptions<'a> {
-    MediaPredictOptions {
-        prediction: PredictOptions {
-            carrier_hz: F_L1_HZ,
-            light_time: false,
-            sagnac: false,
-        },
-        media: media_options(ionex),
-    }
+    let mut prediction = PredictOptions::default();
+    prediction.carrier_hz = F_L1_HZ;
+    prediction.light_time = false;
+    prediction.sagnac = false;
+    let mut options = MediaPredictOptions::default();
+    options.prediction = prediction;
+    options.media = media_options(ionex);
+    options
 }
 
 fn batch_options<'a>(ionex: &'a Ionex) -> EmissionMediaBatchOptions<'a> {
-    EmissionMediaBatchOptions {
-        carrier_hz: F_L1_HZ,
-        media: media_options(ionex),
-        min_elevation_rad: None,
-    }
+    let mut options = EmissionMediaBatchOptions::default();
+    options.carrier_hz = F_L1_HZ;
+    options.media = media_options(ionex);
+    options.min_elevation_rad = None;
+    options
 }
 
 fn assert_vec3_bits_eq(label: &str, left: [f64; 3], right: [f64; 3]) {
@@ -343,16 +343,11 @@ fn emission_media_batch_cutoff_keeps_state_without_delay_placeholders() {
         .observable_state_at_j2000_s(sat, epoch_j2000_s)
         .expect("scalar state");
 
-    let batch = emission_media_batch_at_j2000_s(
-        &sp3,
-        &[sat],
-        &[epoch_j2000_s],
-        receiver,
-        EmissionMediaBatchOptions {
-            min_elevation_rad: Some(core::f64::consts::FRAC_PI_2),
-            ..batch_options(&ionex)
-        },
-    )
+    let batch = emission_media_batch_at_j2000_s(&sp3, &[sat], &[epoch_j2000_s], receiver, {
+        let mut options = batch_options(&ionex);
+        options.min_elevation_rad = Some(core::f64::consts::FRAC_PI_2);
+        options
+    })
     .expect("cutoff batch");
 
     assert_eq!(

--- a/crates/sidereon-core/tests/exact_cache_atomicity.rs
+++ b/crates/sidereon-core/tests/exact_cache_atomicity.rs
@@ -41,12 +41,12 @@ fn cache(path: impl Into<PathBuf>) -> ExactProductCache {
 }
 
 fn single_flight_options() -> ExactCacheSingleFlightOptions {
-    ExactCacheSingleFlightOptions {
-        poll_interval: Duration::from_millis(10),
-        heartbeat_interval: Duration::from_millis(25),
-        liveness_timeout: Duration::from_secs(2),
-        wait_timeout: Duration::from_secs(10),
-    }
+    let mut options = ExactCacheSingleFlightOptions::default();
+    options.poll_interval = Duration::from_millis(10);
+    options.heartbeat_interval = Duration::from_millis(25);
+    options.liveness_timeout = Duration::from_secs(2);
+    options.wait_timeout = Duration::from_secs(10);
+    options
 }
 
 fn temp_directory(label: &str) -> PathBuf {
@@ -291,12 +291,11 @@ fn sigkill_dead_owner_is_taken_over_after_injected_liveness_timeout() {
     let waiter_root = root.clone();
     let waiter_stable = stable.clone();
     let takeover = thread::spawn(move || {
-        let options = ExactCacheSingleFlightOptions {
-            poll_interval: Duration::from_secs(1),
-            heartbeat_interval: Duration::from_secs(1),
-            liveness_timeout: Duration::from_secs(5),
-            wait_timeout: Duration::from_secs(10),
-        };
+        let mut options = ExactCacheSingleFlightOptions::default();
+        options.poll_interval = Duration::from_secs(1);
+        options.heartbeat_interval = Duration::from_secs(1);
+        options.liveness_timeout = Duration::from_secs(5);
+        options.wait_timeout = Duration::from_secs(10);
         let owner = match cache(waiter_stable)
             .open_single_flight_with_test_clock(options, &waiter_clock)
             .expect("dead-owner takeover")
@@ -350,11 +349,13 @@ fn live_owner_total_wait_timeout_does_not_create_a_second_owner() {
     let waiter_stable = stable.clone();
     let waiter = thread::spawn(move || {
         cache(waiter_stable).open_single_flight_with_test_clock(
-            ExactCacheSingleFlightOptions {
-                poll_interval: Duration::from_secs(1),
-                heartbeat_interval: Duration::from_secs(5),
-                liveness_timeout: Duration::from_secs(10),
-                wait_timeout: Duration::from_secs(3),
+            {
+                let mut options = ExactCacheSingleFlightOptions::default();
+                options.poll_interval = Duration::from_secs(1);
+                options.heartbeat_interval = Duration::from_secs(5);
+                options.liveness_timeout = Duration::from_secs(10);
+                options.wait_timeout = Duration::from_secs(3);
+                options
             },
             &waiter_clock,
         )

--- a/crates/sidereon-core/tests/fusion_consistency.rs
+++ b/crates/sidereon-core/tests/fusion_consistency.rs
@@ -266,14 +266,11 @@ fn run_ensemble(
         let truth = *trajectory.last().expect("final truth");
         let nominal = initial_nominal(initial, &mut rng);
         let mut filter = make_filter(nominal, profile.spec);
-        let sequence = simulate_imu_samples_from_increments(
-            &increments,
-            profile.spec,
-            ImuSimulationOptions {
-                seed: seed ^ 0x6d5f_c2a4_1c37_9e21,
-                ..ImuSimulationOptions::default()
-            },
-        )
+        let sequence = simulate_imu_samples_from_increments(&increments, profile.spec, {
+            let mut options = ImuSimulationOptions::default();
+            options.seed = seed ^ 0x6d5f_c2a4_1c37_9e21;
+            options
+        })
         .expect("IMU sequence");
 
         for sample in sequence.samples {
@@ -344,18 +341,15 @@ fn run_turntable_lever_arm_ensemble() -> EnsembleResult {
             TURNTABLE_LEVER_ARM_BODY_M,
             &covariance_diagonal,
         );
-        let sequence = simulate_imu_samples_from_increments(
-            &increments,
-            spec,
-            ImuSimulationOptions {
-                seed: seed ^ 0xa95c_7d63_0f5a_19b3,
-                initial_bias: ImuBias {
-                    accel_mps2: [0.0; 3],
-                    gyro_rps: true_initial_gyro_bias,
-                },
-                ..ImuSimulationOptions::default()
-            },
-        )
+        let sequence = simulate_imu_samples_from_increments(&increments, spec, {
+            let mut options = ImuSimulationOptions::default();
+            options.seed = seed ^ 0xa95c_7d63_0f5a_19b3;
+            options.initial_bias = ImuBias {
+                accel_mps2: [0.0; 3],
+                gyro_rps: true_initial_gyro_bias,
+            };
+            options
+        })
         .expect("IMU sequence");
 
         for (idx, (sample, truth_step)) in sequence
@@ -409,10 +403,9 @@ fn run_loose_outlier_budget_ensemble(robust: bool) -> EnsembleResult {
     let increments = truth_increments(&trajectory);
     let truth = *trajectory.last().expect("final truth");
     let loose = if robust {
-        LooseCouplingConfig {
-            measurement_reweighting: Some(IggIiiMeasurementReweighting::standard()),
-            ..LooseCouplingConfig::default()
-        }
+        let mut config = LooseCouplingConfig::default();
+        config.measurement_reweighting = Some(IggIiiMeasurementReweighting::standard());
+        config
     } else {
         LooseCouplingConfig::default()
     };
@@ -426,14 +419,11 @@ fn run_loose_outlier_budget_ensemble(robust: bool) -> EnsembleResult {
         let initial = trajectory[0];
         let nominal = initial_nominal(initial, &mut rng);
         let mut filter = make_filter_with_loose_config(nominal, profile.spec, loose);
-        let sequence = simulate_imu_samples_from_increments(
-            &increments,
-            profile.spec,
-            ImuSimulationOptions {
-                seed: seed ^ 0x6d5f_c2a4_1c37_9e21,
-                ..ImuSimulationOptions::default()
-            },
-        )
+        let sequence = simulate_imu_samples_from_increments(&increments, profile.spec, {
+            let mut options = ImuSimulationOptions::default();
+            options.seed = seed ^ 0x6d5f_c2a4_1c37_9e21;
+            options
+        })
         .expect("IMU sequence");
 
         for sample in sequence.samples {
@@ -498,16 +488,16 @@ fn make_filter_with_tight_config(
         InsFilterState::from_diagonal(nominal, ErrorStateLayout::Fifteen, covariance_diagonal)
             .expect("filter state");
     let mut config = InertialFilterConfig::new(spec).expect("filter config");
-    config.tight = TightCouplingConfig {
-        lever_arm_body_m,
-        light_time: false,
-        sagnac: false,
-        initial_clock_bias_variance_m2: 1.0e-6,
-        initial_clock_drift_variance_m2_s2: 1.0e-6,
-        clock_bias_random_walk_m2_s: 0.0,
-        clock_drift_random_walk_m2_s3: 0.0,
-        update_options: Default::default(),
-    };
+    let mut tight = TightCouplingConfig::default();
+    tight.lever_arm_body_m = lever_arm_body_m;
+    tight.light_time = false;
+    tight.sagnac = false;
+    tight.initial_clock_bias_variance_m2 = 1.0e-6;
+    tight.initial_clock_drift_variance_m2_s2 = 1.0e-6;
+    tight.clock_bias_random_walk_m2_s = 0.0;
+    tight.clock_drift_random_walk_m2_s3 = 0.0;
+    tight.update_options = Default::default();
+    config.tight = tight;
     InertialFilter::with_config(state, config).expect("filter")
 }
 
@@ -722,10 +712,9 @@ fn tight_epoch_with_kinematics(
     rng: &mut SplitMix64,
     actual_noise_scale: f64,
 ) -> TightGnssEpoch {
-    let options = TransmitTimeOptions {
-        light_time: false,
-        sagnac: false,
-    };
+    let mut options = TransmitTimeOptions::default();
+    options.light_time = false;
+    options.sagnac = false;
     let antenna = antenna_truth_kinematics(truth, lever_arm_body_m, body_rate_wrt_ecef_rps);
     let code_noise_sigma = code_sigma_m * actual_noise_scale;
     let range_rate_noise_sigma = range_rate_sigma_mps * actual_noise_scale;

--- a/crates/sidereon-core/tests/fusion_field_pins.rs
+++ b/crates/sidereon-core/tests/fusion_field_pins.rs
@@ -276,18 +276,15 @@ fn stationary_zupt_zaru_bounds_static_drift_and_estimates_biases() {
     let accel_bias = [0.020, 0.0, 0.0];
     let gyro_bias = [0.0010, -0.0008, 0.0006];
     let spec = ImuSpec::datasheet(0.0015, 2.0e-5, 0.0002, 2.0e-6, 600.0, 600.0, None, None);
-    let sequence = simulate_imu_samples_from_increments(
-        &truth_increments(&truth),
-        spec,
-        ImuSimulationOptions {
-            seed: SEED ^ 0x5a75_7100_0000_0001,
-            initial_bias: ImuBias {
-                accel_mps2: accel_bias,
-                gyro_rps: gyro_bias,
-            },
-            ..ImuSimulationOptions::default()
-        },
-    )
+    let sequence = simulate_imu_samples_from_increments(&truth_increments(&truth), spec, {
+        let mut options = ImuSimulationOptions::default();
+        options.seed = SEED ^ 0x5a75_7100_0000_0001;
+        options.initial_bias = ImuBias {
+            accel_mps2: accel_bias,
+            gyro_rps: gyro_bias,
+        };
+        options
+    })
     .expect("stationary IMU");
 
     let no_updates = run_stationary_constraint_case(&truth, sequence.samples.clone(), spec, false);
@@ -329,14 +326,11 @@ fn non_holonomic_constraint_removes_lateral_velocity_error() {
     let dt_s = 1.0;
     let truth = straight_vehicle_truth(steps, dt_s);
     let spec = ImuSpec::datasheet(0.0, 0.0, 0.0, 0.0, 600.0, 600.0, None, None);
-    let sequence = simulate_imu_samples_from_increments(
-        &truth_increments(&truth),
-        spec,
-        ImuSimulationOptions {
-            seed: SEED ^ 0x5a75_7100_0000_0002,
-            ..ImuSimulationOptions::default()
-        },
-    )
+    let sequence = simulate_imu_samples_from_increments(&truth_increments(&truth), spec, {
+        let mut options = ImuSimulationOptions::default();
+        options.seed = SEED ^ 0x5a75_7100_0000_0002;
+        options
+    })
     .expect("vehicle IMU");
 
     let coast = run_nhc_case(&truth, sequence.samples.clone(), spec, false);
@@ -364,15 +358,11 @@ fn stationary_update_rejects_short_windows_and_nonstationary_samples() {
     let truth = static_truth(3, 1.0);
     let spec = ImuSpec::datasheet(0.0, 0.0, 0.0, 0.0, 600.0, 600.0, None, None);
     let mut config = LooseCouplingConfig::default();
-    config.stationary_updates = Some(StationaryUpdateConfig {
-        detector: StationaryDetectorConfig {
-            window_len: 3,
-            max_specific_force_norm_error_mps2: 0.08,
-            max_body_rate_wrt_ecef_norm_rps: 0.003,
-        },
-        zero_velocity_sigma_mps: 0.015,
-        zero_angular_rate_sigma_rps: 0.00008,
-    });
+    config.stationary_updates = Some(StationaryUpdateConfig::new(
+        StationaryDetectorConfig::new(3, 0.08, 0.003),
+        0.015,
+        0.00008,
+    ));
     let mut filter = direct_filter(truth[0], spec, initial_covariance_diagonal(), config);
     let stationary_force_mps2 = [9.80665, 0.0, 0.0];
     for step in 1..=2 {
@@ -413,15 +403,11 @@ fn stationary_update_rejects_duplicate_epoch_application() {
     let truth = static_truth(3, 1.0);
     let spec = ImuSpec::datasheet(0.0, 0.0, 0.0, 0.0, 600.0, 600.0, None, None);
     let mut config = LooseCouplingConfig::default();
-    config.stationary_updates = Some(StationaryUpdateConfig {
-        detector: StationaryDetectorConfig {
-            window_len: 3,
-            max_specific_force_norm_error_mps2: 0.08,
-            max_body_rate_wrt_ecef_norm_rps: 0.003,
-        },
-        zero_velocity_sigma_mps: 0.015,
-        zero_angular_rate_sigma_rps: 0.00008,
-    });
+    config.stationary_updates = Some(StationaryUpdateConfig::new(
+        StationaryDetectorConfig::new(3, 0.08, 0.003),
+        0.015,
+        0.00008,
+    ));
     let mut filter = direct_filter(truth[0], spec, initial_covariance_diagonal(), config);
     for state in truth.iter().take(4).skip(1) {
         filter
@@ -447,15 +433,8 @@ fn stationary_update_rejects_duplicate_epoch_application() {
 fn non_holonomic_constraint_rejects_sub_min_speed_and_high_rate() {
     let truth = straight_vehicle_truth(1, 1.0);
     let spec = ImuSpec::datasheet(0.0, 0.0, 0.0, 0.0, 600.0, 600.0, None, None);
-    let config = LooseCouplingConfig {
-        non_holonomic: Some(NonHolonomicConstraintConfig {
-            lateral_velocity_sigma_mps: 0.03,
-            vertical_velocity_sigma_mps: 0.03,
-            min_speed_mps: 2.0,
-            max_body_rate_wrt_ecef_norm_rps: 0.01,
-        }),
-        ..LooseCouplingConfig::default()
-    };
+    let mut config = LooseCouplingConfig::default();
+    config.non_holonomic = Some(NonHolonomicConstraintConfig::new(0.03, 0.03, 2.0, 0.01));
     let mut slow_nominal = truth[0];
     slow_nominal.velocity_ecef_mps = [0.5, 0.0, 0.0];
     let mut slow_filter = direct_filter(slow_nominal, spec, initial_covariance_diagonal(), config);
@@ -495,15 +474,8 @@ fn non_holonomic_constraint_rejects_sub_min_speed_and_high_rate() {
 fn non_holonomic_constraint_rejects_duplicate_epoch_application() {
     let truth = straight_vehicle_truth(1, 1.0);
     let spec = ImuSpec::datasheet(0.0, 0.0, 0.0, 0.0, 600.0, 600.0, None, None);
-    let config = LooseCouplingConfig {
-        non_holonomic: Some(NonHolonomicConstraintConfig {
-            lateral_velocity_sigma_mps: 0.03,
-            vertical_velocity_sigma_mps: 0.03,
-            min_speed_mps: 2.0,
-            max_body_rate_wrt_ecef_norm_rps: 0.01,
-        }),
-        ..LooseCouplingConfig::default()
-    };
+    let mut config = LooseCouplingConfig::default();
+    config.non_holonomic = Some(NonHolonomicConstraintConfig::new(0.03, 0.03, 2.0, 0.01));
     let mut filter = direct_filter(truth[0], spec, initial_covariance_diagonal(), config);
     filter
         .propagate(ImuSample::rate(
@@ -560,9 +532,7 @@ fn velocity_matching_reduces_outage_peak_error_and_keeps_span_continuous() {
     let matched = sidereon_core::fusion::velocity_match_outage(
         &span,
         &return_fix,
-        VelocityMatchingConfig {
-            max_outage_duration_s: 20.0,
-        },
+        VelocityMatchingConfig::new(20.0),
     )
     .expect("velocity match");
 
@@ -608,9 +578,7 @@ fn velocity_matching_can_land_on_posterior_endpoint_state() {
     let matched = sidereon_core::fusion::velocity_match_outage_to_state(
         &states,
         endpoint,
-        VelocityMatchingConfig {
-            max_outage_duration_s: 5.0,
-        },
+        VelocityMatchingConfig::new(5.0),
     )
     .expect("velocity match to state");
 
@@ -641,18 +609,15 @@ fn fix_status_weighting_inflates_float_covariance_by_configured_sigma() {
         .expect("measurement")
         .with_fix_status(GnssFixStatus::Float);
     let mut unweighted = direct_filter(nominal, spec, diagonal, LooseCouplingConfig::default());
-    let mut weighted = direct_filter(
-        nominal,
-        spec,
-        diagonal,
-        LooseCouplingConfig {
-            fix_status_weighting: GnssFixStatusWeighting {
-                float_sigma_multiplier: 3.0,
-                ..GnssFixStatusWeighting::default()
-            },
-            ..LooseCouplingConfig::default()
-        },
-    );
+    let mut weighted = direct_filter(nominal, spec, diagonal, {
+        let mut config = LooseCouplingConfig::default();
+        let weighting = GnssFixStatusWeighting {
+            float_sigma_multiplier: 3.0,
+            ..Default::default()
+        };
+        config.fix_status_weighting = weighting;
+        config
+    });
 
     unweighted
         .update_loose(&measurement)
@@ -690,14 +655,13 @@ fn field_mode_defaults_keep_existing_loose_fixture_bits() {
             )
             .expect("filter state");
             let mut config = InertialFilterConfig::new(spec).expect("filter config");
-            config.loose = LooseCouplingConfig {
-                fix_status_weighting: GnssFixStatusWeighting::default(),
-                stationary_updates: None,
-                non_holonomic: None,
-                measurement_reweighting: Some(IggIiiMeasurementReweighting::standard()),
-                prediction_adaptation: Some(YangPredictionAdaptiveFactor::standard()),
-                ..LooseCouplingConfig::default()
-            };
+            let mut loose = LooseCouplingConfig::default();
+            loose.fix_status_weighting = GnssFixStatusWeighting::default();
+            loose.stationary_updates = None;
+            loose.non_holonomic = None;
+            loose.measurement_reweighting = Some(IggIiiMeasurementReweighting::standard());
+            loose.prediction_adaptation = Some(YangPredictionAdaptiveFactor::standard());
+            config.loose = loose;
             InertialFilter::with_config(state, config).expect("filter")
         });
 
@@ -1095,14 +1059,11 @@ where
     let mut velocities = vec![filter.state().nominal.velocity_ecef_mps];
     let mut covariances = vec![filter.state().covariance.clone()];
     let increments = truth_increments(truth);
-    let sequence = simulate_imu_samples_from_increments(
-        &increments,
-        spec,
-        ImuSimulationOptions {
-            seed: SEED ^ 0xa11c_e5e1_5e1d_0f11,
-            ..ImuSimulationOptions::default()
-        },
-    )
+    let sequence = simulate_imu_samples_from_increments(&increments, spec, {
+        let mut options = ImuSimulationOptions::default();
+        options.seed = SEED ^ 0xa11c_e5e1_5e1d_0f11;
+        options
+    })
     .expect("simulated IMU");
 
     for (step, sample) in sequence.samples.into_iter().enumerate() {
@@ -1185,15 +1146,11 @@ fn run_stationary_constraint_case(
     }
     let mut config = LooseCouplingConfig::default();
     if enable_updates {
-        config.stationary_updates = Some(StationaryUpdateConfig {
-            detector: StationaryDetectorConfig {
-                window_len: 3,
-                max_specific_force_norm_error_mps2: 0.08,
-                max_body_rate_wrt_ecef_norm_rps: 0.003,
-            },
-            zero_velocity_sigma_mps: 0.015,
-            zero_angular_rate_sigma_rps: 0.00008,
-        });
+        config.stationary_updates = Some(StationaryUpdateConfig::new(
+            StationaryDetectorConfig::new(3, 0.08, 0.003),
+            0.015,
+            0.00008,
+        ));
     }
     let mut filter = direct_filter(truth[0], spec, diagonal, config);
     let mut applied_updates = 0usize;
@@ -1229,12 +1186,7 @@ fn run_nhc_case(
     }
     let mut config = LooseCouplingConfig::default();
     if enable_updates {
-        config.non_holonomic = Some(NonHolonomicConstraintConfig {
-            lateral_velocity_sigma_mps: 0.03,
-            vertical_velocity_sigma_mps: 0.03,
-            min_speed_mps: 2.0,
-            max_body_rate_wrt_ecef_norm_rps: 0.01,
-        });
+        config.non_holonomic = Some(NonHolonomicConstraintConfig::new(0.03, 0.03, 2.0, 0.01));
     }
     let mut filter = direct_filter(nominal, spec, diagonal, config);
     let mut applied_updates = 0usize;
@@ -1283,14 +1235,11 @@ fn run_tight_fusion(
     let mut velocities = vec![filter.state().nominal.velocity_ecef_mps];
     let mut covariances = vec![filter.state().covariance.clone()];
     let increments = truth_increments(truth);
-    let sequence = simulate_imu_samples_from_increments(
-        &increments,
-        spec,
-        ImuSimulationOptions {
-            seed: imu_seed ^ 0x1a5e_d1f1_f7c0_5eed,
-            ..ImuSimulationOptions::default()
-        },
-    )
+    let sequence = simulate_imu_samples_from_increments(&increments, spec, {
+        let mut options = ImuSimulationOptions::default();
+        options.seed = imu_seed ^ 0x1a5e_d1f1_f7c0_5eed;
+        options
+    })
     .expect("simulated IMU");
 
     for (step, sample) in sequence.samples.into_iter().enumerate() {
@@ -1326,11 +1275,10 @@ fn loose_filter(initial_truth: NavState, spec: ImuSpec) -> InertialFilter {
     )
     .expect("filter state");
     let mut config = InertialFilterConfig::new(spec).expect("filter config");
-    config.loose = LooseCouplingConfig {
-        measurement_reweighting: Some(IggIiiMeasurementReweighting::standard()),
-        prediction_adaptation: Some(YangPredictionAdaptiveFactor::standard()),
-        ..LooseCouplingConfig::default()
-    };
+    let mut loose = LooseCouplingConfig::default();
+    loose.measurement_reweighting = Some(IggIiiMeasurementReweighting::standard());
+    loose.prediction_adaptation = Some(YangPredictionAdaptiveFactor::standard());
+    config.loose = loose;
     InertialFilter::with_config(state, config).expect("filter")
 }
 
@@ -1342,13 +1290,12 @@ fn tight_filter(initial_nominal: NavState, spec: ImuSpec) -> InertialFilter {
     )
     .expect("filter state");
     let mut config = InertialFilterConfig::new(spec).expect("filter config");
-    config.tight = TightCouplingConfig {
-        initial_clock_bias_variance_m2: 2.5e3,
-        initial_clock_drift_variance_m2_s2: 0.25,
-        clock_bias_random_walk_m2_s: 0.02,
-        clock_drift_random_walk_m2_s3: 1.0e-4,
-        ..TightCouplingConfig::default()
-    };
+    let mut tight = TightCouplingConfig::default();
+    tight.initial_clock_bias_variance_m2 = 2.5e3;
+    tight.initial_clock_drift_variance_m2_s2 = 0.25;
+    tight.clock_bias_random_walk_m2_s = 0.02;
+    tight.clock_drift_random_walk_m2_s3 = 1.0e-4;
+    config.tight = tight;
     InertialFilter::with_config(state, config).expect("filter")
 }
 

--- a/crates/sidereon-core/tests/fusion_rts_smoother.rs
+++ b/crates/sidereon-core/tests/fusion_rts_smoother.rs
@@ -214,15 +214,8 @@ fn recorded_stationary_update_and_loose_update_can_share_epoch() {
     let state =
         InsFilterState::from_diagonal(start, ErrorStateLayout::Fifteen, &diagonal).expect("state");
     let mut config = InertialFilterConfig::new(spec).expect("filter config");
-    config.loose.stationary_updates = Some(StationaryUpdateConfig {
-        detector: StationaryDetectorConfig {
-            window_len: 1,
-            max_specific_force_norm_error_mps2: 1.0e-6,
-            max_body_rate_wrt_ecef_norm_rps: 1.0e-6,
-        },
-        zero_velocity_sigma_mps: 0.01,
-        zero_angular_rate_sigma_rps: 1.0e-4,
-    });
+    let detector = StationaryDetectorConfig::new(1, 1.0e-6, 1.0e-6);
+    config.loose.stationary_updates = Some(StationaryUpdateConfig::new(detector, 0.01, 1.0e-4));
     let mut filter = InertialFilter::with_config(state, config).expect("filter");
     let mut history = FusionRtsHistoryBuilder::from_filter(&filter).expect("history");
 
@@ -266,14 +259,11 @@ fn recorded_scenario_arc_smoothing_reduces_3d_rms() {
         .map(|pair| true_imu_increment_between(&pair[0], &pair[1]).expect("truth increment"))
         .collect::<Vec<_>>();
     let spec = ImuSpec::datasheet(0.015, 0.001, 0.001, 1.0e-4, 300.0, 300.0, None, None);
-    let sequence = simulate_imu_samples_from_increments(
-        &increments,
-        spec,
-        ImuSimulationOptions {
-            seed: 0x51d3_7e0f_29a4_d61b,
-            ..ImuSimulationOptions::default()
-        },
-    )
+    let sequence = simulate_imu_samples_from_increments(&increments, spec, {
+        let mut options = ImuSimulationOptions::default();
+        options.seed = 0x51d3_7e0f_29a4_d61b;
+        options
+    })
     .expect("simulated IMU");
 
     let mut filter = scenario_filter(truth[0], spec);

--- a/crates/sidereon-core/tests/geofence.rs
+++ b/crates/sidereon-core/tests/geofence.rs
@@ -135,8 +135,10 @@ fn quadrature_agrees_with_half_space_approximation_inside_bound() {
         point,
         PositionUncertainty::EnuCovarianceM2(covariance),
         &fence,
-        ProbabilityOptions {
-            method: ProbabilityMethod::BoundaryNormal,
+        {
+            let mut options = ProbabilityOptions::default();
+            options.method = ProbabilityMethod::BoundaryNormal;
+            options
         },
     )
     .expect("approximation");
@@ -144,8 +146,10 @@ fn quadrature_agrees_with_half_space_approximation_inside_bound() {
         point,
         PositionUncertainty::EnuCovarianceM2(covariance),
         &fence,
-        ProbabilityOptions {
-            method: ProbabilityMethod::PlanarQuadrature,
+        {
+            let mut options = ProbabilityOptions::default();
+            options.method = ProbabilityMethod::PlanarQuadrature;
+            options
         },
     )
     .expect("quadrature");
@@ -220,9 +224,8 @@ fn planar_quadrature_boundary_edge_and_corner_probabilities() {
         [0.0, sigma_m * sigma_m, 0.0],
         [0.0, 0.0, 0.0],
     ];
-    let options = ProbabilityOptions {
-        method: ProbabilityMethod::PlanarQuadrature,
-    };
+    let mut options = ProbabilityOptions::default();
+    options.method = ProbabilityMethod::PlanarQuadrature;
     let edge_probability = containment_probability_with_options(
         geo(0.01, 0.0),
         PositionUncertainty::EnuCovarianceM2(covariance),
@@ -263,8 +266,10 @@ fn zero_uncertainty_boundary_probability_matches_containment() {
         point,
         PositionUncertainty::CepRadiusM(0.0),
         &fence,
-        ProbabilityOptions {
-            method: ProbabilityMethod::PlanarQuadrature,
+        {
+            let mut options = ProbabilityOptions::default();
+            options.method = ProbabilityMethod::PlanarQuadrature;
+            options
         },
     )
     .expect("quadrature probability");

--- a/crates/sidereon-core/tests/gnss_doppler_velocity_real_arc.rs
+++ b/crates/sidereon-core/tests/gnss_doppler_velocity_real_arc.rs
@@ -147,11 +147,10 @@ fn pixel5_gsdc_l1_doppler_velocity_arc_stays_within_bars() {
         epochs.len()
     );
 
-    let options = VelocitySolveOptions {
-        observable: VelocityObservable::Doppler,
-        light_time: true,
-        sagnac: true,
-    };
+    let mut options = VelocitySolveOptions::default();
+    options.observable = VelocityObservable::Doppler;
+    options.light_time = true;
+    options.sagnac = true;
     let mut errors = Vec::with_capacity(epochs.len());
     let mut truth_speeds = Vec::with_capacity(epochs.len());
     let mut solved = 0_usize;

--- a/crates/sidereon-core/tests/gnss_formula_oracle.rs
+++ b/crates/sidereon-core/tests/gnss_formula_oracle.rs
@@ -321,11 +321,10 @@ fn observable_formula_cases_match_golden_bits() {
         let sat = sat_id(case["sat"].as_str().expect("satellite token"));
         let receiver_ecef_m = hex3(&case["receiver_ecef_m"]);
         let t_rx_j2000_s = j2000_seconds_from_iso(case["epoch"].as_str().expect("epoch"));
-        let options = PredictOptions {
-            light_time: case["light_time"].as_bool().expect("light_time"),
-            sagnac: case["sagnac"].as_bool().expect("sagnac"),
-            carrier_hz: F_L1_HZ,
-        };
+        let mut options = PredictOptions::default();
+        options.light_time = case["light_time"].as_bool().expect("light_time");
+        options.sagnac = case["sagnac"].as_bool().expect("sagnac");
+        options.carrier_hz = F_L1_HZ;
 
         let predicted = predict(&sp3, sat, receiver_ecef_m, t_rx_j2000_s, options)
             .unwrap_or_else(|err| panic!("observable case {index} {sat}: {err}"));

--- a/crates/sidereon-core/tests/hgt_to_dted.rs
+++ b/crates/sidereon-core/tests/hgt_to_dted.rs
@@ -88,9 +88,8 @@ fn hgt_to_dted_round_trips_selected_postings_through_reader() {
     fs::write(&tile_path, &dt2).expect("write converted DTED tile");
 
     let mut terrain = DtedTerrain::new(&root);
-    let nearest = DtedLookupOptions {
-        interpolation: DtedInterpolation::NearestPosting,
-    };
+    let mut nearest = DtedLookupOptions::default();
+    nearest.interpolation = DtedInterpolation::NearestPosting;
 
     for (lat_posting, lon_posting) in [(0, 0), (100, 200), (1234, 2345), (2000, 3000), (3600, 3600)]
     {

--- a/crates/sidereon-core/tests/kepler_oracle.rs
+++ b/crates/sidereon-core/tests/kepler_oracle.rs
@@ -27,11 +27,9 @@ fn test_kepler_circular_orbit_full_period() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-12,
-        rel_tol: 1e-12,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-12;
+    opts.rel_tol = 1e-12;
 
     let result = integrator
         .propagate(initial_state, period, &dynamics, &ctx, &opts)
@@ -98,11 +96,9 @@ fn test_kepler_elliptic_orbit_invariants() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-13,
-        rel_tol: 1e-13,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-13;
+    opts.rel_tol = 1e-13;
 
     // Propagate half an orbit (approx)
     let t_end = SECONDS_PER_HOUR;
@@ -157,11 +153,9 @@ fn test_j2_secular_drift_oracle() {
     };
     let integrator = DP54;
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        abs_tol: 1e-12,
-        rel_tol: 1e-12,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = 1e-12;
+    opts.rel_tol = 1e-12;
 
     // Propagate for one day
     let t_end = SECONDS_PER_DAY;

--- a/crates/sidereon-core/tests/lnav.rs
+++ b/crates/sidereon-core/tests/lnav.rs
@@ -101,13 +101,13 @@ fn encoded_subframes_match_reference_generator_bit_for_bit() {
     let lnav = &golden["lnav"];
     let opts_json = &lnav["options"];
 
-    let opts = LnavOptions {
-        tow: i(opts_json["tow"].as_i64().unwrap()),
-        alert: i(opts_json["alert"].as_i64().unwrap()),
-        anti_spoof: i(opts_json["anti_spoof"].as_i64().unwrap()),
-        integrity: i(opts_json["integrity"].as_i64().unwrap()),
-        tlm_message: i(opts_json["tlm_message"].as_i64().unwrap()),
-    };
+    let opts = LnavOptions::new(
+        i(opts_json["tow"].as_i64().unwrap()),
+        i(opts_json["alert"].as_i64().unwrap()),
+        i(opts_json["anti_spoof"].as_i64().unwrap()),
+        i(opts_json["integrity"].as_i64().unwrap()),
+        i(opts_json["tlm_message"].as_i64().unwrap()),
+    );
 
     let subframes = lnav::encode(&example(), &opts).expect("encode");
 

--- a/crates/sidereon-core/tests/navego_loose_parity.rs
+++ b/crates/sidereon-core/tests/navego_loose_parity.rs
@@ -130,15 +130,12 @@ fn navego_synthetic_adis16488_loose_reduced_gate_matches_stated_subset() {
 
     for trial in 0..TRIALS {
         let mut rng = SplitMix64::new(0x4e41_5645_474f_0000 + trial as u64);
-        let imu = simulate_imu_samples_from_increments(
-            &truth_increments,
-            imu_spec,
-            ImuSimulationOptions {
-                seed: 0x5141_4452_4154_0000 + trial as u64,
-                initial_bias: ImuBias::default(),
-                ..ImuSimulationOptions::default()
-            },
-        )
+        let imu = simulate_imu_samples_from_increments(&truth_increments, imu_spec, {
+            let mut options = ImuSimulationOptions::default();
+            options.seed = 0x5141_4452_4154_0000 + trial as u64;
+            options.initial_bias = ImuBias::default();
+            options
+        })
         .expect("simulated imu");
 
         let initial = initial_filter(&trajectory, imu_spec);

--- a/crates/sidereon-core/tests/ntrip.rs
+++ b/crates/sidereon-core/tests/ntrip.rs
@@ -26,15 +26,15 @@ fn ntrip_machine_payload_feeds_rtcm_assembler() {
     wire.extend_from_slice(&frame);
     wire.extend_from_slice(b"\r\n0\r\n\r\n");
 
-    let mut machine = NtripClientMachine::new(NtripConfig {
-        host: "caster.example.test".into(),
-        port: 2101,
-        mountpoint: "MOUNT".into(),
-        version: NtripVersion::Rev2,
-        credentials: None,
-        user_agent_product: "test-client/0".into(),
-        gga_interval_s: None,
-    });
+    let mut ntrip_config = NtripConfig::default();
+    ntrip_config.host = "caster.example.test".into();
+    ntrip_config.port = 2101;
+    ntrip_config.mountpoint = "MOUNT".into();
+    ntrip_config.version = NtripVersion::Rev2;
+    ntrip_config.credentials = None;
+    ntrip_config.user_agent_product = "test-client/0".into();
+    ntrip_config.gga_interval_s = None;
+    let mut machine = NtripClientMachine::new(ntrip_config);
     machine.connection_request().unwrap();
     let events = machine.push(&wire);
     assert!(matches!(
@@ -74,15 +74,15 @@ fn ntrip_machine_payload_feeds_ssr_correction_store() {
     let mut second = frame[split..].to_vec();
     second.extend_from_slice(b"\r\n0\r\n\r\n");
 
-    let mut machine = NtripClientMachine::new(NtripConfig {
-        host: "caster.example.test".into(),
-        port: 2101,
-        mountpoint: "MOUNT".into(),
-        version: NtripVersion::Rev2,
-        credentials: None,
-        user_agent_product: "test-client/0".into(),
-        gga_interval_s: None,
-    });
+    let mut ntrip_config = NtripConfig::default();
+    ntrip_config.host = "caster.example.test".into();
+    ntrip_config.port = 2101;
+    ntrip_config.mountpoint = "MOUNT".into();
+    ntrip_config.version = NtripVersion::Rev2;
+    ntrip_config.credentials = None;
+    ntrip_config.user_agent_product = "test-client/0".into();
+    ntrip_config.gga_interval_s = None;
+    let mut machine = NtripClientMachine::new(ntrip_config);
     machine.connection_request().unwrap();
 
     let mut assembler = SsrStreamAssembler::new();

--- a/crates/sidereon-core/tests/numerical_propagation.rs
+++ b/crates/sidereon-core/tests/numerical_propagation.rs
@@ -157,12 +157,10 @@ fn dense_step_seconds(
 #[test]
 fn dp54_max_step_limits_controller_growth_and_initial_step() {
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        initial_step: 5.0,
-        max_step: 2.0,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.initial_step = 5.0;
+    opts.max_step = 2.0;
+    opts.dense_output = true;
 
     let result = DP54
         .propagate(
@@ -187,12 +185,10 @@ fn dp54_max_step_limits_controller_growth_and_initial_step() {
 #[test]
 fn dp54_max_step_preserves_backward_step_sign() {
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        initial_step: 5.0,
-        max_step: 2.0,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.initial_step = 5.0;
+    opts.max_step = 2.0;
+    opts.dense_output = true;
 
     let result = DP54
         .propagate(
@@ -217,12 +213,10 @@ fn dp54_max_step_preserves_backward_step_sign() {
 #[test]
 fn dp54_unbound_max_step_keeps_controller_growth() {
     let ctx = PropagationContext::default();
-    let opts = IntegratorOptions {
-        initial_step: 1.0,
-        max_step: 60.0,
-        dense_output: true,
-        ..IntegratorOptions::default()
-    };
+    let mut opts = IntegratorOptions::default();
+    opts.initial_step = 1.0;
+    opts.max_step = 60.0;
+    opts.dense_output = true;
 
     let result = DP54
         .propagate(
@@ -252,10 +246,11 @@ fn two_body_matches_analytic_kepler_to_tight_bound() {
         ForceModelKind::two_body(),
         IntegratorKind::Dp54,
     )
-    .with_options(IntegratorOptions {
-        abs_tol: 1.0e-13,
-        rel_tol: 1.0e-13,
-        ..IntegratorOptions::default()
+    .with_options({
+        let mut options = IntegratorOptions::default();
+        options.abs_tol = 1.0e-13;
+        options.rel_tol = 1.0e-13;
+        options
     });
 
     // Sample across roughly one orbital period.
@@ -301,10 +296,11 @@ fn two_body_conserves_energy_and_angular_momentum() {
         ForceModelKind::two_body(),
         IntegratorKind::Dp54,
     )
-    .with_options(IntegratorOptions {
-        abs_tol: 1.0e-13,
-        rel_tol: 1.0e-13,
-        ..IntegratorOptions::default()
+    .with_options({
+        let mut options = IntegratorOptions::default();
+        options.abs_tol = 1.0e-13;
+        options.rel_tol = 1.0e-13;
+        options
     });
 
     let final_state = propagator
@@ -335,10 +331,11 @@ fn forward_then_back_round_trips_to_start() {
         ForceModelKind::two_body_j2(),
         IntegratorKind::Dp54,
     )
-    .with_options(IntegratorOptions {
-        abs_tol: 1.0e-13,
-        rel_tol: 1.0e-13,
-        ..IntegratorOptions::default()
+    .with_options({
+        let mut options = IntegratorOptions::default();
+        options.abs_tol = 1.0e-13;
+        options.rel_tol = 1.0e-13;
+        options
     });
 
     let mid = forward.propagate_to(5400.0).expect("forward").final_state;
@@ -347,10 +344,11 @@ fn forward_then_back_round_trips_to_start() {
         initial: mid,
         force_model: ForceModelKind::two_body_j2(),
         integrator: IntegratorKind::Dp54,
-        options: IntegratorOptions {
-            abs_tol: 1.0e-13,
-            rel_tol: 1.0e-13,
-            ..IntegratorOptions::default()
+        options: {
+            let mut options = IntegratorOptions::default();
+            options.abs_tol = 1.0e-13;
+            options.rel_tol = 1.0e-13;
+            options
         },
         drag: None,
         space_weather: None,
@@ -380,14 +378,16 @@ fn dump_propagator() -> StatePropagator {
         initial: CartesianState::new(DUMP_EPOCH_S, DUMP_POS_KM, DUMP_VEL_KM_S),
         force_model: ForceModelKind::two_body_j2(),
         integrator: IntegratorKind::Dp54,
-        options: IntegratorOptions {
-            abs_tol: DUMP_ABS_TOL,
-            rel_tol: DUMP_REL_TOL,
-            initial_step: DUMP_INITIAL_STEP_S,
-            min_step: DUMP_MIN_STEP_S,
-            max_step: DUMP_MAX_STEP_S,
-            max_steps: DUMP_MAX_STEPS,
-            dense_output: false,
+        options: {
+            let mut options = IntegratorOptions::default();
+            options.abs_tol = DUMP_ABS_TOL;
+            options.rel_tol = DUMP_REL_TOL;
+            options.initial_step = DUMP_INITIAL_STEP_S;
+            options.min_step = DUMP_MIN_STEP_S;
+            options.max_step = DUMP_MAX_STEP_S;
+            options.max_steps = DUMP_MAX_STEPS;
+            options.dense_output = false;
+            options
         },
         drag: None,
         space_weather: None,
@@ -483,10 +483,11 @@ fn dump_fixture(times: &[f64], states: &[CartesianState]) {
 #[test]
 fn entry_point_is_bit_identical_to_direct_integration() {
     let (pos, vel) = elliptic_start();
-    let opts = || IntegratorOptions {
-        abs_tol: 1.0e-12,
-        rel_tol: 1.0e-12,
-        ..IntegratorOptions::default()
+    let opts = || {
+        let mut options = IntegratorOptions::default();
+        options.abs_tol = 1.0e-12;
+        options.rel_tol = 1.0e-12;
+        options
     };
 
     let via_entry = StatePropagator::new(

--- a/crates/sidereon-core/tests/observables_bench.rs
+++ b/crates/sidereon-core/tests/observables_bench.rs
@@ -47,11 +47,7 @@ fn requests(sp3: &Sp3) -> Vec<RangePredictionRequest> {
     }
     assert!(!times.is_empty(), "fixture has no covered epochs");
     (0..2_000)
-        .map(|i| RangePredictionRequest {
-            sat,
-            receiver_ecef_m: rx,
-            t_rx_j2000_s: times[i % times.len()],
-        })
+        .map(|i| RangePredictionRequest::new(sat, rx, times[i % times.len()]))
         .collect()
 }
 
@@ -61,10 +57,9 @@ fn predict_ranges_throughput() {
     let sp3 = sp3_fixture();
     let requests = requests(&sp3);
     let options = PredictOptions::default();
-    let tt_options = TransmitTimeOptions {
-        light_time: options.light_time,
-        sagnac: options.sagnac,
-    };
+    let mut tt_options = TransmitTimeOptions::default();
+    tt_options.light_time = options.light_time;
+    tt_options.sagnac = options.sagnac;
     let zero = RangePrediction {
         geometric_range_m: 0.0,
         sat_clock_s: None,

--- a/crates/sidereon-core/tests/orbit_residual_ledger.rs
+++ b/crates/sidereon-core/tests/orbit_residual_ledger.rs
@@ -48,24 +48,22 @@ fn time_scales_at(scale: TimeScale, epoch_j2000_s: i64) -> TimeScales {
 }
 
 fn fit_options(force_model: ForceModelKind) -> OrbitFitOptions {
-    OrbitFitOptions {
-        force_model,
-        integrator: IntegratorKind::Dp54,
-        integrator_options: IntegratorOptions {
-            abs_tol: 1.0e-12,
-            rel_tol: 1.0e-13,
-            initial_step: 10.0,
-            max_step: 60.0,
-            ..IntegratorOptions::default()
-        },
-        solver_options: SolveOptions {
-            gtol: 1.0e-15,
-            ftol: 1.0e-15,
-            xtol: 1.0e-15,
-            max_nfev: 1200,
-        },
-        ..OrbitFitOptions::default()
-    }
+    let mut integrator_options = IntegratorOptions::default();
+    integrator_options.abs_tol = 1.0e-12;
+    integrator_options.rel_tol = 1.0e-13;
+    integrator_options.initial_step = 10.0;
+    integrator_options.max_step = 60.0;
+    let mut solver_options = SolveOptions::default();
+    solver_options.gtol = 1.0e-15;
+    solver_options.ftol = 1.0e-15;
+    solver_options.xtol = 1.0e-15;
+    solver_options.max_nfev = 1200;
+    let mut options = OrbitFitOptions::default();
+    options.force_model = force_model;
+    options.integrator = IntegratorKind::Dp54;
+    options.integrator_options = integrator_options;
+    options.solver_options = solver_options;
+    options
 }
 
 fn generated_samples(

--- a/crates/sidereon-core/tests/parity_least_squares.rs
+++ b/crates/sidereon-core/tests/parity_least_squares.rs
@@ -459,12 +459,11 @@ fn lsq_converged_solution_agreement() {
     let x0 = DVector::from_vec(hex_vec(&problem_j["x0"]));
     // Drive this solver to the first-order-optimal minimum so the comparison is
     // against a well-defined point, not its own path-dependent ftol stop.
-    let opts = SolveOptions {
-        gtol: 1e-14,
-        ftol: 1e-15,
-        xtol: 1e-15,
-        max_nfev: 1000,
-    };
+    let mut opts = SolveOptions::default();
+    opts.gtol = 1e-14;
+    opts.ftol = 1e-15;
+    opts.xtol = 1e-15;
+    opts.max_nfev = 1000;
 
     let lsq = LeastSquaresProblem::new(&residual, x0);
     let report = solve_trf(&lsq, &opts).expect("solver converged");

--- a/crates/sidereon-core/tests/pass_finder_arc.rs
+++ b/crates/sidereon-core/tests/pass_finder_arc.rs
@@ -54,41 +54,29 @@ fn find_passes_agrees_with_reference_and_keeps_what_coarse_drops() {
     let (start, end) = window();
 
     // Authoritative reference: the existing pass-prediction path at a fine step.
-    let reference = predict_passes(
-        &elements,
-        STATION,
-        start,
-        end,
-        PassPredictionOptions {
-            min_elevation_deg: 0.0,
-            step_seconds: 10,
-        },
-    )
+    let reference = predict_passes(&elements, STATION, start, end, {
+        let mut options = PassPredictionOptions::default();
+        options.min_elevation_deg = 0.0;
+        options.step_seconds = 10;
+        options
+    })
     .expect("valid pass-prediction step");
     // The dense-sample finder at mask 0 must reproduce the reference passes.
-    let mine = find_passes(
-        &elements,
-        STATION,
-        start,
-        end,
-        PassFinderOptions {
-            elevation_mask_deg: 0.0,
-            coarse_step_seconds: 10.0,
-            time_tolerance_seconds: 1.0e-3,
-        },
-    )
+    let mine = find_passes(&elements, STATION, start, end, {
+        let mut options = PassFinderOptions::default();
+        options.elevation_mask_deg = 0.0;
+        options.coarse_step_seconds = 10.0;
+        options.time_tolerance_seconds = 1.0e-3;
+        options
+    })
     .expect("valid pass-finder step");
     // A deliberately coarse step of the same reference method drops passes.
-    let coarse = predict_passes(
-        &elements,
-        STATION,
-        start,
-        end,
-        PassPredictionOptions {
-            min_elevation_deg: 0.0,
-            step_seconds: 900,
-        },
-    )
+    let coarse = predict_passes(&elements, STATION, start, end, {
+        let mut options = PassPredictionOptions::default();
+        options.min_elevation_deg = 0.0;
+        options.step_seconds = 900;
+        options
+    })
     .expect("valid pass-prediction step");
 
     assert!(

--- a/crates/sidereon-core/tests/ppp_decimeter_arc.rs
+++ b/crates/sidereon-core/tests/ppp_decimeter_arc.rs
@@ -290,17 +290,13 @@ fn gps_float_epochs(sp3: &Sp3, obs: &RinexObs, approx: [f64; 3]) -> Vec<FloatEpo
 }
 
 fn elevation_deg(sp3: &Sp3, sat: GnssSatelliteId, approx: [f64; 3], t_rx_j2000_s: f64) -> f64 {
-    predict(
-        sp3,
-        sat,
-        approx,
-        t_rx_j2000_s,
-        PredictOptions {
-            carrier_hz: F_L1_HZ,
-            light_time: true,
-            sagnac: true,
-        },
-    )
+    predict(sp3, sat, approx, t_rx_j2000_s, {
+        let mut options = PredictOptions::default();
+        options.carrier_hz = F_L1_HZ;
+        options.light_time = true;
+        options.sagnac = true;
+        options
+    })
     .map(|p| p.elevation_deg)
     .unwrap_or(f64::NEG_INFINITY)
 }
@@ -458,13 +454,13 @@ fn receiver_antenna_options(antex: &Antex) -> ReceiverAntennaOptions {
             }
         })
         .collect();
-    ReceiverAntennaOptions {
-        freq1_label: "G01".to_string(),
-        freq1_hz: F_L1_HZ,
-        freq2_label: "G02".to_string(),
-        freq2_hz: F_L2_HZ,
+    ReceiverAntennaOptions::new(
+        "G01".to_string(),
+        F_L1_HZ,
+        "G02".to_string(),
+        F_L2_HZ,
         frequencies,
-    }
+    )
 }
 
 /// Satellite antenna correction options from the ANTEX satellite blocks for the
@@ -502,13 +498,13 @@ fn satellite_antenna_options(antex: &Antex, prns: &[String]) -> SatelliteAntenna
                 }
             })
             .collect();
-    SatelliteAntennaOptions {
-        freq1_label: "G01".to_string(),
-        freq1_hz: F_L1_HZ,
-        freq2_label: "G02".to_string(),
-        freq2_hz: F_L2_HZ,
+    SatelliteAntennaOptions::new(
+        "G01".to_string(),
+        F_L1_HZ,
+        "G02".to_string(),
+        F_L2_HZ,
         antennas,
-    }
+    )
 }
 
 fn gps_id(token: &str) -> GnssSatelliteId {
@@ -602,19 +598,18 @@ fn full_corrections_with_code_bias(
     code_bias: Option<CodeBiasOptions>,
 ) -> RangeCorrections {
     let prns = observed_prns(epochs);
-    let options = PppCorrectionsOptions {
-        solid_earth_tide: true,
-        // Pole tide intentionally off: this arc validates the cm/dm-dominant
-        // stack; pole tide is a sub-cm refinement out of scope here.
-        pole_tide: None,
-        // Ocean tide loading ON with the real ZIM2 BLQ. ZIM2 is deep inland, so
-        // OTL is only a few mm here; the bar is no decimeter regression (a slight
-        // change vs OTL-off is expected and benign).
-        ocean_loading: Some(ZIM2_OCEAN_LOADING_BLQ),
-        phase_windup: true,
-        satellite_antenna: Some(satellite_antenna_options(antex, &prns)),
-        code_bias,
-    };
+    // Pole tide intentionally off: this arc validates the cm/dm-dominant
+    // stack; pole tide is a sub-cm refinement out of scope here.
+    // Ocean tide loading ON with the real ZIM2 BLQ. ZIM2 is deep inland, so
+    // OTL is only a few mm here; the bar is no decimeter regression (a slight
+    // change vs OTL-off is expected and benign).
+    let mut options = PppCorrectionsOptions::new();
+    options.solid_earth_tide = true;
+    options.pole_tide = None;
+    options.ocean_loading = Some(ZIM2_OCEAN_LOADING_BLQ);
+    options.phase_windup = true;
+    options.satellite_antenna = Some(satellite_antenna_options(antex, &prns));
+    options.code_bias = code_bias;
     let precomputed = ppp_corrections::build(
         sp3,
         &ppp_correction_epochs(epochs),
@@ -651,12 +646,11 @@ fn full_stack_config(corrections: RangeCorrections, met: Met) -> FloatSolveConfi
 fn code_bias_options(used: (&str, &str)) -> CodeBiasOptions {
     let mut used_observables_default = BTreeMap::new();
     used_observables_default.insert(GnssSystem::Gps, (used.0.to_string(), used.1.to_string()));
-    CodeBiasOptions {
-        bias_set: load_bias(),
-        used_observables_per_sat: BTreeMap::new(),
-        used_observables_default,
-        clock_reference: None,
-    }
+    let mut options = CodeBiasOptions::new(load_bias());
+    options.used_observables_per_sat = BTreeMap::new();
+    options.used_observables_default = used_observables_default;
+    options.clock_reference = None;
+    options
 }
 
 fn full_stack_config_mapping(
@@ -664,31 +658,30 @@ fn full_stack_config_mapping(
     met: Met,
     mapping: TropoMapping,
 ) -> FloatSolveConfig {
-    FloatSolveConfig {
-        weights: MeasurementWeights {
+    let mut tropo = TroposphereOptions::new(met);
+    tropo.enabled = true;
+    tropo.estimate_ztd = true;
+    tropo.estimate_tropo_gradients = false;
+    tropo.mapping = mapping;
+    let mut opts = FloatSolveOptions::default();
+    opts.max_iterations = 12;
+    opts.position_tolerance_m = 1.0e-4;
+    opts.clock_tolerance_m = 1.0e-4;
+    opts.ambiguity_tolerance_m = 1.0e-4;
+    opts.ztd_tolerance_m = 1.0e-4;
+    FloatSolveConfig::new(
+        MeasurementWeights {
             code: 1.0,
             phase: 100.0,
             elevation_weighting: true,
         },
-        tropo: TroposphereOptions {
-            enabled: true,
-            estimate_ztd: true,
-            estimate_tropo_gradients: false,
-            met,
-            mapping,
-        },
+        tropo,
         corrections,
-        opts: FloatSolveOptions {
-            max_iterations: 12,
-            position_tolerance_m: 1.0e-4,
-            clock_tolerance_m: 1.0e-4,
-            ambiguity_tolerance_m: 1.0e-4,
-            ztd_tolerance_m: 1.0e-4,
-        },
-        elevation_cutoff_deg: None,
-        residual_screen: false,
-        estimate_residual_ionosphere: false,
-    }
+        opts,
+        None,
+        false,
+        false,
+    )
 }
 
 /// ZIM2 VMF1 site-wise mapping `a` coefficients for 2026-05-13 (MJD 61173),

--- a/crates/sidereon-core/tests/ppp_prep.rs
+++ b/crates/sidereon-core/tests/ppp_prep.rs
@@ -136,18 +136,15 @@ fn dual_observation_with_code_noise(
 }
 
 fn wide_lane_options() -> WideLanePrepOptions {
-    WideLanePrepOptions {
-        min_epochs: 2,
-        tolerance_cycles: 0.01,
-    }
+    WideLanePrepOptions::new(2, 0.01)
 }
 
 fn slip_options() -> CycleSlipOptions {
-    CycleSlipOptions {
-        gf_threshold_m: 0.05,
-        mw_threshold_cycles: 4.0,
-        min_arc_gap_s: 1_000.0,
-    }
+    let mut options = CycleSlipOptions::default();
+    options.gf_threshold_m = 0.05;
+    options.mw_threshold_cycles = 4.0;
+    options.min_arc_gap_s = 1_000.0;
+    options
 }
 
 fn float_epochs_from_dual(epochs: Vec<DualFrequencyEpoch>) -> Vec<FloatCycleSlipEpoch> {

--- a/crates/sidereon-core/tests/ppp_real_arc.rs
+++ b/crates/sidereon-core/tests/ppp_real_arc.rs
@@ -256,25 +256,25 @@ fn float_config(
     tropo: TroposphereOptions,
     max_iterations: usize,
 ) -> FloatSolveConfig {
-    FloatSolveConfig {
-        weights: MeasurementWeights {
+    let mut opts = FloatSolveOptions::default();
+    opts.max_iterations = max_iterations;
+    opts.position_tolerance_m = 1.0e-4;
+    opts.clock_tolerance_m = 1.0e-4;
+    opts.ambiguity_tolerance_m = 1.0e-4;
+    opts.ztd_tolerance_m = 1.0e-4;
+    FloatSolveConfig::new(
+        MeasurementWeights {
             code: 1.0,
             phase: 100.0,
             elevation_weighting,
         },
         tropo,
-        corrections: RangeCorrections::disabled(),
-        opts: FloatSolveOptions {
-            max_iterations,
-            position_tolerance_m: 1.0e-4,
-            clock_tolerance_m: 1.0e-4,
-            ambiguity_tolerance_m: 1.0e-4,
-            ztd_tolerance_m: 1.0e-4,
-        },
-        elevation_cutoff_deg: None,
-        residual_screen: false,
-        estimate_residual_ionosphere: false,
-    }
+        RangeCorrections::disabled(),
+        opts,
+        None,
+        false,
+        false,
+    )
 }
 
 fn fixed_config(
@@ -284,40 +284,39 @@ fn fixed_config(
     wavelengths_m: BTreeMap<String, f64>,
     offsets_m: BTreeMap<String, f64>,
 ) -> FixedSolveConfig {
-    FixedSolveConfig {
-        weights: MeasurementWeights {
+    let mut opts = FloatSolveOptions::default();
+    opts.max_iterations = max_iterations;
+    opts.position_tolerance_m = 1.0e-4;
+    opts.clock_tolerance_m = 1.0e-4;
+    opts.ambiguity_tolerance_m = 1.0e-4;
+    opts.ztd_tolerance_m = 1.0e-4;
+    let mut ambiguity = FixedAmbiguityOptions::new(3.0);
+    ambiguity.wavelengths_m = wavelengths_m;
+    ambiguity.offsets_m = offsets_m;
+    FixedSolveConfig::new(
+        MeasurementWeights {
             code: 1.0,
             phase: 100.0,
             elevation_weighting,
         },
         tropo,
-        corrections: RangeCorrections::disabled(),
-        opts: FloatSolveOptions {
-            max_iterations,
-            position_tolerance_m: 1.0e-4,
-            clock_tolerance_m: 1.0e-4,
-            ambiguity_tolerance_m: 1.0e-4,
-            ztd_tolerance_m: 1.0e-4,
-        },
-        elevation_cutoff_deg: None,
-        ambiguity: FixedAmbiguityOptions {
-            wavelengths_m,
-            offsets_m,
-            ratio_threshold: 3.0,
-        },
-        estimate_residual_ionosphere: false,
-    }
+        RangeCorrections::disabled(),
+        opts,
+        None,
+        ambiguity,
+        false,
+    )
 }
 
 fn tropo(enabled: bool, estimate_ztd: bool) -> TroposphereOptions {
     if enabled {
-        TroposphereOptions {
-            enabled: true,
-            estimate_ztd,
-            estimate_tropo_gradients: false,
-            met: Met::new(1013.25, 288.15, 0.5).expect("valid PPP troposphere met"),
-            ..TroposphereOptions::disabled()
-        }
+        let mut options = TroposphereOptions::new(
+            Met::new(1013.25, 288.15, 0.5).expect("valid PPP troposphere met"),
+        );
+        options.enabled = true;
+        options.estimate_ztd = estimate_ztd;
+        options.estimate_tropo_gradients = false;
+        options
     } else {
         TroposphereOptions::disabled()
     }
@@ -368,18 +367,15 @@ fn position_error_m(position_m: [f64; 3], truth_m: [f64; 3]) -> f64 {
 }
 
 fn wide_lane_options(tolerance_cycles: f64) -> WideLanePrepOptions {
-    WideLanePrepOptions {
-        min_epochs: 2,
-        tolerance_cycles,
-    }
+    WideLanePrepOptions::new(2, tolerance_cycles)
 }
 
 fn cycle_slip_options() -> sidereon_core::carrier_phase::CycleSlipOptions {
-    sidereon_core::carrier_phase::CycleSlipOptions {
-        gf_threshold_m: 0.05,
-        mw_threshold_cycles: 4.0,
-        min_arc_gap_s: 300.0,
-    }
+    let mut options = sidereon_core::carrier_phase::CycleSlipOptions::default();
+    options.gf_threshold_m = 0.05;
+    options.mw_threshold_cycles = 4.0;
+    options.min_arc_gap_s = 300.0;
+    options
 }
 
 /// Bounded-tolerance band (m) for canonical PPP vs the PPP-oracle-faithful

--- a/crates/sidereon-core/tests/rtk_real_arc.rs
+++ b/crates/sidereon-core/tests/rtk_real_arc.rs
@@ -1409,11 +1409,9 @@ fn wettzell_rinex_arc_builders_match_real_arc_scaffolding() {
     let base_obs = load_obs(&["obs", "WTZR00DEU_R_20201770000_01D_30S_MO_120epoch.rnx"]);
     let rover_obs = load_obs(&["obs", "WTZZ00DEU_R_20201770000_01D_30S_MO_120epoch.rnx"]);
 
-    let single_options = RtkRinexArcOptions {
-        max_epochs: Some(120),
-        include_prediction_time: false,
-        ..RtkRinexArcOptions::gps_l1_c()
-    };
+    let mut single_options = RtkRinexArcOptions::gps_l1_c();
+    single_options.max_epochs = Some(120);
+    single_options.include_prediction_time = false;
     let single = build_rinex_rtk_arc(&sp3, &base_obs, &rover_obs, &single_options)
         .expect("single-frequency RINEX RTK arc");
     let raw_single = real_gps_l1_epochs(&sp3, &base_obs, &rover_obs, 120);
@@ -1426,11 +1424,9 @@ fn wettzell_rinex_arc_builders_match_real_arc_scaffolding() {
     assert!(single.offsets_m.values().all(|value| *value == 0.0));
     assert_eq!(single.skipped_epoch_count, 0);
 
-    let dual_options = RtkRinexDualArcOptions {
-        max_epochs: Some(120),
-        include_prediction_time: false,
-        ..RtkRinexDualArcOptions::gps_l1_l2_cw()
-    };
+    let mut dual_options = RtkRinexDualArcOptions::gps_l1_l2_cw();
+    dual_options.max_epochs = Some(120);
+    dual_options.include_prediction_time = false;
     let dual = build_dual_frequency_rinex_rtk_arc(&sp3, &base_obs, &rover_obs, &dual_options)
         .expect("dual-frequency RINEX RTK arc");
     let raw_dual = real_gps_l1_l2_epochs(&sp3, &base_obs, &rover_obs, 120);
@@ -1635,14 +1631,12 @@ fn wettzell_static_gps_rtk_real_arc_self_validates_batch_paths() {
         .expect("single GPS reference")
         .clone();
     assert_eq!(reference_sat, "G30");
+    let mut wide_lane_options = WideLaneOptions::new(2, 0.5);
+    wide_lane_options.skip_short_fragments = false;
     let wide_lane_cycles = estimate_wide_lane_ambiguities(
         &dual_epochs(&prepared_dual.epochs),
         &reference_sat,
-        WideLaneOptions {
-            min_epochs: 2,
-            tolerance_cycles: 0.5,
-            skip_short_fragments: false,
-        },
+        wide_lane_options,
     )
     .expect("wide-lane integer estimates");
     assert!(!wide_lane_cycles.is_empty());

--- a/crates/sidereon-core/tests/signal.rs
+++ b/crates/sidereon-core/tests/signal.rs
@@ -54,16 +54,7 @@ fn clean_signal(
     n: usize,
     fs: f64,
 ) -> Vec<IqSample> {
-    let code = replica(
-        prn,
-        ReplicaOptions {
-            sample_rate_hz: fs,
-            num_samples: n,
-            code_phase_chips,
-            code_doppler_hz: 0.0,
-        },
-    )
-    .expect("replica");
+    let code = replica(prn, ReplicaOptions::new(fs, n, code_phase_chips, 0.0)).expect("replica");
     let w = 2.0 * std::f64::consts::PI * doppler_hz / fs;
     code.into_iter()
         .enumerate()
@@ -198,12 +189,12 @@ fn replica_correlate_acquire_and_loss_match_application_oracle_bits() {
 
     let samples = replica(
         rep["prn"].as_i64().unwrap(),
-        ReplicaOptions {
-            sample_rate_hz: hexf(&rep["sample_rate_hz"]),
-            num_samples: rep["num_samples"].as_u64().unwrap() as usize,
-            code_phase_chips: hexf(&rep["code_phase_chips"]),
-            code_doppler_hz: 0.0,
-        },
+        ReplicaOptions::new(
+            hexf(&rep["sample_rate_hz"]),
+            rep["num_samples"].as_u64().unwrap() as usize,
+            hexf(&rep["code_phase_chips"]),
+            0.0,
+        ),
     )
     .expect("replica");
     let expected_samples: Vec<i8> = rep["samples"]
@@ -222,16 +213,14 @@ fn replica_correlate_acquire_and_loss_match_application_oracle_bits() {
         64,
         hexf(&case["sample_rate_hz"]),
     );
-    let got = sidereon_core::signal::correlate(
-        &iq,
-        case["prn"].as_i64().unwrap(),
-        CorrelateOptions {
-            sample_rate_hz: hexf(&case["sample_rate_hz"]),
-            doppler_hz: hexf(&case["doppler_hz"]),
-            code_phase_chips: hexf(&case["code_phase_chips"]),
-            code_doppler_hz: 0.0,
-        },
-    )
+    let got = sidereon_core::signal::correlate(&iq, case["prn"].as_i64().unwrap(), {
+        let mut options = CorrelateOptions::default();
+        options.sample_rate_hz = hexf(&case["sample_rate_hz"]);
+        options.doppler_hz = hexf(&case["doppler_hz"]);
+        options.code_phase_chips = hexf(&case["code_phase_chips"]);
+        options.code_doppler_hz = 0.0;
+        options
+    })
     .expect("correlate");
     assert_eq!(got.i.to_bits(), hexf(&case["i"]).to_bits(), "correlator I");
     assert_eq!(got.q.to_bits(), hexf(&case["q"]).to_bits(), "correlator Q");
@@ -250,14 +239,11 @@ fn replica_correlate_acquire_and_loss_match_application_oracle_bits() {
         n,
         hexf(&acq["sample_rate_hz"]),
     );
-    let got = acquire(
-        &full,
-        acq["prn"].as_i64().unwrap(),
-        AcquisitionOptions {
-            sample_rate_hz: hexf(&acq["sample_rate_hz"]),
-            ..AcquisitionOptions::default()
-        },
-    )
+    let got = acquire(&full, acq["prn"].as_i64().unwrap(), {
+        let mut options = AcquisitionOptions::default();
+        options.sample_rate_hz = hexf(&acq["sample_rate_hz"]);
+        options
+    })
     .expect("acquire");
     assert_eq!(
         got.code_phase_chips.to_bits(),
@@ -318,12 +304,7 @@ fn replica_correlate_acquire_and_loss_match_application_oracle_bits() {
 
 #[test]
 fn signal_replica_and_correlate_reject_non_finite_options() {
-    let finite_replica_options = ReplicaOptions {
-        sample_rate_hz: 2.046e6,
-        num_samples: 8,
-        code_phase_chips: 0.0,
-        code_doppler_hz: 0.0,
-    };
+    let finite_replica_options = ReplicaOptions::new(2.046e6, 8, 0.0, 0.0);
     let finite_replica = replica(1, finite_replica_options).expect("finite replica options");
     assert_eq!(finite_replica, vec![-1, -1, -1, -1, 1, 1, 1, 1]);
 
@@ -331,16 +312,14 @@ fn signal_replica_and_correlate_reject_non_finite_options() {
         .iter()
         .map(|&chip| IqSample::real(f64::from(chip)))
         .collect();
-    let finite_correlation = sidereon_core::signal::correlate(
-        &iq,
-        1,
-        CorrelateOptions {
-            sample_rate_hz: finite_replica_options.sample_rate_hz,
-            doppler_hz: 0.0,
-            code_phase_chips: finite_replica_options.code_phase_chips,
-            code_doppler_hz: finite_replica_options.code_doppler_hz,
-        },
-    )
+    let finite_correlation = sidereon_core::signal::correlate(&iq, 1, {
+        let mut options = CorrelateOptions::default();
+        options.sample_rate_hz = finite_replica_options.sample_rate_hz;
+        options.doppler_hz = 0.0;
+        options.code_phase_chips = finite_replica_options.code_phase_chips;
+        options.code_doppler_hz = finite_replica_options.code_doppler_hz;
+        options
+    })
     .expect("finite correlate options");
     assert_eq!(finite_correlation.i.to_bits(), 8.0_f64.to_bits());
     assert_eq!(finite_correlation.q.to_bits(), 0.0_f64.to_bits());
@@ -348,64 +327,51 @@ fn signal_replica_and_correlate_reject_non_finite_options() {
 
     for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
         assert_invalid_signal(
-            replica(
-                1,
-                ReplicaOptions {
-                    code_phase_chips: bad,
-                    ..finite_replica_options
-                },
-            )
+            replica(1, {
+                let mut options = finite_replica_options;
+                options.code_phase_chips = bad;
+                options
+            })
             .unwrap_err(),
             "code_phase_chips",
             "not finite",
         );
         assert_invalid_signal(
-            replica(
-                1,
-                ReplicaOptions {
-                    code_doppler_hz: bad,
-                    ..finite_replica_options
-                },
-            )
+            replica(1, {
+                let mut options = finite_replica_options;
+                options.code_doppler_hz = bad;
+                options
+            })
             .unwrap_err(),
             "code_doppler_hz",
             "not finite",
         );
         assert_invalid_signal(
-            sidereon_core::signal::correlate(
-                &[IqSample::real(1.0)],
-                1,
-                CorrelateOptions {
-                    code_phase_chips: bad,
-                    ..CorrelateOptions::default()
-                },
-            )
+            sidereon_core::signal::correlate(&[IqSample::real(1.0)], 1, {
+                let mut options = CorrelateOptions::default();
+                options.code_phase_chips = bad;
+                options
+            })
             .unwrap_err(),
             "code_phase_chips",
             "not finite",
         );
         assert_invalid_signal(
-            sidereon_core::signal::correlate(
-                &[IqSample::real(1.0)],
-                1,
-                CorrelateOptions {
-                    code_doppler_hz: bad,
-                    ..CorrelateOptions::default()
-                },
-            )
+            sidereon_core::signal::correlate(&[IqSample::real(1.0)], 1, {
+                let mut options = CorrelateOptions::default();
+                options.code_doppler_hz = bad;
+                options
+            })
             .unwrap_err(),
             "code_doppler_hz",
             "not finite",
         );
         assert_invalid_signal(
-            sidereon_core::signal::correlate(
-                &[IqSample::real(1.0)],
-                1,
-                CorrelateOptions {
-                    doppler_hz: bad,
-                    ..CorrelateOptions::default()
-                },
-            )
+            sidereon_core::signal::correlate(&[IqSample::real(1.0)], 1, {
+                let mut options = CorrelateOptions::default();
+                options.doppler_hz = bad;
+                options
+            })
             .unwrap_err(),
             "doppler_hz",
             "not finite",
@@ -439,14 +405,11 @@ fn signal_correlation_rejects_non_finite_samples_and_empty_explicit_code() {
             "not finite",
         );
         assert_invalid_signal(
-            acquire(
-                &[bad_sample],
-                1,
-                AcquisitionOptions {
-                    sample_rate_hz: 2.046e6,
-                    ..AcquisitionOptions::default()
-                },
-            )
+            acquire(&[bad_sample], 1, {
+                let mut options = AcquisitionOptions::default();
+                options.sample_rate_hz = 2.046e6;
+                options
+            })
             .unwrap_err(),
             "samples",
             "not finite",
@@ -526,115 +489,82 @@ fn acquisition_error_modes_are_explicit() {
     );
     let short = vec![IqSample::real(1.0); 100];
     assert_eq!(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                sample_rate_hz: 2.046e6,
-                ..AcquisitionOptions::default()
-            }
-        ),
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.sample_rate_hz = 2.046e6;
+            options
+        }),
         Err(SignalError::TooShort)
     );
 
     assert_invalid_signal_field(
-        replica(
-            5,
-            ReplicaOptions {
-                sample_rate_hz: 0.0,
-                num_samples: 1,
-                code_phase_chips: 0.0,
-                code_doppler_hz: 0.0,
-            },
-        )
+        replica(5, ReplicaOptions::new(0.0, 1, 0.0, 0.0)).unwrap_err(),
+        "sample_rate_hz",
+    );
+    assert_invalid_signal_field(
+        sidereon_core::signal::correlate(&[IqSample::real(1.0)], 5, {
+            let mut options = CorrelateOptions::default();
+            options.sample_rate_hz = 0.0;
+            options
+        })
         .unwrap_err(),
         "sample_rate_hz",
     );
     assert_invalid_signal_field(
-        sidereon_core::signal::correlate(
-            &[IqSample::real(1.0)],
-            5,
-            CorrelateOptions {
-                sample_rate_hz: 0.0,
-                ..CorrelateOptions::default()
-            },
-        )
-        .unwrap_err(),
-        "sample_rate_hz",
-    );
-    assert_invalid_signal_field(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                sample_rate_hz: 0.0,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.sample_rate_hz = 0.0;
+            options
+        })
         .unwrap_err(),
         "sample_rate_hz",
     );
     assert_invalid_signal(
-        acquire(
-            &[IqSample::real(1.0)],
-            5,
-            AcquisitionOptions {
-                sample_rate_hz: 1.0,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&[IqSample::real(1.0)], 5, {
+            let mut options = AcquisitionOptions::default();
+            options.sample_rate_hz = 1.0;
+            options
+        })
         .unwrap_err(),
         "sample_rate_hz",
         "out of range",
     );
     assert_invalid_signal_field(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                doppler_step_hz: 0.0,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.doppler_step_hz = 0.0;
+            options
+        })
         .unwrap_err(),
         "doppler_step_hz",
     );
     assert_invalid_signal(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                doppler_min_hz: 500.0,
-                doppler_max_hz: -500.0,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.doppler_min_hz = 500.0;
+            options.doppler_max_hz = -500.0;
+            options
+        })
         .unwrap_err(),
         "doppler_max_hz",
         "out of range",
     );
     assert_invalid_signal(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                doppler_min_hz: f64::NAN,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.doppler_min_hz = f64::NAN;
+            options
+        })
         .unwrap_err(),
         "doppler_min_hz",
         "not finite",
     );
     assert_invalid_signal(
-        acquire(
-            &short,
-            5,
-            AcquisitionOptions {
-                doppler_max_hz: f64::INFINITY,
-                ..AcquisitionOptions::default()
-            },
-        )
+        acquire(&short, 5, {
+            let mut options = AcquisitionOptions::default();
+            options.doppler_max_hz = f64::INFINITY;
+            options
+        })
         .unwrap_err(),
         "doppler_max_hz",
         "not finite",
@@ -645,16 +575,14 @@ fn acquisition_error_modes_are_explicit() {
 fn acquisition_accepts_valid_doppler_grid_options() {
     let fs = CA_CHIP_RATE_HZ;
     let samples = clean_signal(5, 0.0, 0.0, CA_CODE_LENGTH, fs);
-    let got = acquire(
-        &samples,
-        5,
-        AcquisitionOptions {
-            sample_rate_hz: fs,
-            doppler_min_hz: 0.0,
-            doppler_max_hz: 0.0,
-            doppler_step_hz: 500.0,
-        },
-    )
+    let got = acquire(&samples, 5, {
+        let mut options = AcquisitionOptions::default();
+        options.sample_rate_hz = fs;
+        options.doppler_min_hz = 0.0;
+        options.doppler_max_hz = 0.0;
+        options.doppler_step_hz = 500.0;
+        options
+    })
     .expect("valid acquisition grid");
 
     assert_eq!(got.grid.doppler_hz, vec![0.0]);
@@ -667,16 +595,14 @@ fn acquisition_accepts_valid_doppler_grid_options() {
 fn acquisition_rejects_oversized_doppler_grid() {
     let fs = CA_CHIP_RATE_HZ;
     let samples = vec![IqSample::real(1.0); CA_CODE_LENGTH];
-    let err = acquire(
-        &samples,
-        5,
-        AcquisitionOptions {
-            sample_rate_hz: fs,
-            doppler_min_hz: -5.0e9,
-            doppler_max_hz: 5.0e9,
-            doppler_step_hz: 1.0,
-        },
-    )
+    let err = acquire(&samples, 5, {
+        let mut options = AcquisitionOptions::default();
+        options.sample_rate_hz = fs;
+        options.doppler_min_hz = -5.0e9;
+        options.doppler_max_hz = 5.0e9;
+        options.doppler_step_hz = 1.0;
+        options
+    })
     .expect_err("oversized Doppler grid must be rejected");
 
     assert_invalid_signal(err, "doppler_grid", "out of range");

--- a/crates/sidereon-core/tests/solver_engine_comparison.rs
+++ b/crates/sidereon-core/tests/solver_engine_comparison.rs
@@ -88,10 +88,8 @@ fn ulp_distance(left: f64, right: f64) -> u64 {
 
 #[test]
 fn compare_engines_on_shared_consumer_fixture_adapter() {
-    let core_options = SolveOptions {
-        max_nfev: 300,
-        ..SolveOptions::default()
-    };
+    let mut core_options = SolveOptions::default();
+    core_options.max_nfev = 300;
     let trls_options = TrfOptions {
         max_nfev: Some(300),
         ..TrfOptions::default()

--- a/crates/sidereon-core/tests/sp3_continuity.rs
+++ b/crates/sidereon-core/tests/sp3_continuity.rs
@@ -177,10 +177,8 @@ fn a_metre_scale_splice_is_caught_while_the_speed_gate_stays_silent() {
         sample.position_ecef_m[2] += splice_m;
     }
 
-    let options = ContinuityOptions {
-        speed_bound: Some(SpeedBound::OrbitClass(OrbitClass::MeoGnss)),
-        residual_tolerance_m: Some(1.0),
-    };
+    let options =
+        ContinuityOptions::new(Some(SpeedBound::OrbitClass(OrbitClass::MeoGnss)), Some(1.0));
     let report = check_continuity(&samples, &options);
 
     assert_eq!(
@@ -359,10 +357,7 @@ fn each_satellite_is_checked_independently() {
 fn an_explicit_bound_overrides_the_class_bound() {
     let samples = arc(1, 800_000_000.0, 10);
 
-    let strict = ContinuityOptions {
-        speed_bound: Some(SpeedBound::ExplicitMaxSpeed(100.0)),
-        residual_tolerance_m: None,
-    };
+    let strict = ContinuityOptions::new(Some(SpeedBound::ExplicitMaxSpeed(100.0)), None);
     let report = check_continuity(&samples, &strict);
 
     assert_eq!(

--- a/crates/sidereon-core/tests/sp3_merge_per_epoch_provenance.rs
+++ b/crates/sidereon-core/tests/sp3_merge_per_epoch_provenance.rs
@@ -185,10 +185,7 @@ fn outlier_rejection_is_recorded_as_its_own_reason() {
     options.precedence_scope = MergePrecedenceScope::Cell;
     options.min_agree = 2;
     options.position_tolerance_m = 1.0;
-    options.outlier_reject = Some(OutlierRejectOptions {
-        position_tolerance_m: 1.0,
-        clock_tolerance_s: 1.0e-6,
-    });
+    options.outlier_reject = Some(OutlierRejectOptions::new(1.0, 1.0e-6));
     options.provenance = Some(ProvenanceMode::Full);
 
     let (_merged, report) = merge(&[wild, steady_a, steady_b], &options).expect("merge");

--- a/crates/sidereon-core/tests/sp3_merge_provenance.rs
+++ b/crates/sidereon-core/tests/sp3_merge_provenance.rs
@@ -57,19 +57,16 @@ fn complete_policy(combine: MergeCombine) -> MergeOptions {
     options.clock_min_common = 3;
     options.combine = combine;
     options.precedence_scope = MergePrecedenceScope::SatelliteArc;
-    options.outlier_reject = Some(OutlierRejectOptions {
-        position_tolerance_m: 1.25,
-        clock_tolerance_s: 7.5e-9,
-    });
+    options.outlier_reject = Some(OutlierRejectOptions::new(1.25, 7.5e-9));
     options.target_epoch_interval_s = Some(900.0);
     options.systems = Some(BTreeSet::from([GnssSystem::Gps, GnssSystem::Galileo]));
-    options.frame_reconciliation = Sp3FrameReconciliationOptions {
-        asserted_equivalent_label_sets: vec![
-            Sp3FrameLabelSet::new(["IGS20", "ITRF2020"]),
-            Sp3FrameLabelSet::new(["IGS14", "ITRF2014"]),
-        ],
-        helmert: true,
-    };
+    let mut frame_reconciliation = Sp3FrameReconciliationOptions::default();
+    frame_reconciliation.asserted_equivalent_label_sets = vec![
+        Sp3FrameLabelSet::new(["IGS20", "ITRF2020"]),
+        Sp3FrameLabelSet::new(["IGS14", "ITRF2014"]),
+    ];
+    frame_reconciliation.helmert = true;
+    options.frame_reconciliation = frame_reconciliation;
     options.provenance = None;
     options.verify_continuity = None;
     options
@@ -301,23 +298,23 @@ fn policy_set_order_does_not_change_the_stable_identity() {
     let contributor = artifact(AnalysisCenter::Esa, 0x11);
     let mut first = MergeOptions::default();
     first.systems = Some(BTreeSet::from([GnssSystem::Galileo, GnssSystem::Gps]));
-    first.frame_reconciliation = Sp3FrameReconciliationOptions {
-        asserted_equivalent_label_sets: vec![
-            Sp3FrameLabelSet::new(["IGS20", "ITRF2020"]),
-            Sp3FrameLabelSet::new(["IGS14", "ITRF2014"]),
-        ],
-        helmert: false,
-    };
+    let mut first_frame = Sp3FrameReconciliationOptions::default();
+    first_frame.asserted_equivalent_label_sets = vec![
+        Sp3FrameLabelSet::new(["IGS20", "ITRF2020"]),
+        Sp3FrameLabelSet::new(["IGS14", "ITRF2014"]),
+    ];
+    first_frame.helmert = false;
+    first.frame_reconciliation = first_frame;
 
     let mut second = MergeOptions::default();
     second.systems = Some(BTreeSet::from([GnssSystem::Gps, GnssSystem::Galileo]));
-    second.frame_reconciliation = Sp3FrameReconciliationOptions {
-        asserted_equivalent_label_sets: vec![
-            Sp3FrameLabelSet::new(["ITRF2014", "IGS14"]),
-            Sp3FrameLabelSet::new(["ITRF2020", "IGS20"]),
-        ],
-        helmert: false,
-    };
+    let mut second_frame = Sp3FrameReconciliationOptions::default();
+    second_frame.asserted_equivalent_label_sets = vec![
+        Sp3FrameLabelSet::new(["ITRF2014", "IGS14"]),
+        Sp3FrameLabelSet::new(["ITRF2020", "IGS20"]),
+    ];
+    second_frame.helmert = false;
+    second.frame_reconciliation = second_frame;
 
     let first = Sp3MergeInputIdentity::new(std::slice::from_ref(&contributor), &first).unwrap();
     let second = Sp3MergeInputIdentity::new(&[contributor], &second).unwrap();
@@ -353,10 +350,10 @@ fn non_executable_merge_policies_fail_closed() {
     ));
 
     let mut incomplete_frame_set = MergeOptions::default();
-    incomplete_frame_set.frame_reconciliation = Sp3FrameReconciliationOptions {
-        asserted_equivalent_label_sets: vec![Sp3FrameLabelSet::new(["IGS20"])],
-        helmert: false,
-    };
+    let mut incomplete_frame = Sp3FrameReconciliationOptions::default();
+    incomplete_frame.asserted_equivalent_label_sets = vec![Sp3FrameLabelSet::new(["IGS20"])];
+    incomplete_frame.helmert = false;
+    incomplete_frame_set.frame_reconciliation = incomplete_frame;
     assert!(matches!(
         Sp3MergeInputIdentity::new(
             &[artifact(AnalysisCenter::Esa, 0x33)],
@@ -374,17 +371,11 @@ fn negative_zero_tolerances_have_the_same_identity_as_positive_zero() {
     let mut positive = MergeOptions::default();
     positive.position_tolerance_m = 0.0;
     positive.clock_tolerance_s = 0.0;
-    positive.outlier_reject = Some(OutlierRejectOptions {
-        position_tolerance_m: 0.0,
-        clock_tolerance_s: 0.0,
-    });
+    positive.outlier_reject = Some(OutlierRejectOptions::new(0.0, 0.0));
     let mut negative = MergeOptions::default();
     negative.position_tolerance_m = -0.0;
     negative.clock_tolerance_s = -0.0;
-    negative.outlier_reject = Some(OutlierRejectOptions {
-        position_tolerance_m: -0.0,
-        clock_tolerance_s: -0.0,
-    });
+    negative.outlier_reject = Some(OutlierRejectOptions::new(-0.0, -0.0));
 
     let positive =
         Sp3MergeInputIdentity::new(std::slice::from_ref(&contributor), &positive).unwrap();

--- a/crates/sidereon-core/tests/sp3_real_orbit_fit.rs
+++ b/crates/sidereon-core/tests/sp3_real_orbit_fit.rs
@@ -61,24 +61,22 @@ fn gps(prn: u8) -> GnssSatelliteId {
 }
 
 fn fit_options(force_model: ForceModelKind) -> OrbitFitOptions {
-    OrbitFitOptions {
-        force_model,
-        integrator: IntegratorKind::Dp54,
-        integrator_options: IntegratorOptions {
-            abs_tol: 1.0e-11,
-            rel_tol: 1.0e-13,
-            initial_step: 30.0,
-            max_step: 180.0,
-            ..IntegratorOptions::default()
-        },
-        solver_options: SolveOptions {
-            gtol: 1.0e-13,
-            ftol: 1.0e-13,
-            xtol: 1.0e-13,
-            max_nfev: 900,
-        },
-        ..OrbitFitOptions::default()
-    }
+    let mut integrator_options = IntegratorOptions::default();
+    integrator_options.abs_tol = 1.0e-11;
+    integrator_options.rel_tol = 1.0e-13;
+    integrator_options.initial_step = 30.0;
+    integrator_options.max_step = 180.0;
+    let mut solver_options = SolveOptions::default();
+    solver_options.gtol = 1.0e-13;
+    solver_options.ftol = 1.0e-13;
+    solver_options.xtol = 1.0e-13;
+    solver_options.max_nfev = 900;
+    let mut options = OrbitFitOptions::default();
+    options.force_model = force_model;
+    options.integrator = IntegratorKind::Dp54;
+    options.integrator_options = integrator_options;
+    options.solver_options = solver_options;
+    options
 }
 
 fn fit_options_with_provider(

--- a/crates/sidereon-core/tests/space_weather_oracle.rs
+++ b/crates/sidereon-core/tests/space_weather_oracle.rs
@@ -72,16 +72,16 @@ fn decay_config(space_weather: SpaceWeather) -> DecayConfig {
         DragForce::DEFAULT_REENTRY_ALTITUDE_KM,
     )
     .expect("valid drag");
+    let mut integrator_options = IntegratorOptions::default();
+    integrator_options.abs_tol = 1.0e-8;
+    integrator_options.rel_tol = 1.0e-10;
+    integrator_options.initial_step = 5.0;
+    integrator_options.min_step = 1.0e-6;
+    integrator_options.max_step = 30.0;
+    integrator_options.max_steps = 200_000;
+    integrator_options.dense_output = false;
     DecayConfig::new(drag)
-        .with_options(IntegratorOptions {
-            abs_tol: 1.0e-8,
-            rel_tol: 1.0e-10,
-            initial_step: 5.0,
-            min_step: 1.0e-6,
-            max_step: 30.0,
-            max_steps: 200_000,
-            dense_output: false,
-        })
+        .with_options(integrator_options)
         .with_scan_step_s(60.0)
         .with_crossing_tolerance_s(2.0)
         .with_max_duration_s(50_000.0)

--- a/crates/sidereon-core/tests/ssr_ppp_join.rs
+++ b/crates/sidereon-core/tests/ssr_ppp_join.rs
@@ -207,25 +207,25 @@ fn initial_ambiguities(epochs: &[FloatEpoch]) -> BTreeMap<String, f64> {
 }
 
 fn float_config() -> FloatSolveConfig {
-    FloatSolveConfig {
-        weights: MeasurementWeights {
+    let mut opts = FloatSolveOptions::default();
+    opts.max_iterations = 8;
+    opts.position_tolerance_m = 1.0e-4;
+    opts.clock_tolerance_m = 1.0e-4;
+    opts.ambiguity_tolerance_m = 1.0e-4;
+    opts.ztd_tolerance_m = 1.0e-4;
+    FloatSolveConfig::new(
+        MeasurementWeights {
             code: 1.0,
             phase: 100.0,
             elevation_weighting: false,
         },
-        tropo: TroposphereOptions::disabled(),
-        corrections: RangeCorrections::disabled(),
-        opts: FloatSolveOptions {
-            max_iterations: 8,
-            position_tolerance_m: 1.0e-4,
-            clock_tolerance_m: 1.0e-4,
-            ambiguity_tolerance_m: 1.0e-4,
-            ztd_tolerance_m: 1.0e-4,
-        },
-        elevation_cutoff_deg: None,
-        residual_screen: false,
-        estimate_residual_ionosphere: false,
-    }
+        TroposphereOptions::disabled(),
+        RangeCorrections::disabled(),
+        opts,
+        None,
+        false,
+        false,
+    )
 }
 
 fn position_error_m(a: [f64; 3], b: [f64; 3]) -> f64 {
@@ -254,17 +254,13 @@ fn synthetic_ssr_store(
         if !used.insert(obs.sat) {
             continue;
         }
-        let prediction = predict(
-            sp3,
-            obs.sat,
-            receiver_m,
-            epoch.t_rx_j2000_s,
-            PredictOptions {
-                carrier_hz: F_L1_HZ,
-                light_time: true,
-                sagnac: true,
-            },
-        )
+        let prediction = predict(sp3, obs.sat, receiver_m, epoch.t_rx_j2000_s, {
+            let mut options = PredictOptions::default();
+            options.carrier_hz = F_L1_HZ;
+            options.light_time = true;
+            options.sagnac = true;
+            options
+        })
         .expect("SP3 prediction");
         let t_tx = prediction.transmit_time_j2000_s;
         let record = broadcast

--- a/crates/sidereon-core/tests/static_reference_station.rs
+++ b/crates/sidereon-core/tests/static_reference_station.rs
@@ -93,64 +93,61 @@ fn carrier_options(
     reference_position_m: [f64; 3],
     max_epochs: usize,
 ) -> StaticReferenceCarrierRinexOptions {
-    StaticReferenceCarrierRinexOptions {
-        arc_options: RtkRinexArcOptions {
-            max_epochs: Some(max_epochs),
-            include_prediction_time: false,
-            ..RtkRinexArcOptions::gps_l1_c()
+    let mut arc_options = RtkRinexArcOptions::gps_l1_c();
+    arc_options.max_epochs = Some(max_epochs);
+    arc_options.include_prediction_time = false;
+    let update_opts = UpdateOpts {
+        hold_sigma_m: 1.0e-4,
+        position_tol_m: 1.0e-4,
+        ambiguity_tol_m: 1.0e-4,
+        max_iterations: 10,
+        process_noise_baseline_sigma_m: 0.0,
+        dynamics_model: DynamicsModel::ConstantPosition,
+        float_only_systems: Vec::new(),
+        report_residuals: true,
+        receiver_antenna_corrections: None,
+        ar_arming_sigma_m: None,
+        search: SearchOpts {
+            ratio_threshold: 3.0,
         },
-        static_config: RtkStaticArcConfig {
-            arc: RtkArcConfig {
-                base_m: reference_position_m,
-                reference: BaselineReferenceSelection::Auto,
-                model: simple_model(),
-                baseline_prior_sigma_m: 30.0,
-                ambiguity_prior_sigma_m: 30.0,
-                initial_baseline_m: [0.0, 0.0, 0.0],
-                wavelengths_m: BTreeMap::new(),
-                offsets_m: BTreeMap::new(),
-                update_opts: UpdateOpts {
-                    hold_sigma_m: 1.0e-4,
-                    position_tol_m: 1.0e-4,
-                    ambiguity_tol_m: 1.0e-4,
-                    max_iterations: 10,
-                    process_noise_baseline_sigma_m: 0.0,
-                    dynamics_model: DynamicsModel::ConstantPosition,
-                    float_only_systems: Vec::new(),
-                    report_residuals: true,
-                    receiver_antenna_corrections: None,
-                    ar_arming_sigma_m: None,
-                    search: SearchOpts {
-                        ratio_threshold: 3.0,
-                    },
-                },
-                preprocessing: RtkArcPreprocessing {
-                    cycle_slip: Some(CycleSlipPolicy::SplitArc),
-                    hatch_window_cap: None,
-                    elevation_mask_deg: None,
-                },
-            },
-            opts: ValidatedFixedSolveOpts {
-                float: FloatSolveOpts {
-                    position_tol_m: 1.0e-4,
-                    ambiguity_tol_m: 1.0e-4,
-                    max_iterations: 10,
-                },
-                fixed: FixedSolveOpts {
-                    position_tol_m: 1.0e-4,
-                    ambiguity_tol_m: 1.0e-4,
-                    max_iterations: 10,
-                    ratio_threshold: 3.0,
-                    partial_ambiguity_resolution: true,
-                    partial_min_ambiguities: 4,
-                },
-                residual: ResidualValidationOpts {
-                    threshold_sigma: None,
-                    max_exclusions: 0,
-                },
-            },
+    };
+    let preprocessing = RtkArcPreprocessing {
+        cycle_slip: Some(CycleSlipPolicy::SplitArc),
+        hatch_window_cap: None,
+        elevation_mask_deg: None,
+    };
+    let arc = RtkArcConfig::new(
+        reference_position_m,
+        BaselineReferenceSelection::Auto,
+        simple_model(),
+        30.0,
+        30.0,
+        [0.0, 0.0, 0.0],
+        BTreeMap::new(),
+        BTreeMap::new(),
+        update_opts,
+        preprocessing,
+    );
+    let opts = ValidatedFixedSolveOpts {
+        float: FloatSolveOpts {
+            position_tol_m: 1.0e-4,
+            ambiguity_tol_m: 1.0e-4,
+            max_iterations: 10,
         },
-    }
+        fixed: FixedSolveOpts {
+            position_tol_m: 1.0e-4,
+            ambiguity_tol_m: 1.0e-4,
+            max_iterations: 10,
+            ratio_threshold: 3.0,
+            partial_ambiguity_resolution: true,
+            partial_min_ambiguities: 4,
+        },
+        residual: ResidualValidationOpts {
+            threshold_sigma: None,
+            max_exclusions: 0,
+        },
+    };
+    StaticReferenceCarrierRinexOptions::new(arc_options, RtkStaticArcConfig::new(arc, opts))
 }
 
 fn assert_covariance_psd(covariance: [[f64; 3]; 3]) {

--- a/crates/sidereon-core/tests/station_displacement.rs
+++ b/crates/sidereon-core/tests/station_displacement.rs
@@ -149,11 +149,10 @@ fn station_displacement_entry_sums_components_and_batch_matches_scalar() {
         .as_array();
     let epoch = StationDisplacementEpoch::from_utc(2026, 5, 13, 12, 30, 0.0)
         .with_polar_motion_arcsec(ZIM2_XP_ARCSEC, ZIM2_YP_ARCSEC);
-    let options = StationDisplacementOptions {
-        solid_earth_tide: true,
-        pole_tide: true,
-        ocean_loading: Some(&block.coefficients),
-    };
+    let mut options = StationDisplacementOptions::default();
+    options.solid_earth_tide = true;
+    options.pole_tide = true;
+    options.ocean_loading = Some(&block.coefficients);
 
     let got =
         station_displacement_ecef_m(StationDisplacementPosition::from(geodetic), epoch, options)
@@ -193,11 +192,10 @@ fn station_displacement_entry_sums_components_and_batch_matches_scalar() {
 #[test]
 fn station_displacement_requires_polar_motion_when_pole_tide_enabled() {
     let geodetic = zim2_geodetic();
-    let options = StationDisplacementOptions {
-        solid_earth_tide: false,
-        pole_tide: true,
-        ocean_loading: None,
-    };
+    let mut options = StationDisplacementOptions::default();
+    options.solid_earth_tide = false;
+    options.pole_tide = true;
+    options.ocean_loading = None;
     let err = station_displacement_ecef_m(
         StationDisplacementPosition::from(geodetic),
         StationDisplacementEpoch::from_utc(2026, 5, 13, 12, 0, 0.0),
@@ -216,11 +214,10 @@ fn station_displacement_requires_polar_motion_when_pole_tide_enabled() {
 fn station_displacement_validates_epoch_without_solid_tide() {
     let block = parse_ocean_loading_blq_block(ZIM2_BLQ_BLOCK).expect("parse BLQ");
     let geodetic = zim2_geodetic();
-    let options = StationDisplacementOptions {
-        solid_earth_tide: false,
-        pole_tide: false,
-        ocean_loading: Some(&block.coefficients),
-    };
+    let mut options = StationDisplacementOptions::default();
+    options.solid_earth_tide = false;
+    options.pole_tide = false;
+    options.ocean_loading = Some(&block.coefficients);
 
     let err = station_displacement_ecef_m(
         StationDisplacementPosition::from(geodetic),
@@ -259,16 +256,15 @@ fn station_displacement_magnitude_bounds_hold_on_daily_grid() {
     let geodetic = zim2_geodetic();
     for hour in (0..24).step_by(3) {
         let epoch = StationDisplacementEpoch::from_utc(2026, 5, 13, hour, 0, 0.0);
-        let displacement = station_displacement_ecef_m(
-            StationDisplacementPosition::from(geodetic),
-            epoch,
-            StationDisplacementOptions {
-                solid_earth_tide: true,
-                pole_tide: false,
-                ocean_loading: None,
-            },
-        )
-        .expect("solid tide displacement");
+        let displacement =
+            station_displacement_ecef_m(StationDisplacementPosition::from(geodetic), epoch, {
+                let mut options = StationDisplacementOptions::default();
+                options.solid_earth_tide = true;
+                options.pole_tide = false;
+                options.ocean_loading = None;
+                options
+            })
+            .expect("solid tide displacement");
         assert!(
             norm(displacement.ecef_m) < 0.5,
             "solid Earth tide magnitude is outside the expected decimetre band"

--- a/crates/sidereon-core/tests/terrain_store.rs
+++ b/crates/sidereon-core/tests/terrain_store.rs
@@ -223,7 +223,8 @@ fn dyadic_fixture_lookups_are_bit_identical_to_naive_scaling() {
         DtedInterpolation::Bilinear,
         DtedInterpolation::NearestPosting,
     ] {
-        let options = DtedLookupOptions { interpolation };
+        let mut options = DtedLookupOptions::default();
+        options.interpolation = interpolation;
         for (lon_numerator, lat_numerator) in offsets {
             let longitude_deg = -107.0 + f64::from(lon_numerator) / 256.0;
             let latitude_deg = 36.0 + f64::from(lat_numerator) / 256.0;
@@ -265,7 +266,8 @@ fn mmap_store_matches_dted_reader_over_multi_tile_fixture() {
         DtedInterpolation::Bilinear,
         DtedInterpolation::NearestPosting,
     ] {
-        let options = DtedLookupOptions { interpolation };
+        let mut options = DtedLookupOptions::default();
+        options.interpolation = interpolation;
         let got = mmap.height_batch(&points, options);
         let want = dted.height_batch(&points, options);
         assert_height_results_match(&got, &want, &format!("{interpolation:?} batch"));
@@ -314,7 +316,8 @@ fn mmap_store_matches_committed_multi_tile_fixture_bits() {
         DtedInterpolation::Bilinear,
         DtedInterpolation::NearestPosting,
     ] {
-        let options = DtedLookupOptions { interpolation };
+        let mut options = DtedLookupOptions::default();
+        options.interpolation = interpolation;
         let got = mmap.height_batch(&points, options);
         assert_eq!(got.len(), cases.len(), "{interpolation:?} batch length");
 
@@ -369,9 +372,8 @@ fn mmap_store_nearest_posting_matches_real_skadi_source_posts() {
 
     let bytes = dted_tree_to_mmap_store(&root).expect("convert DTED tree");
     let mut mmap = MmapTerrain::from_bytes(&bytes).expect("parse terrain store");
-    let options = DtedLookupOptions {
-        interpolation: DtedInterpolation::NearestPosting,
-    };
+    let mut options = DtedLookupOptions::default();
+    options.interpolation = DtedInterpolation::NearestPosting;
 
     for (lon_index, lat_index) in [(0usize, 0usize), (0, 4), (3, 0), (3, 4), (2, 3), (4, 4)] {
         let longitude_deg = -107.0 + lon_index as f64 / 4.0;
@@ -402,9 +404,8 @@ fn mmap_store_returns_typed_zero_for_hgt_void_posting() {
     let bytes = dted_tree_to_mmap_store(&root).expect("convert DTED tree");
     let mut mmap = MmapTerrain::from_bytes(&bytes).expect("parse terrain store");
     let mut dted = DtedTerrain::new(&root);
-    let options = DtedLookupOptions {
-        interpolation: DtedInterpolation::NearestPosting,
-    };
+    let mut options = DtedLookupOptions::default();
+    options.interpolation = DtedInterpolation::NearestPosting;
     let latitude_deg = 36.0 + 1234.0 / 3600.0;
     let longitude_deg = -107.0 + 2345.0 / 3600.0;
 

--- a/crates/sidereon-scoreboard/tests/scoreboard.rs
+++ b/crates/sidereon-scoreboard/tests/scoreboard.rs
@@ -605,19 +605,18 @@ fn synthetic_state_arc_runs_full_path_to_near_zero_rms() {
     let mut options = ScoreOptions::default();
     options.fit_options.force_model = ForceModelKind::two_body();
     options.fit_options.integrator = IntegratorKind::Dp54;
-    options.fit_options.integrator_options = IntegratorOptions {
-        abs_tol: 1.0e-12,
-        rel_tol: 1.0e-13,
-        initial_step: 10.0,
-        max_step: 60.0,
-        ..IntegratorOptions::default()
-    };
-    options.fit_options.solver_options = SolveOptions {
-        gtol: 1.0e-15,
-        ftol: 1.0e-15,
-        xtol: 1.0e-15,
-        max_nfev: 1200,
-    };
+    let mut integrator_options = IntegratorOptions::default();
+    integrator_options.abs_tol = 1.0e-12;
+    integrator_options.rel_tol = 1.0e-13;
+    integrator_options.initial_step = 10.0;
+    integrator_options.max_step = 60.0;
+    options.fit_options.integrator_options = integrator_options;
+    let mut solver_options = SolveOptions::default();
+    solver_options.gtol = 1.0e-15;
+    solver_options.ftol = 1.0e-15;
+    solver_options.xtol = 1.0e-15;
+    solver_options.max_nfev = 1200;
+    options.fit_options.solver_options = solver_options;
 
     let report = score_sp3_bytes(sp3.as_bytes(), "synthetic.sp3", date(2026, 6, 1), &options)
         .expect("synthetic arc scores");
@@ -878,17 +877,16 @@ fn duration_token_seconds(token: &str) -> i64 {
 
 fn synthetic_sp3(initial: CartesianState, epochs_j2000_s: &[i64]) -> String {
     let sat = GnssSatelliteId::new(GnssSystem::Gps, 1).expect("valid satellite");
+    let mut options = IntegratorOptions::default();
+    options.abs_tol = 1.0e-12;
+    options.rel_tol = 1.0e-13;
+    options.initial_step = 10.0;
+    options.max_step = 60.0;
     let propagator = StatePropagator {
         initial,
         force_model: ForceModelKind::two_body(),
         integrator: IntegratorKind::Dp54,
-        options: IntegratorOptions {
-            abs_tol: 1.0e-12,
-            rel_tol: 1.0e-13,
-            initial_step: 10.0,
-            max_step: 60.0,
-            ..IntegratorOptions::default()
-        },
+        options,
         drag: None,
         space_weather: None,
     };

--- a/crates/sidereon/src/lib.rs
+++ b/crates/sidereon/src/lib.rs
@@ -1536,42 +1536,61 @@ mod tests {
     }
 
     fn ppp_float_solve_config() -> FloatSolveConfig {
-        FloatSolveConfig {
-            weights: precise_positioning::MeasurementWeights {
-                code: 1.0,
-                phase: 100.0,
-                elevation_weighting: false,
-            },
-            tropo: precise_positioning::TroposphereOptions::disabled(),
-            corrections: precise_positioning::RangeCorrections::disabled(),
-            opts: precise_positioning::FloatSolveOptions {
-                max_iterations: 1,
-                position_tolerance_m: 1.0e-4,
-                clock_tolerance_m: 1.0e-4,
-                ambiguity_tolerance_m: 1.0e-4,
-                ztd_tolerance_m: 1.0e-4,
-            },
-            elevation_cutoff_deg: None,
-            residual_screen: false,
-            estimate_residual_ionosphere: false,
-        }
+        let weights = precise_positioning::MeasurementWeights {
+            code: 1.0,
+            phase: 100.0,
+            elevation_weighting: false,
+        };
+        let tropo = precise_positioning::TroposphereOptions::disabled();
+        let corrections = precise_positioning::RangeCorrections::disabled();
+        let mut opts = precise_positioning::FloatSolveOptions::default();
+        opts.max_iterations = 1;
+        opts.position_tolerance_m = 1.0e-4;
+        opts.clock_tolerance_m = 1.0e-4;
+        opts.ambiguity_tolerance_m = 1.0e-4;
+        opts.ztd_tolerance_m = 1.0e-4;
+        let mut config = FloatSolveConfig::new(
+            weights,
+            tropo,
+            corrections.clone(),
+            opts,
+            None,
+            false,
+            false,
+        );
+        config.weights = weights;
+        config.tropo = tropo;
+        config.corrections = corrections;
+        config.opts = opts;
+        config.elevation_cutoff_deg = None;
+        config.residual_screen = false;
+        config.estimate_residual_ionosphere = false;
+        config
     }
 
     fn ppp_fixed_solve_config() -> FixedSolveConfig {
         let float = ppp_float_solve_config();
-        FixedSolveConfig {
-            weights: float.weights,
-            tropo: float.tropo,
-            corrections: float.corrections,
-            opts: float.opts,
-            elevation_cutoff_deg: None,
-            ambiguity: precise_positioning::FixedAmbiguityOptions {
-                wavelengths_m: BTreeMap::new(),
-                offsets_m: BTreeMap::new(),
-                ratio_threshold: 3.0,
-            },
-            estimate_residual_ionosphere: false,
-        }
+        let mut ambiguity = precise_positioning::FixedAmbiguityOptions::new(3.0);
+        ambiguity.wavelengths_m = BTreeMap::new();
+        ambiguity.offsets_m = BTreeMap::new();
+        ambiguity.ratio_threshold = 3.0;
+        let mut config = FixedSolveConfig::new(
+            float.weights,
+            float.tropo,
+            float.corrections.clone(),
+            float.opts,
+            None,
+            ambiguity.clone(),
+            false,
+        );
+        config.weights = float.weights;
+        config.tropo = float.tropo;
+        config.corrections = float.corrections;
+        config.opts = float.opts;
+        config.elevation_cutoff_deg = None;
+        config.ambiguity = ambiguity;
+        config.estimate_residual_ionosphere = false;
+        config
     }
 
     fn empty_ppp_state() -> FloatState {
@@ -2036,10 +2055,9 @@ mod tests {
             sidereon_core::constants::SECONDS_PER_DAY,
         )
         .expect("valid one-day window");
-        let options = tca::TcaFinderOptions {
-            coarse_step_seconds: 120.0,
-            time_tolerance_seconds: 1.0e-2,
-        };
+        let mut options = tca::TcaFinderOptions::default();
+        options.coarse_step_seconds = 120.0;
+        options.time_tolerance_seconds = 1.0e-2;
 
         let candidates =
             tca::find_tca_candidates_between_tles(primary_tle, secondary_tle, window, options)
@@ -2230,13 +2248,13 @@ mod tests {
             },
             robust: None,
         };
-        let options = quality::FdeSppOptions {
-            fde: quality::FdeOptions {
-                raim: quality::RaimOptions::default(),
-                max_iterations: 0,
-            },
-            validation: quality::SolutionValidationOptions::default(),
-        };
+        let mut fde = quality::FdeOptions::new(quality::RaimOptions::default(), 0);
+        fde.raim = quality::RaimOptions::default();
+        fde.max_iterations = 0;
+        let mut options =
+            quality::FdeSppOptions::new(fde.clone(), quality::SolutionValidationOptions::default());
+        options.fde = fde;
+        options.validation = quality::SolutionValidationOptions::default();
 
         let result = spp_robust_fde_driver(
             &sp3,

--- a/crates/sidereon/tests/core_domain_facade.rs
+++ b/crates/sidereon/tests/core_domain_facade.rs
@@ -83,14 +83,14 @@ fn core_domain_modules_are_reachable_through_facade() {
         sidereon::frequencies::CarrierBand::L1,
     )
     .expect("facade GPS L1 frequency");
-    let request = sidereon::atmosphere::IonexSlantRequest {
-        receiver: sidereon::Wgs84Geodetic::new(30.0_f64.to_radians(), 0.0_f64.to_radians(), 0.0)
+    let request = sidereon::atmosphere::IonexSlantRequest::new(
+        sidereon::Wgs84Geodetic::new(30.0_f64.to_radians(), 0.0_f64.to_radians(), 0.0)
             .expect("facade receiver"),
-        elevation_rad: 45.0_f64.to_radians(),
-        azimuth_rad: 90.0_f64.to_radians(),
-        epoch_j2000_s: ionex.map_epochs_s()[0],
+        45.0_f64.to_radians(),
+        90.0_f64.to_radians(),
+        ionex.map_epochs_s()[0],
         frequency_hz,
-    };
+    );
     let mut batch = [f64::NAN];
     ionex
         .slant_delays_batch(&[request], &mut batch)

--- a/crates/sidereon/tests/ephemeris_sample_facade.rs
+++ b/crates/sidereon/tests/ephemeris_sample_facade.rs
@@ -12,10 +12,7 @@ fn facade_reexports_sp3_merge_controls_and_prediction_metadata() {
 
     let mut options = MergeOptions::default();
     options.precedence_scope = MergePrecedenceScope::SatelliteArc;
-    options.outlier_reject = Some(OutlierRejectOptions {
-        position_tolerance_m: 0.5,
-        clock_tolerance_s: 5.0e-9,
-    });
+    options.outlier_reject = Some(OutlierRejectOptions::new(0.5, 5.0e-9));
     assert_eq!(options.precedence_scope, MergePrecedenceScope::SatelliteArc);
     assert!(options.outlier_reject.is_some());
 }

--- a/crates/sidereon/tests/ntrip_facade.rs
+++ b/crates/sidereon/tests/ntrip_facade.rs
@@ -4,15 +4,15 @@ use sidereon::ntrip::{
 };
 
 fn config(version: NtripVersion) -> NtripConfig {
-    NtripConfig {
-        host: "caster.example.test".into(),
-        port: 2101,
-        mountpoint: "MOUNT".into(),
-        version,
-        credentials: None,
-        user_agent_product: "sidereon-test/0".into(),
-        gga_interval_s: None,
-    }
+    let mut config = NtripConfig::default();
+    config.host = "caster.example.test".into();
+    config.port = 2101;
+    config.mountpoint = "MOUNT".into();
+    config.version = version;
+    config.credentials = None;
+    config.user_agent_product = "sidereon-test/0".into();
+    config.gga_interval_s = None;
+    config
 }
 
 #[test]

--- a/crates/sidereon/tests/tle_fit_facade.rs
+++ b/crates/sidereon/tests/tle_fit_facade.rs
@@ -6,11 +6,9 @@ use sidereon::{DecayLatch, DecayLatchedError, Loss, XScale};
 
 #[test]
 fn facade_reexports_fit_loss_and_x_scale_types() {
-    let config = FitConfig {
-        loss: Loss::Huber,
-        x_scale: Some(XScale::Unit),
-        ..FitConfig::default()
-    };
+    let mut config = FitConfig::default();
+    config.loss = Loss::Huber;
+    config.x_scale = Some(XScale::Unit);
 
     assert_eq!(config.loss, Sgp4Loss::Huber);
     assert_eq!(config.x_scale, Some(Sgp4XScale::Unit));

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -137,16 +137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,18 +444,20 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "1.3.3"
+version = "1.4.1"
 dependencies = [
+ "approx",
  "cc",
- "fs2",
  "getrandom 0.2.17",
  "libm",
  "nalgebra",
+ "num-traits",
  "rayon",
  "roxmltree",
  "serde",
  "serde_json",
  "sha2",
+ "simba",
  "thiserror",
  "trust-region-least-squares",
 ]
@@ -526,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "trust-region-least-squares"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "libloading",
  "nalgebra",
@@ -575,28 +567,6 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/fuzz/fuzz_targets/fuzz_atmosphere.rs
+++ b/fuzz/fuzz_targets/fuzz_atmosphere.rs
@@ -132,13 +132,14 @@ fuzz_target!(|data: &[u8]| {
         input.grid_values.to_vec(),
     );
     if let Ok(grid) = grid {
-        let opts = TecGridEvalOptions {
-            epoch: TecGridEpoch::new(input.nanos, input.doy),
-            min_elevation_rad: input.params[12],
-            nan_pierce_point_height_m: input.params[13],
-            frequency_hz: input.params[10],
-            ..TecGridEvalOptions::l1(TecGridEpoch::new(input.nanos, input.doy))
-        };
+        let epoch = TecGridEpoch::new(input.nanos, input.doy);
+        let base = TecGridEvalOptions::l1(epoch);
+        let mut opts = TecGridEvalOptions::new(epoch, input.params[10]);
+        opts.epoch = epoch;
+        opts.min_elevation_rad = input.params[12];
+        opts.nan_pierce_point_height_m = input.params[13];
+        opts.frequency_hz = input.params[10];
+        opts.shell_geometry = base.shell_geometry;
         assert_ok_finite_or_err(
             "TecGrid::vtec_at_pierce_point",
             grid.vtec_at_pierce_point(opts.epoch, input.params[0], input.params[1]),
@@ -255,10 +256,9 @@ fuzz_target!(|data: &[u8]| {
             [phase.phase_geometry_free_m, phase.slant_tec_tecu],
         );
     }
-    let tec_config = TecConfig {
-        shell_height_m: input.params[6],
-        earth_radius_m: input.params[7],
-    };
+    let mut tec_config = TecConfig::default();
+    tec_config.shell_height_m = input.params[6];
+    tec_config.earth_radius_m = input.params[7];
     assert_ok_finite_or_err(
         "precise_positioning::thin_shell_mapping_function",
         precise_positioning::thin_shell_mapping_function(input.params[8], tec_config),

--- a/fuzz/fuzz_targets/fuzz_math.rs
+++ b/fuzz/fuzz_targets/fuzz_math.rs
@@ -220,12 +220,11 @@ fuzz_target!(|data: &[u8]| {
     );
     assert_ok_finite_or_err("least_squares::cost", cost(&f0));
     let problem = LeastSquaresProblem::new(residual, x0.clone());
-    let opts = SolveOptions {
-        gtol: input.scalars[6],
-        ftol: input.scalars[7],
-        xtol: input.scalars[8],
-        max_nfev: bounded_usize(input.dims[3], 1, 8),
-    };
+    let mut opts = SolveOptions::default();
+    opts.gtol = input.scalars[6];
+    opts.ftol = input.scalars[7];
+    opts.xtol = input.scalars[8];
+    opts.max_nfev = bounded_usize(input.dims[3], 1, 8);
     assert_ok_finite_or_err("least_squares::solve_trf", solve_trf(&problem, &opts));
     assert_ok_finite_or_err(
         "least_squares::solve_trf_with",

--- a/fuzz/fuzz_targets/fuzz_positioning.rs
+++ b/fuzz/fuzz_targets/fuzz_positioning.rs
@@ -171,25 +171,36 @@ fn ppp_state(input: &Input, epoch: &FloatEpoch) -> FloatState {
 }
 
 fn float_config(input: &Input) -> FloatSolveConfig {
-    FloatSolveConfig {
-        weights: MeasurementWeights {
-            code: input.scalars[0],
-            phase: input.scalars[1],
-            elevation_weighting: input.bits[2] & 1 == 1,
-        },
-        tropo: TroposphereOptions::disabled(),
-        corrections: RangeCorrections::disabled(),
-        opts: FloatSolveOptions {
-            max_iterations: bounded_usize(input.bits[3], 1, 5),
-            position_tolerance_m: input.scalars[2],
-            clock_tolerance_m: input.scalars[3],
-            ambiguity_tolerance_m: input.scalars[4],
-            ztd_tolerance_m: input.scalars[5],
-        },
-        elevation_cutoff_deg: None,
-        residual_screen: input.bits[4] & 1 == 1,
-        estimate_residual_ionosphere: false,
-    }
+    let weights = MeasurementWeights {
+        code: input.scalars[0],
+        phase: input.scalars[1],
+        elevation_weighting: input.bits[2] & 1 == 1,
+    };
+    let tropo = TroposphereOptions::disabled();
+    let corrections = RangeCorrections::disabled();
+    let mut opts = FloatSolveOptions::default();
+    opts.max_iterations = bounded_usize(input.bits[3], 1, 5);
+    opts.position_tolerance_m = input.scalars[2];
+    opts.clock_tolerance_m = input.scalars[3];
+    opts.ambiguity_tolerance_m = input.scalars[4];
+    opts.ztd_tolerance_m = input.scalars[5];
+    let mut config = FloatSolveConfig::new(
+        weights,
+        tropo,
+        corrections.clone(),
+        opts,
+        None,
+        input.bits[4] & 1 == 1,
+        false,
+    );
+    config.weights = weights;
+    config.tropo = tropo;
+    config.corrections = corrections;
+    config.opts = opts;
+    config.elevation_cutoff_deg = None;
+    config.residual_screen = input.bits[4] & 1 == 1;
+    config.estimate_residual_ionosphere = false;
+    config
 }
 
 fn raim_residuals(epoch: &FloatEpoch, input: &Input) -> Vec<FloatResidual> {
@@ -231,6 +242,12 @@ fuzz_target!(|data: &[u8]| {
     assert_ok_finite_or_err("Wgs84Geodetic::new", geodetic.as_ref());
     let geodetic = geodetic.ok();
 
+    let mut robust_cfg = RobustConfig::default();
+    robust_cfg.huber_k = input.scalars[5];
+    robust_cfg.scale_floor_m = input.scalars[6];
+    robust_cfg.max_outer = bounded_usize(input.bits[5], 1, 4);
+    robust_cfg.outer_tol_m = input.scalars[7];
+
     let solve_inputs = SolveInputs {
         observations: observations(&input),
         t_rx_j2000_s: input.scalars[11],
@@ -251,12 +268,7 @@ fuzz_target!(|data: &[u8]| {
             temperature_k: input.scalars[3],
             relative_humidity: input.scalars[4],
         },
-        robust: Some(RobustConfig {
-            huber_k: input.scalars[5],
-            scale_floor_m: input.scalars[6],
-            max_outer: bounded_usize(input.bits[5], 1, 4),
-            outer_tol_m: input.scalars[7],
-        }),
+        robust: Some(robust_cfg),
     };
     assert_ok_finite_or_err(
         "positioning::solve",
@@ -327,12 +339,11 @@ fuzz_target!(|data: &[u8]| {
                 .unwrap_or_else(|| LineOfSight::new(1.0, 0.0, 0.0)),
         })
         .collect();
-    let raim_config = RaimConfig {
-        false_alarm_probability: input.scalars[0],
-        missed_detection_probability: input.scalars[1],
-        measurement_sigma_m: input.scalars[2],
-        chi_square_threshold: Some(input.scalars[3]),
-    };
+    let mut raim_config = RaimConfig::default();
+    raim_config.false_alarm_probability = input.scalars[0];
+    raim_config.missed_detection_probability = input.scalars[1];
+    raim_config.measurement_sigma_m = input.scalars[2];
+    raim_config.chi_square_threshold = Some(input.scalars[3]);
     assert_ok_finite_or_err(
         "precise_positioning::global_test",
         global_test(&residuals, bounded_usize(input.bits[7], 1, 16), raim_config),
@@ -399,23 +410,33 @@ fuzz_target!(|data: &[u8]| {
             arcs_used: 0,
         },
     };
-    let fixed_config = FixedSolveConfig {
-        weights: config.weights,
-        tropo: config.tropo,
-        corrections: config.corrections.clone(),
-        opts: config.opts,
-        elevation_cutoff_deg: None,
-        ambiguity: FixedAmbiguityOptions {
-            wavelengths_m: epoch
-                .observations
-                .iter()
-                .map(|obs| (obs.ambiguity_id.clone(), input.scalars[7]))
-                .collect(),
-            offsets_m: BTreeMap::new(),
-            ratio_threshold: input.scalars[8],
-        },
-            estimate_residual_ionosphere: false,
-    };
+    let ratio_threshold = input.scalars[8];
+    let wavelengths_m = epoch
+        .observations
+        .iter()
+        .map(|obs| (obs.ambiguity_id.clone(), input.scalars[7]))
+        .collect();
+    let offsets_m = BTreeMap::new();
+    let mut ambiguity = FixedAmbiguityOptions::new(ratio_threshold);
+    ambiguity.wavelengths_m = wavelengths_m;
+    ambiguity.offsets_m = offsets_m;
+    ambiguity.ratio_threshold = ratio_threshold;
+    let mut fixed_config = FixedSolveConfig::new(
+        config.weights,
+        config.tropo,
+        config.corrections.clone(),
+        config.opts,
+        None,
+        ambiguity.clone(),
+        false,
+    );
+    fixed_config.weights = config.weights;
+    fixed_config.tropo = config.tropo;
+    fixed_config.corrections = config.corrections.clone();
+    fixed_config.opts = config.opts;
+    fixed_config.elevation_cutoff_deg = None;
+    fixed_config.ambiguity = ambiguity;
+    fixed_config.estimate_residual_ionosphere = false;
     assert_ok_finite_or_err(
         "precise_positioning::solve_fixed_from_float",
         precise_positioning::solve_fixed_from_float(
@@ -443,14 +464,18 @@ fuzz_target!(|data: &[u8]| {
         ambiguities_m: state.ambiguities_m.clone(),
     };
     let mut kin_cov = finite_square(kin_state.dimension(), input.scalars[10]);
-    let kin_config = KinematicConfig {
-        initial_state: kin_state.clone(),
-        initial_covariance_m2: kin_cov.clone(),
-        motion: KinematicMotionModel::ConstantVelocity {
-            velocity_m_s: input.velocities[0],
-        },
-        ..KinematicConfig::default()
+    let default = KinematicConfig::default();
+    let mut kin_config = KinematicConfig::default();
+    kin_config.initial_state = kin_state.clone();
+    kin_config.initial_covariance_m2 = kin_cov.clone();
+    kin_config.motion = KinematicMotionModel::ConstantVelocity {
+        velocity_m_s: input.velocities[0],
     };
+    kin_config.process_noise = default.process_noise;
+    kin_config.new_ambiguity_variance_m2 = default.new_ambiguity_variance_m2;
+    kin_config.weights = default.weights;
+    kin_config.tropo = default.tropo;
+    kin_config.corrections = default.corrections;
     let active: Vec<String> = epoch
         .observations
         .iter()
@@ -503,20 +528,20 @@ fuzz_target!(|data: &[u8]| {
             ),
         );
     }
+    let mut velocity_robust = VelocityRobustConfig::default();
+    velocity_robust.huber_k = input.scalars[0];
+    velocity_robust.scale_floor_m_s = input.scalars[1];
+    velocity_robust.max_outer = bounded_usize(input.bits[2], 1, 4);
+    velocity_robust.outer_tol_m_s = input.scalars[2];
+    let mut velocity_config = VelocityConfig::default();
+    velocity_config.minimum_observations = bounded_usize(input.bits[0], 1, 8);
+    velocity_config.robust = Some(velocity_robust);
     assert_ok_finite_or_err(
         "precise_positioning::solve_velocity",
         precise_positioning::solve_velocity(
             &ppp_velocity_obs,
             receiver,
-            VelocityConfig {
-                minimum_observations: bounded_usize(input.bits[0], 1, 8),
-                robust: Some(VelocityRobustConfig {
-                    huber_k: input.scalars[0],
-                    scale_floor_m_s: input.scalars[1],
-                    max_outer: bounded_usize(input.bits[2], 1, 4),
-                    outer_tol_m_s: input.scalars[2],
-                }),
-            },
+            velocity_config,
         ),
     );
 
@@ -538,6 +563,14 @@ fuzz_target!(|data: &[u8]| {
         "velocity::range_rate_to_doppler",
         velocity::range_rate_to_doppler(input.scalars[2], input.scalars[3]),
     );
+    let mut velocity_solve_opts = VelocitySolveOptions::default();
+    velocity_solve_opts.observable = if input.bits[0] & 1 == 0 {
+        VelocityObservable::RangeRate
+    } else {
+        VelocityObservable::Doppler
+    };
+    velocity_solve_opts.light_time = input.bits[1] & 1 == 1;
+    velocity_solve_opts.sagnac = input.bits[2] & 1 == 1;
     assert_ok_finite_or_err(
         "velocity::solve",
         velocity::solve(
@@ -545,15 +578,7 @@ fuzz_target!(|data: &[u8]| {
             &velocity_obs,
             receiver,
             input.scalars[11],
-            VelocitySolveOptions {
-                observable: if input.bits[0] & 1 == 0 {
-                    VelocityObservable::RangeRate
-                } else {
-                    VelocityObservable::Doppler
-                },
-                light_time: input.bits[1] & 1 == 1,
-                sagnac: input.bits[2] & 1 == 1,
-            },
+            velocity_solve_opts,
         ),
     );
 });

--- a/fuzz/fuzz_targets/fuzz_propagation.rs
+++ b/fuzz/fuzz_targets/fuzz_propagation.rs
@@ -39,15 +39,15 @@ struct Input {
 }
 
 fn integrator_options(input: &Input) -> IntegratorOptions {
-    IntegratorOptions {
-        abs_tol: input.opts[0],
-        rel_tol: input.opts[1],
-        min_step: input.opts[2],
-        max_step: bounded_positive_or_raw(input.opts[3], 1.0, 600.0),
-        initial_step: bounded_positive_or_raw(input.opts[4], 1.0, 120.0),
-        max_steps: bounded_usize(input.opt_bits[0], 1, 32) as u32,
-        dense_output: input.opt_bits[1] & 1 == 1,
-    }
+    let mut opts = IntegratorOptions::default();
+    opts.abs_tol = input.opts[0];
+    opts.rel_tol = input.opts[1];
+    opts.min_step = input.opts[2];
+    opts.max_step = bounded_positive_or_raw(input.opts[3], 1.0, 600.0);
+    opts.initial_step = bounded_positive_or_raw(input.opts[4], 1.0, 120.0);
+    opts.max_steps = bounded_usize(input.opt_bits[0], 1, 32) as u32;
+    opts.dense_output = input.opt_bits[1] & 1 == 1;
+    opts
 }
 
 fn elements(input: &Input) -> ElementSet {

--- a/fuzz/fuzz_targets/fuzz_rtk.rs
+++ b/fuzz/fuzz_targets/fuzz_rtk.rs
@@ -344,16 +344,18 @@ fuzz_target!(|data: &[u8]| {
             })
             .collect(),
     };
+    let min_epochs = bounded_usize(input.bits[2], 1, 4);
+    let tolerance_cycles = input.scalars[10];
+    let mut wide_lane_options = WideLaneOptions::new(min_epochs, tolerance_cycles);
+    wide_lane_options.min_epochs = min_epochs;
+    wide_lane_options.tolerance_cycles = tolerance_cycles;
+    wide_lane_options.skip_short_fragments = input.bits[3] & 1 == 1;
     assert_ok_or_err(
         "rtk::estimate_wide_lane_ambiguities",
         rtk::estimate_wide_lane_ambiguities(
             std::slice::from_ref(&dual_epoch),
             "G01",
-            WideLaneOptions {
-                min_epochs: bounded_usize(input.bits[2], 1, 4),
-                tolerance_cycles: input.scalars[10],
-                skip_short_fragments: input.bits[3] & 1 == 1,
-            },
+            wide_lane_options,
         ),
     );
     let if_epoch = DualIonosphereFreeEpoch {

--- a/fuzz/fuzz_targets/fuzz_signal.rs
+++ b/fuzz/fuzz_targets/fuzz_signal.rs
@@ -124,48 +124,46 @@ fuzz_target!(|data: &[u8]| {
             signal::correlation_at(&chips, &other, input.ints[2]).map(f64::from),
         );
     }
+    let sample_rate_hz = input.params[0];
+    let num_samples = bounded_usize(input.bits[1], 0, 256);
+    let code_phase_chips = input.params[1];
+    let code_doppler_hz = input.params[2];
+    let mut replica_opts = ReplicaOptions::new(
+        sample_rate_hz,
+        num_samples,
+        code_phase_chips,
+        code_doppler_hz,
+    );
+    replica_opts.sample_rate_hz = sample_rate_hz;
+    replica_opts.num_samples = num_samples;
+    replica_opts.code_phase_chips = code_phase_chips;
+    replica_opts.code_doppler_hz = code_doppler_hz;
     assert_ok_or_err(
         "signal::replica",
-        signal::replica(
-            prn,
-            ReplicaOptions {
-                sample_rate_hz: input.params[0],
-                num_samples: bounded_usize(input.bits[1], 0, 256),
-                code_phase_chips: input.params[1],
-                code_doppler_hz: input.params[2],
-            },
-        ),
+        signal::replica(prn, replica_opts),
     );
     let iq = iq(&input);
+    let mut correlate_opts = CorrelateOptions::default();
+    correlate_opts.sample_rate_hz = input.params[0];
+    correlate_opts.doppler_hz = input.params[3];
+    correlate_opts.code_phase_chips = input.params[1];
+    correlate_opts.code_doppler_hz = input.params[2];
     assert_ok_finite_or_err(
         "signal::correlate",
-        signal::correlate(
-            &iq,
-            prn,
-            CorrelateOptions {
-                sample_rate_hz: input.params[0],
-                doppler_hz: input.params[3],
-                code_phase_chips: input.params[1],
-                code_doppler_hz: input.params[2],
-            },
-        ),
+        signal::correlate(&iq, prn, correlate_opts),
     );
     assert_ok_finite_or_err(
         "signal::correlate_against",
         signal::correlate_against(&iq, &chips, input.params[0], input.params[3]),
     );
+    let mut acq_opts = AcquisitionOptions::default();
+    acq_opts.sample_rate_hz = input.params[0];
+    acq_opts.doppler_min_hz = bounded_abs_or_raw(input.params[4], 5_000.0);
+    acq_opts.doppler_max_hz = bounded_abs_or_raw(input.params[5], 5_000.0);
+    acq_opts.doppler_step_hz = bounded_positive_or_raw(input.params[6], 1.0, 1_000.0);
     assert_ok_finite_or_err(
         "signal::acquire",
-        signal::acquire(
-            &iq,
-            prn,
-            AcquisitionOptions {
-                sample_rate_hz: input.params[0],
-                doppler_min_hz: bounded_abs_or_raw(input.params[4], 5_000.0),
-                doppler_max_hz: bounded_abs_or_raw(input.params[5], 5_000.0),
-                doppler_step_hz: bounded_positive_or_raw(input.params[6], 1.0, 1_000.0),
-            },
-        ),
+        signal::acquire(&iq, prn, acq_opts),
     );
     assert_ok_finite_or_err(
         "signal::coherent_loss",
@@ -316,6 +314,10 @@ fuzz_target!(|data: &[u8]| {
         observables::j2000_seconds_from_split(input.params[10], input.params[11]),
     );
     if let Ok(sat) = GnssSatelliteId::new(GnssSystem::Gps, 1) {
+        let mut predict_opts = PredictOptions::default();
+        predict_opts.carrier_hz = input.params[4];
+        predict_opts.light_time = input.bits[0] & 1 == 1;
+        predict_opts.sagnac = input.bits[1] & 1 == 1;
         assert_ok_finite_or_err(
             "observables::predict",
             observables::predict(
@@ -323,11 +325,7 @@ fuzz_target!(|data: &[u8]| {
                 sat,
                 input.receiver,
                 input.params[12],
-                PredictOptions {
-                    carrier_hz: input.params[4],
-                    light_time: input.bits[0] & 1 == 1,
-                    sagnac: input.bits[1] & 1 == 1,
-                },
+                predict_opts,
             ),
         );
     }

--- a/fuzz/fuzz_targets/rinex_qc_repair_roundtrip.rs
+++ b/fuzz/fuzz_targets/rinex_qc_repair_roundtrip.rs
@@ -8,14 +8,16 @@ use sidereon_core::rinex::qc::{lint_obs, repair_obs, RepairOptions};
 const MAX_INPUT_LEN: usize = 1 << 20;
 
 fn repair_options() -> RepairOptions {
-    RepairOptions {
-        set_interval: true,
-        set_time_of_last_obs: true,
-        set_obs_counts: true,
-        drop_empty_records: true,
-        drop_unsupported: true,
-        ..RepairOptions::default()
-    }
+    let base = RepairOptions::default();
+    let mut options = RepairOptions::default();
+    options.set_interval = true;
+    options.set_time_of_last_obs = true;
+    options.set_obs_counts = true;
+    options.drop_empty_records = true;
+    options.drop_unsupported = true;
+    options.file_stamp = base.file_stamp;
+    options.sort_records = base.sort_records;
+    options
 }
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
Breaking, for 2.0.0.

Every public options/config/request struct is now `#[non_exhaustive]`, so adding an optional knob to one is a minor release instead of a major. Without this, a library that gains options regularly and ships six interfaces in lockstep would cut a major version for routine additive work.

Fields stay public. `#[non_exhaustive]` only forbids struct-literal syntax outside the crate, so external construction becomes `Default::default()` or `T::new(...)` followed by field assignment.

## Scope

116 input types. Output types (results, reports, solutions, statistics) are deliberately left exhaustive: callers read those, and keeping their field set a checked contract is worth more than the flexibility.

The 53 input structs that had no `Default` gain a `new()` taking the fields with no safe neutral value. A physical input — a station position, a frequency, an epoch, a required threshold — is never given an invented default, because a wrong default there is a wrong result rather than a build error.

## The migration hazard, and how it was contained

Rewriting a checked struct literal into construct-then-assign removes the compiler's guarantee that every field was set: drop one and the code still compiles while the value silently becomes the default. So every one of the ~180 rewritten sites preserves the exact field set the literal assigned, including fields whose value equals the default.

Two independent checks back that up:

- a script comparing the removed literal's field names against the fields assigned in the replacement, over the whole diff;
- the pinned bit-exact suites, which are where a silently defaulted numeric field would surface. They are unchanged: 3,048 workspace tests and 2,859 mmap tests pass, and no fixture or pinned value is touched.

The facade and CLI sites, the ones a test would not catch, were read individually.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace`, `cargo nextest run -p sidereon-core --features mmap`.