### PR TITLE
Documentation pass: the remaining 41 modules

### DIFF
--- a/crates/sidereon-core/src/araim/mod.rs
+++ b/crates/sidereon-core/src/araim/mod.rs
@@ -7,9 +7,23 @@
 //! per-satellite effective sigmas for reference cases that publish `Cint` and
 //! `Cacc` diagonals.
 
+/// Enumerates the fault hypotheses used by the ARAIM multi-hypothesis solve.
+/// [`crate::araim::enumerate_fault_modes`] returns a fault-free hypothesis
+/// first, followed by allowed satellite and constellation events and then
+/// higher-order satellite candidates ordered by prior mass.
 pub mod fault_modes;
+/// Holds the integrity support models consumed by ARAIM.
+/// [`crate::araim::Ism`] combines constellation defaults with optional
+/// satellite overrides; its effective-model path either uses supplied
+/// effective sigmas or adds local pseudorange variance to the URA/URE
+/// variances before taking their square roots.
 pub mod ism;
 mod mhss;
+/// Supplies the range-error interface and gain-matrix primitives used by ARAIM
+/// and single-hypothesis protection calculations.
+/// [`crate::araim::ProtectionModel`] implementations provide external
+/// per-row sigmas; the module projects weighted line-of-sight designs into ENU
+/// and applies the WG-C protection equations to derive protection levels.
 pub mod protection;
 pub mod reliability;
 

--- a/crates/sidereon-core/src/astro/almanac/mod.rs
+++ b/crates/sidereon-core/src/astro/almanac/mod.rs
@@ -54,9 +54,13 @@ pub enum EphemerisSource<'a> {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SeasonKind {
+    /// The Sun's ecliptic longitude crossing at `0` degrees.
     MarchEquinox,
+    /// The Sun's ecliptic longitude crossing at `90` degrees.
     JuneSolstice,
+    /// The Sun's ecliptic longitude crossing at `180` degrees.
     SeptemberEquinox,
+    /// The Sun's ecliptic longitude crossing at `270` degrees.
     DecemberSolstice,
 }
 
@@ -64,9 +68,13 @@ pub enum SeasonKind {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoonPhaseKind {
+    /// The wrapped Moon-minus-Sun ecliptic longitude is `0` degrees.
     New,
+    /// The wrapped Moon-minus-Sun ecliptic longitude is `90` degrees.
     FirstQuarter,
+    /// The wrapped Moon-minus-Sun ecliptic longitude is `180` degrees.
     Full,
+    /// The wrapped Moon-minus-Sun ecliptic longitude is `270` degrees.
     LastQuarter,
 }
 
@@ -74,7 +82,9 @@ pub enum MoonPhaseKind {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlanetaryEventKind {
+    /// The planet-minus-Sun ecliptic longitude is `0` degrees.
     Conjunction,
+    /// The planet-minus-Sun ecliptic longitude is `180` degrees; `planetary_events` rejects this request for Mercury and Venus.
     Opposition,
 }
 
@@ -82,7 +92,9 @@ pub enum PlanetaryEventKind {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CulminationKind {
+    /// The cosine of the topocentric apparent hour angle is positive.
     Upper,
+    /// The cosine of the topocentric apparent hour angle is negative; a zero-cosine crossing is skipped.
     Lower,
 }
 
@@ -90,12 +102,19 @@ pub enum CulminationKind {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EclipseKind {
+    /// The Moon's apparent disk overlaps the penumbral shadow after the umbral tests fail.
     LunarPenumbral,
+    /// The Moon's apparent disk overlaps the umbra without fitting fully inside it.
     LunarPartial,
+    /// The Moon's apparent disk fits fully within the umbral shadow.
     LunarTotal,
+    /// The apparent disks do not meet the total or annular containment tests, including the non-overlap case.
     SolarPartial,
+    /// The Moon's apparent disk is smaller than the Sun's and is fully inside it.
     SolarAnnular,
+    /// The Moon's apparent disk is at least as large as the Sun's and fully covers it.
     SolarTotal,
+    /// The solar eclipse switches between total and annular across Earth's near and far intersections.
     SolarHybrid,
 }
 
@@ -103,12 +122,19 @@ pub enum EclipseKind {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Planet {
+    /// NAIF body ID `1`.
     Mercury,
+    /// NAIF body ID `2`.
     Venus,
+    /// NAIF body ID `4`.
     Mars,
+    /// NAIF body ID `5`.
     Jupiter,
+    /// NAIF body ID `6`.
     Saturn,
+    /// NAIF body ID `7`.
     Uranus,
+    /// NAIF body ID `8`.
     Neptune,
 }
 
@@ -116,8 +142,11 @@ pub enum Planet {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransitBody {
+    /// The Sun, with NAIF body ID `10`.
     Sun,
+    /// The Moon, with NAIF body ID `301`.
     Moon,
+    /// A planet resolved through `planet_naif`.
     Planet(Planet),
 }
 
@@ -125,7 +154,9 @@ pub enum TransitBody {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SeasonEvent {
+    /// UTC instant of the crossing; returned events are sorted by this field.
     pub time: UtcInstant,
+    /// The seasonal marker whose Sun-longitude target produced the crossing.
     pub kind: SeasonKind,
 }
 
@@ -133,7 +164,9 @@ pub struct SeasonEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoonPhaseEvent {
+    /// UTC instant of the phase crossing; returned events are sorted by this field.
     pub time: UtcInstant,
+    /// The phase whose Moon-minus-Sun angle target produced the crossing.
     pub kind: MoonPhaseKind,
 }
 
@@ -141,9 +174,13 @@ pub struct MoonPhaseEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PlanetaryEvent {
+    /// UTC instant of the planet-minus-Sun longitude crossing.
     pub time: UtcInstant,
+    /// The planet supplied to [`planetary_events`].
     pub planet: Planet,
+    /// The conjunction or opposition supplied to [`planetary_events`].
     pub kind: PlanetaryEventKind,
+    /// Wrapped planet-minus-Sun ecliptic longitude at `time`, in degrees on `[0, 360)`.
     pub elongation_deg: f64,
 }
 
@@ -151,8 +188,11 @@ pub struct PlanetaryEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CulminationEvent {
+    /// UTC instant of the hour-angle crossing.
     pub time: UtcInstant,
+    /// Whether the crossing is upper or lower, based on the sign of the hour-angle cosine.
     pub kind: CulminationKind,
+    /// Topocentric apparent geometric altitude at `time`, in degrees without refraction.
     pub altitude_deg: f64,
 }
 
@@ -160,11 +200,17 @@ pub struct CulminationEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct EclipseEvent {
+    /// UTC instant of the selected eclipse maximum within the requested window.
     pub time_maximum: UtcInstant,
+    /// The lunar shadow or solar disk-overlap classification.
     pub kind: EclipseKind,
+    /// For lunar events, `(rho_u + s_moon - sigma) / (2.0 * s_moon)` is used for total or partial events and `(rho_p + s_moon - sigma) / (2.0 * s_moon)` for penumbral events; solar events use `max(0.0, (s_sun + s_moon - sep) / (2.0 * s_sun))`.
     pub magnitude: f64,
+    /// Apparent geocentric ecliptic latitude of the Moon at `time_maximum`, in degrees.
     pub moon_latitude_deg: f64,
+    /// `0.0` for lunar events; for solar events, the norm of the shadow axis's perpendicular offset from Earth's center divided by the mean Earth radius.
     pub gamma: f64,
+    /// True when a lunar shadow boundary, solar shadow-reach boundary, or solar limb boundary is within `0.01`, or when near/far intersections switch the solar class.
     pub uncertain: bool,
 }
 
@@ -172,13 +218,21 @@ pub struct EclipseEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum AlmanacError {
+    /// An event-finder window or search returned an error.
     Finder(EventFinderError),
+    /// An SPK-backed apparent-place reduction returned an error.
     Spk(SpkError),
+    /// A frame reduction failed; the payload identifies the reduction stage.
     Frame(&'static str),
+    /// An analytic source was asked for a body other than the Sun or Moon, or for a planetary event or transit that requires SPK data.
     EphemerisRequired,
+    /// Opposition was requested for Mercury or Venus.
     InferiorPlanetOpposition,
+    /// A scan control, station coordinate, predicate, vector, geometry, or other intermediate quantity failed a finiteness, positivity, range, or degeneracy check.
     InvalidInput {
+        /// Static label identifying the rejected input or intermediate quantity, such as `step_seconds`, `predicate`, `geometry`, or a vector label.
         field: &'static str,
+        /// Static explanation supplied by validation, such as `not finite`, `exceeds maximum`, `degenerate`, or `components must be finite`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/bodies/sun_moon.rs
+++ b/crates/sidereon-core/src/astro/bodies/sun_moon.rs
@@ -43,7 +43,12 @@ pub enum SunMoonError {
     /// A public ephemeris input was non-finite or outside its valid domain.
     #[error("invalid Sun/Moon input {field}: {reason}")]
     InvalidInput {
+        /// Label from validation: `"t"` or `"jd_tt"` for a non-finite time
+        /// input, or `"sun[0]"` through `"sun[2]"` / `"moon[0]"` through
+        /// `"moon[2]"` for a non-finite computed vector component.
         field: &'static str,
+        /// Static reason copied from validation; this module's finite checks
+        /// report `"not finite"` for a non-finite input or computed component.
         reason: &'static str,
     },
     /// The ECI-to-ECEF frame rotation rejected the supplied time scales.

--- a/crates/sidereon-core/src/astro/covariance.rs
+++ b/crates/sidereon-core/src/astro/covariance.rs
@@ -250,7 +250,20 @@ pub fn interpolate_covariance_psd(
 pub enum RtnFrameError {
     /// A numeric input was non-finite.
     InvalidInput {
+        /// Input name reported by the frame, covariance, relative-state, or
+        /// Clohessy-Wiltshire validation path.
+        ///
+        /// Covariance APIs use names such as `"position"`, `"velocity"`,
+        /// `"cov_rtn"`, and `"covariance"`; relative-motion APIs use the
+        /// parameter or state path being checked.
         field: &'static str,
+        /// Stable validation text paired with `field`, including
+        /// finite-component, symmetry, positivity, range, parameter, epoch,
+        /// and orbit-geometry failures.
+        ///
+        /// [`RtnFrameError::message`] intentionally reduces this variant to
+        /// `"invalid input"`, while `OrbitFitError::RtnFrame` exposes the
+        /// nested error through debug formatting.
         reason: &'static str,
     },
     /// The position vector is effectively zero.

--- a/crates/sidereon-core/src/astro/data/iers.rs
+++ b/crates/sidereon-core/src/astro/data/iers.rs
@@ -10,6 +10,10 @@ pub struct Ut1Entry {
     pub ut1_utc: f64,
 }
 
+/// Daily UT1 minus UTC entries from IERS `finals2000A.all` spanning MJD 41684 to MJD 61239.
+///
+/// Used by [`TimeTables::embedded`](crate::astro::time::TimeTables::embedded)
+/// for Delta-T interpolation and UT1 time-scale conversions.
 pub static UT1_DATA: [Ut1Entry; 19906] = [
     Ut1Entry {
         mjd: 41684,

--- a/crates/sidereon-core/src/astro/data/mod.rs
+++ b/crates/sidereon-core/src/astro/data/mod.rs
@@ -5,5 +5,9 @@
 //! byte-for-byte from the upstream sources and must not be regenerated or
 //! reformatted in ways that alter any literal.
 
+/// IAU 2000A (MHB2000) lunisolar and planetary nutation series tables.
+///
+/// Contains coefficients from IERS Conventions (2010) Chapter 5 in 0.1
+/// microarcsecond units used by Earth orientation frame transformations.
 pub mod iau2000a;
 pub mod iers;

--- a/crates/sidereon-core/src/astro/events/mod.rs
+++ b/crates/sidereon-core/src/astro/events/mod.rs
@@ -8,8 +8,18 @@ pub use r#trait::{
 };
 
 #[derive(Debug, Clone)]
+/// Event record stored in [`crate::astro::propagator::PropagationResult::events`].
+///
+/// The built-in RK4 and DP54 integrators currently return an empty event vector,
+/// so no built-in propagation path constructs this record.
 pub struct DetectedEvent {
+    /// No built-in propagation path currently populates this field: RK4 and
+    /// DP54 return an empty [`crate::astro::propagator::PropagationResult::events`]
+    /// vector.
     pub epoch_tdb_seconds: f64,
+    /// No built-in propagation path currently populates this field: RK4 and
+    /// DP54 return an empty [`crate::astro::propagator::PropagationResult::events`]
+    /// vector.
     pub name: String,
     // Additional fields as needed
 }

--- a/crates/sidereon-core/src/astro/forces/mod.rs
+++ b/crates/sidereon-core/src/astro/forces/mod.rs
@@ -1,13 +1,23 @@
 pub mod albedo;
+/// Combines the accelerations returned by multiple [`ForceModel`]
+/// components in insertion order and returns the first component error.
 pub mod composite;
 pub mod drag;
 pub mod geopotential;
+/// Provides [`J2Gravity`], a degree-2 zonal-harmonic perturbation model built
+/// after [`TwoBodyGravity`] by [`crate::astro::propagator::ForceModelKind::TwoBodyJ2`].
 pub mod j2;
 pub mod relativity;
 pub mod srp;
 pub mod third_body;
 pub mod tides;
+/// Defines the thread-safe [`ForceModel`] acceleration interface used by
+/// numerical propagation. Its [`ForceModel::acceleration`] method returns an
+/// acceleration in km/s² or [`crate::astro::error::PropagationError`].
 pub mod r#trait;
+/// Provides [`TwoBodyGravity`], which returns central point-mass acceleration
+/// and reports an exact zero position norm as
+/// [`crate::astro::error::PropagationError::NumericalFailure`].
 pub mod two_body;
 pub mod zonal;
 

--- a/crates/sidereon-core/src/astro/forces/two_body.rs
+++ b/crates/sidereon-core/src/astro/forces/two_body.rs
@@ -5,7 +5,19 @@ use crate::astro::propagator::api::PropagationContext;
 use crate::astro::state::CartesianState;
 use nalgebra::Vector3;
 
+/// Central point-mass gravity model for Cartesian propagation.
+///
+/// [`ForceModel::acceleration`] returns `-mu * position_km / |position_km|³`
+/// in the propagator's inertial frame. [`Default::default`] uses
+/// [`MU_EARTH`], and an exact zero position norm is reported as
+/// [`PropagationError::NumericalFailure`].
 pub struct TwoBodyGravity {
+    /// Gravitational parameter in km³/s² used to scale the central point-mass
+    /// acceleration.
+    ///
+    /// [`Default::default`] sets this to [`MU_EARTH`], while
+    /// `ForceModelKind::build` copies the configured central-gravity parameter
+    /// into it for legacy and composite force-model variants.
     pub mu: f64,
 }
 

--- a/crates/sidereon-core/src/astro/frames/nutation.rs
+++ b/crates/sidereon-core/src/astro/frames/nutation.rs
@@ -26,7 +26,11 @@ pub enum NutationError {
     /// A nutation input was non-finite or otherwise invalid.
     #[error("invalid nutation {field}: {reason}")]
     InvalidInput {
+        /// Static label identifying the value that failed validation: a public time input, a
+        /// computed scalar, a computed component collection, or a nutation-matrix angle input.
         field: &'static str,
+        /// Static validation detail: `must be finite` for a scalar and `components must be
+        /// finite` for a computed array or matrix.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/integrators/mod.rs
+++ b/crates/sidereon-core/src/astro/integrators/mod.rs
@@ -1,5 +1,11 @@
+/// Adaptive Dormand-Prince 5(4) integrator implementation ([`DP54`]) using a
+/// 7-stage DOPRI5 tableau, PI step-size controller, and dense-output generation.
 pub mod dp54;
+/// Fixed-step fourth-order Runge-Kutta integrator implementation ([`RK4`])
+/// advancing Cartesian states with four derivative stages per step.
 pub mod rk4;
+/// Butcher tableau structures for Runge-Kutta integrators, including the
+/// DOPRI5 coefficients used by [`DP54`].
 pub mod tableau;
 
 pub use dp54::DP54;
@@ -10,7 +16,20 @@ use crate::astro::propagator::api::{IntegratorOptions, PropagationContext};
 use crate::astro::propagator::result::PropagationResult;
 use crate::astro::state::{CartesianState, StateDerivative};
 
+/// Right-hand-side equations of motion `d/dt [r; v] = f(t, [r, v])` for
+/// numerical orbit integration.
+///
+/// Implementations provide state derivatives for a given [`CartesianState`] and
+/// [`PropagationContext`], such as
+/// [`OrbitalDynamics`](crate::astro::propagator::dynamics::OrbitalDynamics)
+/// querying configured force models.
 pub trait DynamicsModel: Send + Sync {
+    /// Evaluates the state derivative for a given [`CartesianState`] and
+    /// [`PropagationContext`].
+    ///
+    /// Assigns position derivative `dpos_km_s` from velocity in km/s and
+    /// velocity derivative `dvel_km_s2` from force model acceleration in km/s²,
+    /// returning [`PropagationError`] on force evaluation failure.
     fn derivative(
         &self,
         state: &CartesianState,
@@ -18,7 +37,18 @@ pub trait DynamicsModel: Send + Sync {
     ) -> Result<StateDerivative, PropagationError>;
 }
 
+/// Numerical integrator interface for advancing Cartesian orbital states across
+/// time intervals in TDB seconds.
+///
+/// Implementations such as [`RK4`] and [`DP54`] advance an initial state to a
+/// target epoch using equations of motion specified by a [`DynamicsModel`].
 pub trait Integrator: Send + Sync {
+    /// Integrates equations of motion `rhs` from `initial.epoch_tdb_seconds` to
+    /// `t_end_seconds` in TDB.
+    ///
+    /// Supports forward and backward integration, validates finite epochs and
+    /// step options, and returns [`PropagationError::MaxStepsExceeded`] if the
+    /// step count reaches `opts.max_steps`.
     fn propagate(
         &self,
         initial: CartesianState,

--- a/crates/sidereon-core/src/astro/integrators/rk4.rs
+++ b/crates/sidereon-core/src/astro/integrators/rk4.rs
@@ -8,6 +8,14 @@ use crate::astro::propagator::result::{
 };
 use crate::astro::state::{CartesianState, StateDerivative};
 
+/// Fixed-step classical fourth-order Runge-Kutta integrator for Cartesian-state propagation.
+///
+/// [`Integrator::propagate`] limits [`IntegratorOptions::initial_step`] to the remaining absolute
+/// TDB span, applies its sign toward the target, and uses a final partial step when needed. Each
+/// completed step evaluates the dynamics four times; the result contains the initial point and
+/// either every completed-step endpoint or only the final point according to
+/// [`IntegratorOptions::dense_output`], leaves [`PropagationResult::dense`] as `None`, and
+/// validates finite epochs plus the final state and emitted points.
 pub struct RK4;
 
 impl Integrator for RK4 {

--- a/crates/sidereon-core/src/astro/math/least_squares.rs
+++ b/crates/sidereon-core/src/astro/math/least_squares.rs
@@ -316,7 +316,15 @@ pub enum SolveError {
     /// A boundary input or derived least-squares quantity was malformed.
     #[error("invalid least-squares {field}: {reason}")]
     InvalidInput {
+        /// Static label identifying the rejected input or derived quantity.
+        /// Direct checks pass labels such as `fd_step`, `residual`,
+        /// `jacobian`, `weights`, and `max_nfev`; mapped
+        /// [`crate::validate::FieldError`] values preserve their `field()`.
         field: &'static str,
+        /// Static condition paired with `field` in the formatted error.
+        /// Direct checks use conditions such as `empty`, `zero`, and
+        /// `length mismatch`; mapped [`crate::validate::FieldError`] values
+        /// preserve their `reason()` string.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/math/mod.rs
+++ b/crates/sidereon-core/src/astro/math/mod.rs
@@ -3,6 +3,9 @@ pub mod interp;
 pub mod least_squares;
 pub mod linear;
 pub mod mat3;
+/// Polynomial operations module within the mathematical subsystem.
+///
+/// Currently serves as a namespace placeholder with no exported items.
 pub mod polynomial;
 pub mod portable;
 pub mod robust;

--- a/crates/sidereon-core/src/astro/math/portable.rs
+++ b/crates/sidereon-core/src/astro/math/portable.rs
@@ -259,11 +259,13 @@ pub fn svd(matrix: &DMatrix<f64>, compute_u: bool, compute_v: bool) -> SVD<Porta
 }
 
 impl Portable {
+    /// Wraps a binary64 value without changing its bit pattern.
     #[inline]
     pub const fn new(value: f64) -> Self {
         Self(value)
     }
 
+    /// Returns the wrapped binary64 value without changing its bit pattern.
     #[inline]
     pub const fn get(self) -> f64 {
         self.0

--- a/crates/sidereon-core/src/astro/propagator/dense_output.rs
+++ b/crates/sidereon-core/src/astro/propagator/dense_output.rs
@@ -9,9 +9,15 @@ pub enum DenseOutputError {
     /// A segment query lies outside the segment's allowed time interval.
     #[error("Time {t} out of range [{t_start}, {t_end}] (theta={theta})")]
     SegmentOutOfRange {
+        /// Epoch supplied to [`DenseSegment::eval`] for the failed segment query.
+        /// This is the query value retained for the range-error message.
         t: f64,
+        /// Start epoch copied from the segment for the failed range query.
         t_start: f64,
+        /// Endpoint epoch computed as `t_start + h` for the failed range query.
         t_end: f64,
+        /// Normalized query coordinate computed by [`DenseSegment::eval`] as `(t - t_start) / h`.
+        /// For `|h| < 1e-18`, the evaluator uses `0.0` instead.
         theta: f64,
     },
     /// No dense segments are available for evaluation.
@@ -19,7 +25,16 @@ pub enum DenseOutputError {
     Empty,
     /// A collection query lies outside the covered time interval.
     #[error("Time {t} out of range [{t_min}, {t_max}]")]
-    OutputOutOfRange { t: f64, t_min: f64, t_max: f64 },
+    OutputOutOfRange {
+        /// Epoch supplied to [`DenseOutput::eval`] for the failed collection query.
+        t: f64,
+        /// Lower covered epoch, computed from the first segment start and last segment endpoint.
+        /// The evaluator reports this error only when the query is less than `t_min - 1e-7`.
+        t_min: f64,
+        /// Upper covered epoch, computed from the first segment start and last segment endpoint.
+        /// The evaluator reports this error only when the query is greater than `t_max + 1e-7`.
+        t_max: f64,
+    },
 }
 
 #[cfg(test)]

--- a/crates/sidereon-core/src/astro/propagator/dynamics.rs
+++ b/crates/sidereon-core/src/astro/propagator/dynamics.rs
@@ -4,7 +4,21 @@ use crate::astro::integrators::DynamicsModel;
 use crate::astro::propagator::api::PropagationContext;
 use crate::astro::state::{CartesianState, StateDerivative};
 
+/// Adapter that supplies Cartesian state rates from a [`ForceModel`].
+///
+/// [`crate::astro::propagator::StatePropagator`] constructs it around the force
+/// model selected for propagation, and [`DynamicsModel`] consumers request its
+/// derivative during [`crate::astro::integrators::RK4`] or
+/// [`crate::astro::integrators::DP54`] integration. The derivative uses the
+/// state's velocity as the position rate and the force model's returned
+/// acceleration as the velocity rate, returning any [`PropagationError`]
+/// unchanged.
 pub struct OrbitalDynamics<'a> {
+    /// Borrowed [`ForceModel`] used for acceleration evaluation.
+    ///
+    /// Each derivative call passes the current [`CartesianState`] and
+    /// [`PropagationContext`] to this model. Its returned vector becomes
+    /// [`StateDerivative::dvel_km_s2`].
     pub force_model: &'a dyn ForceModel,
 }
 

--- a/crates/sidereon-core/src/astro/propagator/mod.rs
+++ b/crates/sidereon-core/src/astro/propagator/mod.rs
@@ -1,11 +1,32 @@
+/// Propagation context and integrator configuration options.
+///
+/// Provides [`PropagationContext`] for passing optional body-fixed frame
+/// providers and [`IntegratorOptions`] for configuring tolerances and step sizes.
 pub mod api;
+/// Adaptive step-size controller for Runge-Kutta integration.
+///
+/// Implements [`PIController`](controller::PIController) using a Hairer/Wanner
+/// power-law factor to adjust signed integration steps based on normalized
+/// error estimates.
 pub mod controller;
 pub mod covariance;
 pub mod decay;
+/// Continuous polynomial interpolation along accepted integration steps.
+///
+/// Implements Shampine's fourth-order continuous extension for DP5(4),
+/// evaluated through [`DenseOutput`](dense_output::DenseOutput).
 pub mod dense_output;
 pub mod driver;
+/// Right-hand-side equations of motion for orbital states.
+///
+/// Provides [`OrbitalDynamics`], evaluating Cartesian position derivatives
+/// in km/s and force model accelerations in km/s².
 pub mod dynamics;
 pub mod numerical;
+/// Output structures returned by numerical integrators.
+///
+/// Defines [`PropagationResult`], discrete [`PropagationPoint`] trajectory
+/// samples at TDB epochs, and work counters in [`PropagationStats`].
 pub mod result;
 
 pub use crate::astro::forces::DragParameters;

--- a/crates/sidereon-core/src/astro/rf.rs
+++ b/crates/sidereon-core/src/astro/rf.rs
@@ -29,7 +29,13 @@ pub enum RfError {
     /// A public RF input was non-finite or outside its physical domain.
     #[error("invalid RF input {field}: {reason}")]
     InvalidInput {
+        /// Static label for the rejected input or non-finite computed output.
+        /// Input validators preserve names such as `distance_km` and
+        /// `frequency_hz`; output checks use labels such as `fspl_db` and
+        /// `link_margin_db`.
         field: &'static str,
+        /// Machine-readable validation result: `not finite`, `not positive`,
+        /// or `out of range`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/astro/sgp4/fit.rs
+++ b/crates/sidereon-core/src/astro/sgp4/fit.rs
@@ -62,8 +62,12 @@ const TAU: f64 = std::f64::consts::TAU;
 /// velocity.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FitSample {
+    /// UTC sample time as a split Julian date; the fraction must be in `[0, 1)`.
     pub epoch: JulianDate,
+    /// Target TEME position in kilometers, in the three-component order used by SGP4.
     pub position_teme_km: [f64; 3],
+    /// Optional target TEME velocity in kilometers per second; velocity fitting requires this
+    /// value on every sample or on none of them.
     pub velocity_teme_km_s: Option<[f64; 3]>,
 }
 
@@ -73,7 +77,9 @@ pub enum FitEpoch {
     /// The sample nearest the arc midpoint.
     #[default]
     Midpoint,
+    /// The first sample's epoch.
     First,
+    /// The last sample's epoch.
     Last,
     /// A specific sample index.
     Sample(usize),
@@ -84,11 +90,17 @@ pub enum FitEpoch {
 /// Pass-through TLE/OMM bookkeeping.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TleMetadata {
+    /// Catalog number copied to the generated TLE, OMM, and [`crate::astro::sgp4::ElementSet`].
     pub catalog_number: u32,
+    /// TLE and OMM classification; validation accepts only `U`, `C`, or `S`.
     pub classification: String,
+    /// TLE international designator; the OMM object identifier is derived from its trimmed text.
     pub international_designator: String,
+    /// Element-set number copied to the generated TLE and OMM.
     pub element_set_number: i32,
+    /// Revolution number at the fit epoch; it must fit the TLE `i32` field.
     pub rev_at_epoch: i64,
+    /// Object name copied to the generated OMM, including when it is empty.
     pub object_name: String,
 }
 
@@ -108,20 +120,35 @@ impl Default for TleMetadata {
 /// Configuration for [`fit_tle`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct FitConfig {
+    /// Selects the fit epoch from the sample arc.
     pub epoch: FitEpoch,
+    /// Whether B\* is an optimized variable instead of the fixed [`bstar_seed`](Self::bstar_seed).
     pub fit_bstar: bool,
+    /// Initial B\* value, and the fixed value when [`fit_bstar`](Self::fit_bstar) is false.
     pub bstar_seed: f64,
+    /// Whether velocity residual rows are included when the samples provide velocities.
     pub use_velocity: bool,
+    /// Positive multiplier for velocity residuals; `None` derives it from the seed mean motion.
     pub velocity_weight_s: Option<f64>,
+    /// Optional positive per-sample multipliers for both position and velocity residuals.
     pub weights: Option<Vec<f64>>,
+    /// SGP4 operation mode used for seed, trial, final-element, and TLE-satellite propagation.
     pub opsmode: OpsMode,
+    /// Optional positive solver cost tolerance; `None` keeps the trust-region default.
     pub ftol: Option<f64>,
+    /// Optional positive solver step tolerance; `None` keeps the trust-region default.
     pub xtol: Option<f64>,
+    /// Optional positive solver gradient tolerance; `None` keeps the trust-region default.
     pub gtol: Option<f64>,
+    /// Optional maximum solver function-evaluation count; zero is rejected.
     pub max_nfev: Option<usize>,
+    /// Optional positive solver parameter scaling; `None` selects [`XScale::Jac`].
     pub x_scale: Option<XScale>,
+    /// Residual-loss model passed to the trust-region solver.
     pub loss: Loss,
+    /// Positive scale passed to the selected residual-loss model.
     pub f_scale: f64,
+    /// Catalog and object metadata copied into the generated TLE and OMM.
     pub metadata: TleMetadata,
 }
 
@@ -150,17 +177,29 @@ impl Default for FitConfig {
 /// Fit diagnostics computed from the returned elements and encoded TLE.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FitStatistics {
+    /// RMS of full-precision fitted-element TEME position residuals, in kilometers.
     pub rms_position_km: f64,
+    /// Largest full-precision fitted-element TEME position residual, in kilometers.
     pub max_position_km: f64,
+    /// Per-axis RMS fitted-element TEME position residuals, in kilometers, ordered by component.
     pub rms_position_axes_km: [f64; 3],
+    /// RMS fitted-element TEME velocity residual, in kilometers per second, or `None` when unused.
     pub rms_velocity_km_s: Option<f64>,
+    /// Position RMS after the fitted elements are encoded and reparsed as a TLE.
     pub tle_rms_position_km: f64,
+    /// Trust-region result status; status 0 is returned through [`TleFitError::DidNotConverge`].
     pub status: i32,
+    /// Trust-region function-evaluation count.
     pub nfev: usize,
+    /// Trust-region Jacobian-evaluation count.
     pub njev: usize,
+    /// Trust-region objective cost.
     pub cost: f64,
+    /// Trust-region optimality measure.
     pub optimality: f64,
+    /// Whether the final Jacobian provides the configured relative B\* observability signal.
     pub bstar_observable: bool,
+    /// Number of accepted fixed-point corrections used to refine the initial seed.
     pub seed_refine_passes: usize,
 }
 
@@ -181,10 +220,15 @@ pub struct FitStatistics {
 /// `stats.tle_rms_position_km`).
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TleFit {
+    /// Full-precision fitted SGP4 elements at the resolved fit epoch.
     pub elements: ElementSet,
+    /// Fixed-width encoded TLE line 1 produced from [`elements`](Self::elements) and metadata.
     pub line1: String,
+    /// Fixed-width encoded TLE line 2 produced from [`elements`](Self::elements).
     pub line2: String,
+    /// OMM carrying the fitted SGP4 elements and the exact in-memory split epoch.
     pub omm: Omm,
+    /// Arc, encoded-TLE, solver, B\*, and seed-refinement diagnostics.
     pub stats: FitStatistics,
 }
 
@@ -192,34 +236,64 @@ pub struct TleFit {
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum TleFitError {
     #[error("fit arc has {samples} samples; need at least {needed}")]
-    ArcTooShort { samples: usize, needed: usize },
+    /// The input has fewer than three samples or too few residual rows for the active parameters.
+    ArcTooShort {
+        /// Number of samples supplied by the caller.
+        samples: usize,
+        /// Minimum sample count required by the failing validation branch.
+        needed: usize,
+    },
     #[error("fit input invalid: {field}: {reason}")]
+    /// A finite, positive, length, metadata, epoch, or domain validation failed.
     InvalidInput {
+        /// Static dotted path identifying the rejected input.
         field: &'static str,
+        /// Static text identifying the rejected condition.
         reason: &'static str,
     },
     #[error("sample epochs must be strictly increasing (violation at index {index})")]
-    EpochsNotIncreasing { index: usize },
+    /// A sample epoch is not strictly later than its predecessor.
+    EpochsNotIncreasing {
+        /// Zero-based index of the current sample that violates the ordering check.
+        index: usize,
+    },
     #[error("requested epoch lies outside the sample arc")]
+    /// An explicit [`FitEpoch::Jd`] lies before the first or after the last sample.
     EpochOutsideArc,
     #[error("velocities must be present on every sample or on none")]
+    /// Velocity fitting was requested for an arc with only some velocity values present.
     MixedVelocityPresence,
     #[error("target arc is not elliptical (ecc >= 1 at the seed epoch)")]
+    /// The seed state cannot be converted to finite positive semimajor-axis elliptical data.
     NotElliptical,
     #[error("seed inclination {inclination_deg} deg is too close to retrograde-equatorial")]
-    InclinationNearRetrograde { inclination_deg: f64 },
+    /// The seed inclination reaches the 179.5-degree retrograde-equatorial guard.
+    InclinationNearRetrograde {
+        /// Seed inclination in degrees at the guard threshold.
+        inclination_deg: f64,
+    },
     #[error("seed elements cannot propagate the arc at sample {epoch_index}: {source}")]
+    /// Seed satellite initialization or propagation failed before optimization.
     SeedPropagation {
+        /// Zero for seed initialization failure; otherwise the failed sample index.
         epoch_index: usize,
+        /// Underlying SGP4 initialization or propagation error.
         source: Sgp4Error,
     },
     #[error("solver error: {0}")]
+    /// The trust-region solver returned a [`TrfError`] instead of a result.
     Solver(TrfError),
     #[error("solver stopped at an infeasible point")]
+    /// The final solver vector or residual evaluation is infeasible.
     SolutionInfeasible,
     #[error("evaluation budget exhausted before convergence (best-effort result attached)")]
-    DidNotConverge { result: Box<TleFit> },
+    /// A buildable fit has solver status 0 and is returned for inspection as a best effort.
+    DidNotConverge {
+        /// Best-effort fit built before reporting non-convergence.
+        result: Box<TleFit>,
+    },
     #[error("fitted elements failed final validation: {0}")]
+    /// SGP4 rejected fitted elements, the reparsed TLE, or a final statistics propagation.
     FinalElements(Sgp4Error),
     /// The final fitted TLE elements could not be encoded as TLE text.
     #[error("fitted TLE failed encoding: {0}")]

--- a/crates/sidereon-core/src/astro/time/mod.rs
+++ b/crates/sidereon-core/src/astro/time/mod.rs
@@ -53,10 +53,16 @@ pub use scales::{
 /// model lives in [`model`].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Time {
+    /// Elapsed duration in seconds from 2000-01-01 12:00:00 TDB.
+    ///
+    /// Must be finite; validated on construction by [`Time::new`].
     pub seconds_since_j2000: f64,
 }
 
 impl Time {
+    /// Creates a new [`Time`] after validating that `seconds_since_j2000` is finite.
+    ///
+    /// Returns [`TimeModelError::InvalidInput`] if the value is NaN or infinite.
     pub fn new(seconds_since_j2000: f64) -> Result<Self, TimeModelError> {
         if !seconds_since_j2000.is_finite() {
             return Err(TimeModelError::InvalidInput {
@@ -69,6 +75,7 @@ impl Time {
         })
     }
 
+    /// Returns elapsed seconds since J2000 in Barycentric Dynamical Time (TDB).
     pub fn tdb(&self) -> f64 {
         self.seconds_since_j2000
     }

--- a/crates/sidereon-core/src/astro/time/model.rs
+++ b/crates/sidereon-core/src/astro/time/model.rs
@@ -23,7 +23,16 @@ pub enum TimeModelError {
     /// A public constructor received a non-finite or out-of-domain input.
     #[error("invalid time model {field}: {reason}")]
     InvalidInput {
+        /// Stable label naming the rejected input. `JulianDateSplit::new` reports `jd_whole` or
+        /// `fraction`, `Duration::from_seconds` reports `seconds`, [`GnssWeekTow`] methods report
+        /// `tow_s` or `rollovers`, and [`crate::astro::time::Time::new`] reports
+        /// `seconds_since_j2000`; translating adapters may prefix split-date labels for their own
+        /// errors.
         field: &'static str,
+        /// Stable message describing why the labeled input was rejected. It distinguishes
+        /// finiteness, residual range, nanosecond representability, week-carry range,
+        /// normalized-week range, and unrolled-week overflow checks, and error adapters preserve
+        /// it when converting the error.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/clock_stability/mod.rs
+++ b/crates/sidereon-core/src/clock_stability/mod.rs
@@ -428,31 +428,50 @@ pub enum AllanError {
     /// The input series has no samples.
     EmptySeries,
     /// The basic sampling interval is not finite and positive.
-    InvalidTau0 { tau0_s: f64 },
+    InvalidTau0 {
+        /// The non-finite or non-positive basic sampling interval supplied to the estimator, in seconds.
+        tau0_s: f64,
+    },
     /// No estimator was requested.
     NoEstimators,
     /// An explicit tau grid was empty.
     EmptyTauGrid,
     /// Averaging factors must be positive.
-    InvalidAveragingFactor { averaging_factor: usize },
+    InvalidAveragingFactor {
+        /// The zero averaging factor encountered during estimator evaluation.
+        averaging_factor: usize,
+    },
     /// A requested estimator has no valid term for this sample count.
     TooFewSamples {
+        /// The estimator being evaluated when candidate counting or term accumulation produced no usable terms.
         estimator: AllanEstimator,
+        /// The factor being evaluated when no usable term was available; the final empty-curve error uses `1` as its fallback.
         averaging_factor: usize,
+        /// Number of prepared phase samples used for candidate counting; fractional-frequency input includes its initial phase point.
         available_phase_samples: usize,
     },
     /// A sample was not finite.
-    NonFiniteSample { index: usize },
+    NonFiniteSample {
+        /// Source-series index of the non-finite value or the frequency sample whose integrated phase became non-finite.
+        index: usize,
+    },
     /// A missing sample was present under [`GapPolicy::Reject`].
-    Gap { index: usize },
+    Gap {
+        /// Source-series index of the missing entry rejected under [`GapPolicy::Reject`].
+        index: usize,
+    },
     /// The computed tau was not finite.
     NonFiniteTau {
+        /// Estimator for which `tau0_s * averaging_factor` was non-finite.
         estimator: AllanEstimator,
+        /// Averaging factor in the non-finite `tau0_s * averaging_factor` product.
         averaging_factor: usize,
     },
     /// The computed deviation was not finite.
     NonFiniteDeviation {
+        /// Estimator being evaluated when its deviation formula returned a non-finite result.
         estimator: AllanEstimator,
+        /// Averaging factor used by the non-finite deviation calculation.
         averaging_factor: usize,
     },
 }

--- a/crates/sidereon-core/src/id.rs
+++ b/crates/sidereon-core/src/id.rs
@@ -116,7 +116,11 @@ pub enum SatelliteIdError {
     /// The PRN is outside the documented range for its constellation.
     #[error("invalid GNSS satellite {field}: {reason}")]
     InvalidInput {
+        /// The rejected input name; [`GnssSatelliteId::new`] sets this to
+        /// `"prn"` for its constellation-specific range check.
         field: &'static str,
+        /// The diagnostic from [`GnssSatelliteId::new`] when the PRN fails the
+        /// [`GnssSystem`] range check: `"out of range for constellation"`.
         reason: &'static str,
     },
 }

--- a/crates/sidereon-core/src/ionex/tec_grid.rs
+++ b/crates/sidereon-core/src/ionex/tec_grid.rs
@@ -30,16 +30,28 @@ pub enum TecGridError {
     DimensionsOverflow,
     /// The number of values does not match the grid dimensions.
     #[error("TEC grid has {actual} values but expected {expected}")]
-    ValueCountMismatch { actual: usize, expected: usize },
+    ValueCountMismatch {
+        /// Number of values supplied to [`TecGrid::new`] when it did not match the checked product of the three axis lengths.
+        actual: usize,
+        /// Checked epoch-by-latitude-by-longitude axis-length product required for the flat value vector.
+        expected: usize,
+    },
     /// A named input failed a shared validation rule.
     #[error("{field} {reason}")]
     InvalidField {
+        /// Stable label returned by `validate::FieldError::field()` for the rejected input.
         field: &'static str,
+        /// Short reason returned by `validate::FieldError::reason()` for the rejected input.
         reason: &'static str,
     },
     /// A query lies outside the grid's interpolation bounds.
     #[error("{name} {value} is out of TEC grid bounds")]
-    OutOfBounds { name: &'static str, value: f64 },
+    OutOfBounds {
+        /// Axis label passed by `TecGrid::interpolate_vtec` for the query that exceeded an axis endpoint.
+        name: &'static str,
+        /// Query coordinate passed by `TecGrid::interpolate_vtec` that exceeded the named axis endpoint.
+        value: f64,
+    },
 }
 
 #[cfg(test)]

--- a/crates/sidereon-core/src/lib.rs
+++ b/crates/sidereon-core/src/lib.rs
@@ -113,6 +113,10 @@ mod rinex_qc; // RINEX observation/navigation lint and mechanical repair
 pub mod rtcm; // RTCM 3 differential-GNSS stream decode/encode (MSM, station, ephemeris)
 pub mod rtk; // RTK double-difference construction
 pub mod sbas;
+/// Provides the sans-I/O [`sbas_protection_levels`] API for calculating SBAS
+/// protection levels from caller-supplied [`ProtectionGeometry`] and
+/// [`SbasErrorModel`] inputs. Decoded SBAS messages and correction storage
+/// remain in [`crate::sbas`].
 pub mod sbas_pl; // SBAS single-hypothesis protection levels
 pub mod scenario; // scenario-driven synthetic GNSS observable generation
 pub mod sidereal; // repeating-geometry residual filtering and period diagnostics

--- a/crates/sidereon-core/src/nmea/mod.rs
+++ b/crates/sidereon-core/src/nmea/mod.rs
@@ -22,33 +22,63 @@ pub use sentence::{NmeaBody, NmeaSentence};
 pub use write::write_gga;
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
+/// Errors raised while framing, decoding, or writing an NMEA sentence.
+/// Forgiving stream entry points convert these errors into typed skips in their [`Diagnostics`].
 pub enum NmeaError {
     #[error("not an NMEA sentence: {reason}")]
-    NotFramed { reason: &'static str },
+    /// The input has no usable NMEA framing, contains a non-ASCII byte, exceeds the sentence length cap, or has a malformed checksum token.
+    NotFramed {
+        /// A parser reason such as `no NMEA start delimiter`, `sentence over length cap`, `non-ASCII byte`, or `malformed checksum`.
+        reason: &'static str,
+    },
     #[error("checksum mismatch: computed {computed:02X}, stated {stated:02X}")]
-    ChecksumMismatch { computed: u8, stated: u8 },
+    /// The XOR checksum calculated from the sentence body differs from the stated checksum.
+    ChecksumMismatch {
+        /// The checksum calculated by XORing the sentence body bytes.
+        computed: u8,
+        /// The hexadecimal checksum supplied after the sentence body.
+        stated: u8,
+    },
     #[error("unsupported sentence type {address}")]
-    UnsupportedType { address: String },
+    /// The delimiter is `!`, the address is not five bytes long, or its three-letter suffix is outside the supported sentence set.
+    UnsupportedType {
+        /// The rejected address, or `"encapsulated sentence"` for an `!` delimiter.
+        address: String,
+    },
     #[error("proprietary sentence {address}")]
-    Proprietary { address: String },
+    /// The address token begins with `P` and is proprietary rather than one of the supported standard sentence addresses.
+    Proprietary {
+        /// The proprietary address token beginning with `P`.
+        address: String,
+    },
     #[error("malformed field: {0}")]
+    /// A typed payload-field parser returned a [`FieldError`].
     MalformedField(#[from] FieldError),
     #[error("invalid input {field}: {reason}")]
+    /// A programmatic conversion or GGA-writing input failed validation.
     InvalidInput {
+        /// The input area rejected by the conversion or writer, such as `time`, `coordinate`, or `position`.
         field: &'static str,
+        /// The static validation or writer-contract message for the rejected input.
         reason: &'static str,
     },
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A decoded NMEA log containing only sentences accepted by [`parse_nmea`].
 pub struct NmeaLog {
+    /// Accepted sentences in input line order; rejected and blank lines are represented only in parser diagnostics.
     pub sentences: Vec<NmeaSentence>,
 }
 
+/// Parses one NMEA line into a typed sentence and its non-fatal framing diagnostics.
+/// Terminal CR/LF characters are trimmed, the optional checksum is validated before payload decoding, and framing or decoding failures are returned as [`NmeaError`].
 pub fn parse_sentence(line: &str) -> Result<Parsed<NmeaSentence>, NmeaError> {
     sentence::parse_framed(sentence::frame_sentence(line)?)
 }
 
+/// Parses an LF-delimited byte stream into accepted sentences and line-numbered diagnostics.
+/// A trailing CR is removed from each line, blank lines are ignored, invalid UTF-8 and sentence errors become skips, and accepted sentences remain in input order.
 pub fn parse_nmea(input: &[u8]) -> Parsed<NmeaLog> {
     let mut diagnostics = Diagnostics::new();
     let mut sentences = Vec::new();
@@ -79,10 +109,13 @@ pub fn parse_nmea(input: &[u8]) -> Parsed<NmeaLog> {
     Parsed::new(NmeaLog { sentences }, diagnostics)
 }
 
+/// Parses UTF-8 NMEA text with the same line handling and diagnostics as [`parse_nmea`].
 pub fn parse_nmea_str(text: &str) -> Parsed<NmeaLog> {
     parse_nmea(text.as_bytes())
 }
 
+/// Groups the accepted sentences in `log` into completed NMEA epochs.
+/// Snapshots closed while pushing sentences are returned in order, followed by the final open snapshot when one remains.
 pub fn group_epochs(log: &NmeaLog) -> Vec<EpochSnapshot> {
     let mut accumulator = NmeaAccumulator::new();
     let mut snapshots = Vec::new();

--- a/crates/sidereon-core/src/nmea/write.rs
+++ b/crates/sidereon-core/src/nmea/write.rs
@@ -5,6 +5,9 @@ use crate::format::fmtnum::fixed_decimals;
 use super::sentence::checksum_body;
 use super::{Gga, NmeaCoordinate, NmeaError, NmeaTalker, NmeaTime};
 
+/// Serializes the GGA fields in `gga` into a checksummed `$<talker>GGA,...*HH\r\n` sentence.
+/// An optional [`NmeaTime`] must have `decimals == 2` and nanoseconds on the centisecond grid, latitude and longitude must be supplied together, and [`NmeaTalker::code`] must accept `talker`; violations return [`NmeaError::InvalidInput`].
+/// The output uses the parser's GGA field order, preserves stored coordinate minute precision and derives hemisphere letters from `negative`, formats HDOP with two decimals and altitude, geoid separation, and differential age with one, pads satellite and station identifiers to widths 2 and 4, emits `M` for present height fields, XORs the address and fields for the checksum, and ends with `\r\n`.
 pub fn write_gga(talker: NmeaTalker, gga: &Gga) -> Result<String, NmeaError> {
     if let Some(time) = gga.time {
         if time.decimals != 2 {

--- a/crates/sidereon-core/src/ntrip/machine.rs
+++ b/crates/sidereon-core/src/ntrip/machine.rs
@@ -56,7 +56,11 @@ pub enum NtripEvent {
     /// A status, response classification, or malformed/oversized handshake input was rejected; emitting this event closes the machine.
     Rejected(NtripRejection),
     /// A chunked-body decoder or sourcetable parser failed; emitting this event closes the machine.
-    StreamCorrupted { detail: String },
+    StreamCorrupted {
+        /// Diagnostic message formatted from the underlying decoder or parser
+        /// error via [`core::fmt::Display`].
+        detail: String,
+    },
     /// A chunked data body reached its zero-size chunk and trailer terminator; the machine becomes closed after this event.
     StreamEnded,
 }

--- a/crates/sidereon-core/src/observation_qc/mod.rs
+++ b/crates/sidereon-core/src/observation_qc/mod.rs
@@ -84,7 +84,11 @@ pub enum IntervalSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum ObservationQcNote {
     /// Adjacent observation epochs were duplicate or out of order.
-    NonMonotonicEpoch { epoch_index: usize },
+    NonMonotonicEpoch {
+        /// Zero-based index of the later epoch in the observation sequence
+        /// that failed strict monotonicity (`delta_t <= 0.0`).
+        epoch_index: usize,
+    },
     /// No interval could be resolved.
     IntervalUnresolved,
 }

--- a/crates/sidereon-core/src/observation_qc/report_html.rs
+++ b/crates/sidereon-core/src/observation_qc/report_html.rs
@@ -5,6 +5,13 @@ use crate::format::fmtnum::fixed_decimals;
 use super::report_text::{format_epoch_time, format_vec3_m, severity_label, system_rows};
 use super::{IntervalSource, ObservationQcHeader, ObservationQcReport};
 
+/// Render an [`ObservationQcReport`] as a self-contained HTML document.
+///
+/// The result contains inline CSS and `Header`, `Per-Constellation`, and
+/// `Findings` sections: header metadata, shared formatted constellation rows,
+/// and finding code, severity, and specification-reference cells. Report
+/// text is HTML-escaped, optional header fields are omitted when absent or
+/// empty, and empty constellation or finding collections produce a `None` row.
 pub fn render_html(report: &ObservationQcReport) -> String {
     let mut out = String::new();
     out.push_str(

--- a/crates/sidereon-core/src/observation_qc/report_text.rs
+++ b/crates/sidereon-core/src/observation_qc/report_text.rs
@@ -11,6 +11,8 @@ use super::{
 
 const SNR_COL_WIDTH: usize = 96;
 
+/// Renders an [`ObservationQcReport`] as a plain-text `RINEX OBSERVATION QC +QC SUMMARY` report.
+/// The result contains a header, a fixed-width per-constellation table, and a findings section separated by blank lines; absent or empty header fields are omitted, SNR and multipath values use fixed-decimal formatting, and an empty findings list is printed as `NONE`.
 pub fn render_text(report: &ObservationQcReport) -> String {
     let mut out = String::new();
     writeln!(&mut out, "RINEX OBSERVATION QC +QC SUMMARY").expect("write to string");

--- a/crates/sidereon-core/src/precise_positioning/prep.rs
+++ b/crates/sidereon-core/src/precise_positioning/prep.rs
@@ -19,15 +19,25 @@ use crate::combinations::{self, IonosphereFreeError};
 /// Raw dual-frequency PPP observation used by wide-lane/narrow-lane prep.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualFrequencyObservation {
+    /// Satellite token produced by RINEX/QC and used to group samples into an arc.
     pub satellite_id: String,
+    /// Ambiguity-arc key retained by cycle-slip detection and replaced with a `sat#N` key for split PPP arcs.
     pub ambiguity_id: String,
+    /// First selected code pseudorange, in meters, used by the Melbourne-Wubbena, ionosphere-free, and `P1 - P2` TEC combinations.
     pub p1_m: f64,
+    /// Second selected code pseudorange, in meters, used by the Melbourne-Wubbena, ionosphere-free, and `P1 - P2` TEC combinations.
     pub p2_m: f64,
+    /// First selected carrier phase, in cycles; carrier helpers convert it with the first frequency for wide-lane, geometry-free, and ionosphere-free combinations.
     pub phi1_cyc: f64,
+    /// Second selected carrier phase, in cycles; carrier helpers convert it with the second frequency for wide-lane, geometry-free, and ionosphere-free combinations.
     pub phi2_cyc: f64,
+    /// First selected carrier frequency, in hertz, used to scale the first phase and derive frequency-dependent combinations.
     pub f1_hz: f64,
+    /// Second selected carrier frequency, in hertz, used to scale the second phase and derive frequency-dependent combinations.
     pub f2_hz: f64,
+    /// Optional first-band loss-of-lock value; detector bit 0 marks the observation as a cycle-slip candidate.
     pub lli1: Option<i64>,
+    /// Optional second-band loss-of-lock value; detector bit 0 marks the observation as a cycle-slip candidate.
     pub lli2: Option<i64>,
 }
 
@@ -36,79 +46,119 @@ pub struct DualFrequencyObservation {
 pub struct DualFrequencyEpoch {
     /// Comparable epoch coordinate in seconds for data-gap cycle-slip checks.
     pub gap_time_s: Option<f64>,
+    /// Complete dual-frequency records for this accepted input epoch; prep later sorts retained records by satellite and ambiguity id.
     pub observations: Vec<DualFrequencyObservation>,
 }
 
 /// One ionosphere-free PPP observation emitted by dual-frequency prep.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PreparedFloatObservation {
+    /// Satellite token copied from the retained raw observation.
     pub satellite_id: String,
+    /// Bare or split (`sat#N`) ambiguity key copied from the wide-lane arc preparation.
     pub ambiguity_id: String,
+    /// Ionosphere-free code combination of the two pseudoranges, in meters.
     pub code_m: f64,
+    /// Ionosphere-free carrier-phase combination evaluated from cycle-valued inputs, in meters.
     pub phase_m: f64,
 }
 
 /// One prepared ionosphere-free epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PreparedFloatEpoch {
+    /// Original index of the input dual-frequency epoch.
     pub epoch_index: usize,
+    /// Ionosphere-free observations for the retained ambiguities in this epoch, in deterministic satellite/id order.
     pub observations: Vec<PreparedFloatObservation>,
 }
 
 /// Wide-lane and narrow-lane prep controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct WideLanePrepOptions {
+    /// Minimum wide-lane sample count; short split segments are skipped and a short unsplit arc returns [`WideLanePrepError::TooFewWideLaneEpochs`].
     pub min_epochs: usize,
+    /// Maximum distance in wide-lane cycles between the sample mean and its rounded integer.
     pub tolerance_cycles: f64,
 }
 
 /// Public split-arc metadata for PPP ambiguity segmentation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PppSplitArc {
+    /// Satellite token of the segmented arc.
     pub satellite_id: String,
+    /// One-based split ambiguity key in the form `sat#N`.
     pub ambiguity_id: String,
+    /// Original input index of the segment's first sample.
     pub start_epoch_index: usize,
+    /// Original input index of the segment's last sample.
     pub end_epoch_index: usize,
+    /// Number of samples in the retained segment.
     pub n_epochs: usize,
 }
 
 /// Prepared dual-frequency PPP arc for the fixed wide-lane/narrow-lane path.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WideLanePrepResult {
+    /// Filtered epochs after wide-lane retention and ionosphere-free conversion.
     pub epochs: Vec<PreparedFloatEpoch>,
+    /// Narrow-lane wavelengths in meters, keyed by prepared ambiguity id.
     pub wavelengths_m: BTreeMap<String, f64>,
+    /// Narrow-lane offsets in meters, keyed by prepared ambiguity id.
     pub offsets_m: BTreeMap<String, f64>,
+    /// Rounded Melbourne-Wubbena wide-lane integer for each retained ambiguity id.
     pub wide_lane_cycles: BTreeMap<String, i64>,
+    /// Sorted, deduplicated satellite tokens removed by policy or by loss of every usable split segment.
     pub dropped_sats: Vec<String>,
+    /// Metadata for split segments that met the minimum length and produced a wide-lane integer.
     pub split_arcs: Vec<PppSplitArc>,
 }
 
 /// Error from PPP wide-lane/narrow-lane prep.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WideLanePrepError {
+    /// A detected slip was rejected instead of being dropped or split into a new ambiguity arc.
     CycleSlipDetected {
+        /// Satellite token of the arc containing the detected slip.
         satellite_id: String,
+        /// Original input epoch index at which the selected slip event occurred.
         epoch_index: usize,
+        /// Detector reasons retained for the selected event.
         reasons: Vec<SlipReason>,
     },
+    /// A raw sample could not be converted into a finite wide-lane cycle value.
     WideLaneFailed {
+        /// Bare or split ambiguity id whose sample failed.
         ambiguity_id: String,
+        /// Carrier-phase error returned while forming the sample's wide-lane value.
         reason: CarrierPhaseError,
     },
+    /// An arc had fewer usable wide-lane samples than the configured minimum.
     TooFewWideLaneEpochs {
+        /// Ambiguity id of the short arc.
         ambiguity_id: String,
+        /// Number of cycle samples supplied to the estimator.
         count: usize,
+        /// Minimum sample count requested by the prep options.
         minimum: usize,
     },
+    /// The wide-lane sample mean was outside the configured distance from an integer.
     WideLaneNotInteger {
+        /// Ambiguity id whose wide-lane mean failed the integer check.
         ambiguity_id: String,
+        /// Left-fold mean of the arc's Melbourne-Wubbena wide-lane samples.
         mean_cycles: f64,
+        /// Rounded integer candidate rejected by the tolerance check.
         fixed_cycles: i64,
     },
+    /// A prepared observation had no matching entry in the wide-lane integer map.
     MissingWideLaneAmbiguity(String),
+    /// Repeated observations for one ambiguity id disagreed on a selected carrier frequency.
     InconsistentFrequencies(String),
+    /// Narrow-lane parameter construction or an ionosphere-free code/phase combination failed.
     IonosphereFreeFailed {
+        /// Source satellite token for a code or phase failure; narrow-lane parameter failures leave this empty.
         satellite_id: String,
+        /// Underlying frequency or observation error from the ionosphere-free helper.
         reason: IonosphereFreeError,
     },
 }
@@ -117,28 +167,36 @@ pub enum WideLanePrepError {
 /// cycle-slip ambiguity-tagging.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatCycleSlipObservation {
+    /// Satellite token used to collect the observation into a detector arc.
     pub satellite_id: String,
+    /// Input ambiguity key retained when no slip tag is produced for this epoch and satellite.
     pub ambiguity_id: String,
+    /// Raw dual-frequency sample used by the detector when present; absent samples are omitted from detector input.
     pub raw: Option<DualFrequencyObservation>,
 }
 
 /// One float PPP epoch for cycle-slip ambiguity-tagging.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatCycleSlipEpoch {
+    /// Optional comparable time copied into detector samples for data-gap checks.
     pub gap_time_s: Option<f64>,
+    /// Float observations grouped by satellite for cycle-slip tagging.
     pub observations: Vec<FloatCycleSlipObservation>,
 }
 
 /// One tagged float PPP observation returned by cycle-slip prep.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloatCycleSlipTaggedObservation {
+    /// Satellite token copied from the input observation.
     pub satellite_id: String,
+    /// Detected `sat#N` segment id, or the input ambiguity id when no tag exists.
     pub ambiguity_id: String,
 }
 
 /// One tagged float PPP epoch returned by cycle-slip prep.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloatCycleSlipTaggedEpoch {
+    /// Tagged rows sorted lexicographically by satellite token and ambiguity id.
     pub observations: Vec<FloatCycleSlipTaggedObservation>,
 }
 /// Prepare raw dual-frequency PPP observations for the wide-lane then

--- a/crates/sidereon-core/src/precise_positioning/types.rs
+++ b/crates/sidereon-core/src/precise_positioning/types.rs
@@ -25,11 +25,18 @@ pub struct FloatObservation {
     pub satellite_id: String,
     /// Ambiguity state key. Split arcs use ids like `"G07#2"`.
     pub ambiguity_id: String,
+    /// Ionosphere-free code measurement in meters; the row builder subtracts
+    /// the modeled code range from it for the code prefit residual.
     pub code_m: f64,
+    /// Ionosphere-free phase measurement in meters; the row builder applies
+    /// phase bias and wind-up corrections before subtracting the modeled range
+    /// and ambiguity.
     pub phase_m: f64,
     /// Optional raw carrier frequencies, used by phase wind-up precompute when
     /// no explicit satellite ANTEX frequency pair is configured.
     pub freq1_hz: f64,
+    /// Second raw carrier frequency passed to correction precomputation for
+    /// phase-windup and code-bias ionosphere-free combinations.
     pub freq2_hz: f64,
     /// GLONASS FDMA frequency-channel number for this satellite, when known.
     pub glonass_channel: Option<i8>,
@@ -38,19 +45,37 @@ pub struct FloatObservation {
 /// One static PPP epoch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatEpoch {
+    /// Civil reception time copied into correction precomputation for
+    /// epoch-dependent tide, antenna-validity, and bias evaluation.
     pub epoch: CivilDateTime,
+    /// Whole part of the split Julian date used by the troposphere model to
+    /// construct its validated instant and VMF site-series MJD.
     pub jd_whole: f64,
+    /// Fractional part of the split Julian date paired with [`Self::jd_whole`]
+    /// for validated time conversion and VMF site-series lookup.
     pub jd_fraction: f64,
+    /// Receiver epoch in seconds from J2000, used for observable prediction,
+    /// correction precomputation, and regular-spacing detection.
     pub t_rx_j2000_s: f64,
+    /// Observations traversed in input order to build code/phase rows; an
+    /// elevation cutoff replaces this vector with only the retained rows.
     pub observations: Vec<FloatObservation>,
 }
 
 /// Initial static-arc state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatState {
+    /// Receiver seed and updated position in ECEF meters, passed to satellite
+    /// prediction and covariance extraction.
     pub position_m: [f64; 3],
+    /// One receiver-clock state in meters per epoch; the solve boundary requires
+    /// the vector length to equal the number of epochs.
     pub clocks_m: Vec<f64>,
+    /// Float ambiguity estimates in meters keyed by ambiguity id; the row
+    /// builder uses them for the estimated ambiguity columns.
     pub ambiguities_m: BTreeMap<String, f64>,
+    /// Residual zenith total delay state in meters, applied through the wet
+    /// mapping only when ZTD estimation is enabled.
     pub ztd_m: f64,
     /// North horizontal troposphere gradient state, in metres.
     pub tropo_gradient_north_m: f64,
@@ -65,18 +90,32 @@ pub struct FloatState {
 /// historical row scaling.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MeasurementWeights {
+    /// Inverse-sigma multiplier for code rows; it must be finite and positive.
     pub code: f64,
+    /// Inverse-sigma multiplier for phase rows; it must be finite and positive.
     pub phase: f64,
+    /// If true, multiplies each base weight by the sine-of-elevation scale,
+    /// floored at `1e-3` for non-finite or very low elevations.
     pub elevation_weighting: bool,
 }
 
 /// Iteration and convergence controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FloatSolveOptions {
+    /// Inclusive iteration cap; zero and values above the 10,000 PPP cap are
+    /// rejected before the solve loop starts.
     pub max_iterations: usize,
+    /// Maximum allowed norm of the three-component position update in meters
+    /// for a state-tolerance result.
     pub position_tolerance_m: f64,
+    /// Maximum absolute receiver-clock update in meters required for a
+    /// state-tolerance result.
     pub clock_tolerance_m: f64,
+    /// Maximum absolute estimated-ambiguity update in meters required for a
+    /// float state-tolerance result.
     pub ambiguity_tolerance_m: f64,
+    /// Maximum absolute ZTD update in meters; the fixed path also uses this
+    /// tolerance for each horizontal-gradient update component.
     pub ztd_tolerance_m: f64,
 }
 
@@ -99,18 +138,29 @@ impl Default for FloatSolveOptions {
 /// Troposphere controls.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TroposphereOptions {
+    /// Enables troposphere modeling; when false, the model returns zero slant,
+    /// ZTD-mapping, and gradient-mapping terms and skips meteorological checks.
     pub enabled: bool,
+    /// Adds one ZTD normal-equation state only when [`Self::enabled`] is also
+    /// true; otherwise the solution reports no ZTD residual.
     pub estimate_ztd: bool,
     /// Estimate constant north/east horizontal tropospheric gradients over a
     /// static PPP arc. This can help at sites with strong horizontal delay
     /// gradients, but is off by default because it adds two solve states.
     pub estimate_tropo_gradients: bool,
+    /// Meteorological input passed to the Saastamoinen slant-delay calculation
+    /// when enabled; pressure and temperature must be positive and humidity a
+    /// fraction.
     pub met: Met,
     /// Mapping function applied to the zenith delays and the estimated ZTD.
     pub mapping: TropoMapping,
 }
 
 impl TroposphereOptions {
+    /// Return the explicit all-off troposphere configuration.
+    ///
+    /// The returned meteorological values are standard-atmosphere placeholders;
+    /// the disabled model path does not consume them.
     pub fn disabled() -> Self {
         Self {
             enabled: false,
@@ -280,32 +330,53 @@ impl VmfSiteSeries {
 /// One ANTEX PCV sample.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PcvSample {
+    /// `None` marks a no-azimuth sample; `Some` places the sample in an azimuth
+    /// bracket for circular interpolation.
     pub azimuth_deg: Option<f64>,
+    /// Zenith angle in degrees, validated in the inclusive range 0..=180
+    /// before sorted zenith interpolation.
     pub zenith_deg: f64,
+    /// Receiver PCV correction in meters carried into the interpolated value
+    /// added to the PCO projection.
     pub value_m: f64,
 }
 
 /// Receiver antenna calibration at one frequency.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiverAntennaFrequency {
+    /// Frequency label searched by the configured signal selectors.
     pub label: String,
+    /// Receiver phase-center offset in local north/east/up meters, projected
+    /// onto the predicted line of sight before the two-frequency combination.
     pub pco_m: [f64; 3],
+    /// ANTEX PCV samples scanned into no-azimuth and azimuth-indexed grids; an
+    /// empty or unusable grid produces a missing receiver PCV correction.
     pub pcv_samples: Vec<PcvSample>,
 }
 
 /// Receiver antenna correction options.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiverAntennaOptions {
+    /// Label selecting the first receiver-frequency calibration record.
     pub freq1_label: String,
+    /// First carrier frequency in hertz used in the receiver antenna
+    /// ionosphere-free combination; it must be finite and positive.
     pub freq1_hz: f64,
+    /// Label selecting the second receiver-frequency calibration record.
     pub freq2_label: String,
+    /// Second carrier frequency in hertz used with [`Self::freq1_hz`] in the
+    /// receiver antenna ionosphere-free combination; it must differ from it.
     pub freq2_hz: f64,
+    /// Frequency calibration records searched by label for local PCO and PCV
+    /// data for each configured signal.
     pub frequencies: Vec<ReceiverAntennaFrequency>,
 }
 
 /// Fine satellite clock series, keyed by GPS seconds.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SatelliteClockCorrections {
+    /// Per-satellite `(GPS seconds, clock bias seconds)` records. Each series is
+    /// strictly increasing and is interpolated with one-interval endpoint bounds.
     pub series: BTreeMap<GnssSatelliteId, Vec<(f64, f64)>>,
 }
 
@@ -321,9 +392,17 @@ pub struct SatelliteClockCorrections {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct RangeCorrections {
+    /// Optional receiver antenna calibration; when present, both configured
+    /// frequency records and usable PCV data are required.
     pub receiver_antenna: Option<ReceiverAntennaOptions>,
+    /// Enables the relativistic satellite range term
+    /// `2 * dot(position, velocity) / c`; false contributes zero.
     pub sat_clock_relativity: bool,
+    /// Optional external CLK series used when an observable prediction has no
+    /// satellite clock; a missing series or time gap reports a clock error.
     pub satellite_clock: Option<SatelliteClockCorrections>,
+    /// Indexed tide, wind-up, antenna, and bias tables consumed by the row
+    /// model; enabled tables must contain each requested key.
     pub ppp: PppCorrectionLookup,
 }
 
@@ -342,9 +421,15 @@ impl RangeCorrections {
 /// Static float solve controls.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatSolveConfig {
+    /// Code/phase inverse-sigma weights copied into the solve model context.
     pub weights: MeasurementWeights,
+    /// Troposphere and optional ZTD/gradient controls copied into the solve
+    /// model context.
     pub tropo: TroposphereOptions,
+    /// Receiver, satellite-clock, tide, antenna, wind-up, and bias data queried
+    /// while assembling solve rows.
     pub corrections: RangeCorrections,
+    /// Iteration cap and state tolerances used by the float solve loop.
     pub opts: FloatSolveOptions,
     /// Optional PPP observation elevation cutoff in degrees.
     ///
@@ -354,6 +439,9 @@ pub struct FloatSolveConfig {
     /// ambiguity ids, residual rows, normal rows, or fixed ambiguity search are
     /// assembled.
     pub elevation_cutoff_deg: Option<f64>,
+    /// Enables leave-one-observation-per-satellite residual screening; a
+    /// screened solution is accepted only when its weighted RMS is less than
+    /// half the unscreened value.
     pub residual_screen: bool,
     /// Estimate one post-combination residual ionosphere state per ambiguity
     /// arc. This is disabled by default in repository configs and is intended
@@ -365,44 +453,81 @@ pub struct FloatSolveConfig {
 /// Indexed static PPP correction lookup tables.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PppCorrectionLookup {
+    /// ECEF solid-earth tide vectors keyed by zero-based epoch index and
+    /// projected with the negative line-of-sight dot product when enabled.
     pub tide: BTreeMap<usize, [f64; 3]>,
+    /// ECEF pole-tide vectors keyed by epoch index and projected with the
+    /// negative line-of-sight dot product when enabled.
     pub pole_tide: BTreeMap<usize, [f64; 3]>,
+    /// ECEF ocean-loading vectors keyed by epoch index and projected with the
+    /// negative line-of-sight dot product when enabled.
     pub ocean_loading: BTreeMap<usize, [f64; 3]>,
+    /// Ionosphere-free phase wind-up meters keyed by `(satellite, epoch index)`.
     pub windup_m: BTreeMap<(GnssSatelliteId, usize), f64>,
+    /// Ionosphere-free satellite PCO vectors in ECEF meters keyed by satellite
+    /// and epoch index, then projected onto the line of sight.
     pub sat_pco_ecef: BTreeMap<(GnssSatelliteId, usize), [f64; 3]>,
+    /// Ionosphere-free satellite PCV meters keyed by satellite and epoch index.
     pub sat_pcv_m: BTreeMap<(GnssSatelliteId, usize), f64>,
+    /// Clock-datum ionosphere-free code-bias meters keyed by satellite and
+    /// epoch index and inserted into the modeled code range.
     pub code_bias_m: BTreeMap<(GnssSatelliteId, usize), f64>,
+    /// HAS/SSR ionosphere-free code bias stored with the opposite sign of the
+    /// observation-side bias because the row model adds it to modeled code.
     pub ssr_code_bias_m: BTreeMap<(GnssSatelliteId, usize), f64>,
+    /// HAS/SSR ionosphere-free phase bias stored with observation-side sign and
+    /// added directly to the phase residual.
     pub phase_bias_m: BTreeMap<(GnssSatelliteId, usize), f64>,
+    /// Selects whether a solid-earth tide entry is required for each epoch.
     pub tide_enabled: bool,
+    /// Selects whether a pole-tide entry is required for each epoch.
     pub pole_tide_enabled: bool,
+    /// Selects whether an ocean-loading entry is required for each epoch.
     pub ocean_loading_enabled: bool,
+    /// Selects whether a phase wind-up entry is required for each satellite and
+    /// epoch.
     pub windup_enabled: bool,
+    /// Selects whether both satellite PCO and PCV entries are required.
     pub satellite_antenna_enabled: bool,
+    /// Selects whether a clock-datum code-bias entry is required.
     pub code_bias_enabled: bool,
+    /// Selects whether an SSR/HAS code-bias entry is required.
     pub ssr_code_bias_enabled: bool,
+    /// Selects whether an SSR/HAS phase-bias entry is required.
     pub phase_bias_enabled: bool,
 }
 
 /// SSR/HAS signal ids used to apply parsed per-signal biases to an IF PPP row.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SsrPppBiasSignalPair {
+    /// Signal id queried for the first code bias in the correction store.
     pub code1_signal: u8,
+    /// Signal id queried for the second code bias in the correction store.
     pub code2_signal: u8,
+    /// Signal id queried for the first phase bias in the correction store.
     pub phase1_signal: u8,
+    /// Signal id queried for the second phase bias in the correction store.
     pub phase2_signal: u8,
+    /// First carrier frequency used for the ionosphere-free bias combination.
     pub freq1_hz: f64,
+    /// Second carrier frequency paired with [`Self::freq1_hz`] for the
+    /// ionosphere-free bias combination.
     pub freq2_hz: f64,
 }
 
 /// Per-satellite and per-system default signal mapping for SSR/HAS PPP biases.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SsrPppBiasOptions {
+    /// Satellite-specific signal pairs checked first for each observation.
     pub per_satellite: BTreeMap<GnssSatelliteId, SsrPppBiasSignalPair>,
+    /// Fallback signal pairs selected by the observation satellite's GNSS
+    /// system when no satellite-specific pair exists.
     pub per_system: BTreeMap<GnssSystem, SsrPppBiasSignalPair>,
 }
 
 impl SsrPppBiasOptions {
+    /// Return the satellite-specific pair, or the pair configured for its GNSS
+    /// system when no satellite-specific entry exists.
     pub fn signal_pair(&self, sat: GnssSatelliteId) -> Option<SsrPppBiasSignalPair> {
         self.per_satellite
             .get(&sat)
@@ -412,6 +537,8 @@ impl SsrPppBiasOptions {
 }
 
 impl PppCorrectionLookup {
+    /// Convert precomputed correction vectors and scalars into indexed lookup
+    /// tables, copying option enablement and leaving SSR/HAS tables disabled.
     pub fn from_options(value: PppCorrections, options: &PppCorrectionsOptions) -> Self {
         Self::from_parts(
             value,
@@ -562,11 +689,18 @@ fn ionosphere_free_bias_m(b1_m: f64, b2_m: f64, f1_hz: f64, f2_hz: f64) -> f64 {
 /// Per-satellite residual row in the returned public solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FloatResidual {
+    /// Zero-based input-epoch index for this residual row.
     pub epoch_index: usize,
+    /// Public satellite token copied from the observation and used to group
+    /// temporal residual arcs.
     pub satellite_id: String,
+    /// Code prefit residual returned by the undifferenced row model.
     pub code_m: f64,
+    /// Phase prefit residual returned by the undifferenced row model.
     pub phase_m: f64,
+    /// Code inverse-sigma row weight, including optional elevation scaling.
     pub code_weight: f64,
+    /// Phase inverse-sigma row weight, including optional elevation scaling.
     pub phase_weight: f64,
 }
 
@@ -646,9 +780,17 @@ pub struct FloatSolution {
     /// Residual temporal-correlation estimate used by
     /// [`Self::temporal_position_covariance`].
     pub temporal_correlation: TemporalCorrelationSummary,
+    /// Final receiver-clock states in meters copied from [`FloatState`], with
+    /// one element required for each input epoch.
     pub epoch_clocks_m: Vec<f64>,
+    /// Final float ambiguity estimates in meters keyed by ambiguity id; fixed
+    /// resolution converts selected values to cycles with wavelength and offset.
     pub ambiguities_m: BTreeMap<String, f64>,
+    /// Post-combination ionosphere states when residual-ionosphere estimation is
+    /// enabled; otherwise this is an empty map.
     pub residual_ionosphere_m: BTreeMap<String, f64>,
+    /// Estimated residual zenith total delay when troposphere and ZTD estimation
+    /// are enabled; otherwise this is `None`.
     pub ztd_residual_m: Option<f64>,
     /// Estimated north horizontal troposphere gradient, in metres.
     pub tropo_gradient_north_m: Option<f64>,
@@ -659,51 +801,93 @@ pub struct FloatSolution {
     pub tropo_gradient_covariance_m2: Option<[[f64; 2]; 2]>,
     /// Unscaled formal covariance of north/east troposphere gradients.
     pub formal_tropo_gradient_covariance_m2: Option<[[f64; 2]; 2]>,
+    /// Returned residual rows in epoch and observation traversal order.
     pub residuals_m: Vec<FloatResidual>,
+    /// Sorted ambiguity ids collected from active observations and used as the
+    /// default fixed integer-search order.
     pub used_sats: Vec<String>,
+    /// Iteration counter retained from the float solve loop, which starts at 1.
     pub iterations: usize,
+    /// True only when the state-tolerance branch ended the float solve.
     pub converged: bool,
+    /// Records whether the float solve met state tolerances or reached its
+    /// iteration cap.
     pub status: FloatStatus,
+    /// Root-mean-square of the returned code prefit residuals.
     pub code_rms_m: f64,
+    /// Root-mean-square of the returned phase prefit residuals.
     pub phase_rms_m: f64,
+    /// Root-mean-square after each returned code and phase residual is
+    /// multiplied by its row weight.
     pub weighted_rms_m: f64,
 }
 
 /// Static PPP solve termination status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatStatus {
+    /// The current position, clock, ZTD, gradient, and ambiguity updates all
+    /// met their configured tolerances.
     StateTolerance,
+    /// The solve reached `max_iterations` before all active updates met their
+    /// configured tolerances.
     MaxIterations,
 }
 
 /// Static PPP solve errors.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FloatSolveError {
+    /// Observable prediction or a required satellite clock could not provide
+    /// the requested epoch.
     NoEphemeris {
+        /// Public satellite token for the failed observation.
         satellite_id: String,
+        /// Distinguishes absent ephemeris, an absent clock, and an upstream
+        /// prediction or media error.
         reason: NoEphemerisReason,
     },
+    /// The normal equations, covariance, or related geometry could not produce
+    /// a valid nonsingular result.
     SingularGeometry,
+    /// A receiver-clock vector does not contain one entry per input epoch.
     InvalidClockCount {
+        /// Number of clock entries required by the input epoch slice.
         expected: usize,
+        /// Number of clock entries supplied by the caller.
         actual: usize,
     },
+    /// An iteration or convergence option failed pre-solve validation.
     InvalidSolveOption {
+        /// Static option name reported by validation.
         field: &'static str,
+        /// Static reason the option was rejected.
         reason: &'static str,
     },
+    /// An epoch, observation, state, correction, covariance, or meteorological
+    /// input failed field-level validation.
     InvalidInput {
+        /// Static input label identifying the rejected value.
         field: &'static str,
+        /// Static validation reason paired with the input label.
         reason: &'static str,
     },
+    /// Elevation filtering left too few observations or fewer than four active
+    /// satellites for the configured PPP parameter layout.
     InsufficientObservationsAfterElevationCutoff {
+        /// Elevation threshold applied before row assembly.
         cutoff_deg: f64,
+        /// Number of observations remaining after filtering.
         retained_observations: usize,
+        /// Minimum retained count computed from the active PPP unknown count.
         required_observations: usize,
     },
+    /// An estimated ambiguity id was absent when an update or fixed conversion
+    /// required it.
     MissingAmbiguity(String),
+    /// An enabled correction lookup did not contain the required datum.
     MissingCorrection {
+        /// Public satellite token for the observation needing the datum.
         satellite_id: String,
+        /// Correction or receiver-antenna datum that was absent.
         correction: MissingCorrection,
     },
 }
@@ -752,18 +936,32 @@ impl core::fmt::Display for FloatSolveError {
 impl std::error::Error for FloatSolveError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Identifies the correction lookup or receiver-antenna datum missing from a
+/// PPP measurement row.
 pub enum MissingCorrection {
+    /// The epoch-indexed solid-earth tide vector was absent while enabled.
     SolidEarthTide,
+    /// The epoch-indexed pole-tide vector was absent while enabled.
     PoleTide,
+    /// The epoch-indexed ocean-loading vector was absent while enabled.
     OceanLoading,
+    /// The satellite/epoch phase wind-up value was absent while enabled.
     PhaseWindup,
+    /// The satellite/epoch satellite PCO vector was absent while enabled.
     SatelliteAntennaPco,
+    /// The satellite/epoch satellite PCV value was absent while enabled.
     SatelliteAntennaPcv,
+    /// The satellite/epoch clock-datum code bias was absent while enabled.
     CodeBias,
+    /// The satellite/epoch SSR/HAS code bias was absent while enabled.
     SsrCodeBias,
+    /// The satellite/epoch SSR/HAS phase bias was absent while enabled.
     PhaseBias,
+    /// The configured receiver frequency label had no matching calibration.
     ReceiverAntennaFrequency(String),
+    /// The configured receiver frequency had no usable PCV value.
     ReceiverAntennaPcv(String),
+    /// The satellite-to-receiver vector could not be normalized for projection.
     ReceiverAntennaGeometry,
 }
 
@@ -789,9 +987,15 @@ impl core::fmt::Display for MissingCorrection {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Explains why observable prediction or satellite-clock lookup could not supply
+/// a requested PPP epoch.
 pub enum NoEphemerisReason {
+    /// No ephemeris product covers the requested epoch.
     NoEphemeris,
+    /// Predicted or external satellite clock data is unavailable at the transmit
+    /// time.
     MissingSatelliteClock,
+    /// Formatted upstream invalid-input, ephemeris, or media error text.
     Reason(String),
 }
 
@@ -808,17 +1012,28 @@ impl core::fmt::Display for NoEphemerisReason {
 /// Integer ambiguity resolution controls for fixed PPP.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedAmbiguityOptions {
+    /// Per-ambiguity carrier wavelengths in meters used for meter/cycle
+    /// conversion and ambiguity covariance scaling; each value must be finite
+    /// and positive.
     pub wavelengths_m: BTreeMap<String, f64>,
+    /// Per-ambiguity meter offsets removed before float-to-cycle conversion and
+    /// added after integer cycles are converted back to meters.
     pub offsets_m: BTreeMap<String, f64>,
+    /// Acceptance threshold passed to the LAMBDA integer lattice search.
     pub ratio_threshold: f64,
 }
 
 /// Static fixed-ambiguity PPP solve controls.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedSolveConfig {
+    /// Code/phase inverse-sigma weights copied into the fixed solve context.
     pub weights: MeasurementWeights,
+    /// Troposphere and optional ZTD/gradient controls copied into the fixed
+    /// solve context.
     pub tropo: TroposphereOptions,
+    /// Correction tables reused for integer-search covariance and fixed rows.
     pub corrections: RangeCorrections,
+    /// Iteration cap and state tolerances used by the fixed re-solve.
     pub opts: FloatSolveOptions,
     /// Optional PPP observation elevation cutoff in degrees.
     ///
@@ -826,6 +1041,8 @@ pub struct FixedSolveConfig {
     /// path applies the cutoff before active ambiguity ids, integer covariance
     /// assembly, residual rows, and normal rows are built.
     pub elevation_cutoff_deg: Option<f64>,
+    /// Per-ambiguity wavelengths, offsets, and integer acceptance ratio used by
+    /// the LAMBDA search and the ambiguity-held re-solve.
     pub ambiguity: FixedAmbiguityOptions,
     /// Estimate one post-combination residual ionosphere state per ambiguity
     /// arc during the fixed re-solve.
@@ -833,28 +1050,45 @@ pub struct FixedSolveConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Records whether the integer lattice result passed its fixed-status condition.
 pub enum IntegerStatus {
+    /// The lattice resolver accepted an integer-fixed candidate.
     Fixed,
+    /// The lattice resolver returned candidates without accepting an integer fix.
     NotFixed,
 }
 
 /// Frozen ambiguity-search metadata returned with a fixed PPP solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AmbiguitySearch {
+    /// Ambiguity ids in the exact order supplied to the integer lattice search.
     pub order: Vec<String>,
+    /// Float ambiguity estimates converted from meters to cycles using the
+    /// configured wavelength and offset.
     pub float_cycles: BTreeMap<String, f64>,
+    /// Ambiguity covariance returned by the lattice resolver, in cycles squared
+    /// and ordered by [`Self::order`].
     pub covariance_cycles: Vec<Vec<f64>>,
+    /// Inverse ambiguity covariance returned by the lattice resolver in the same
+    /// order as [`Self::covariance_cycles`].
     pub covariance_inverse_cycles: Vec<Vec<f64>>,
 }
 
 /// Integer-search summary returned with a fixed PPP solution.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedIntegerMetadata {
+    /// Whether the integer lattice resolver accepted the selected candidate.
     pub integer_status: IntegerStatus,
+    /// Candidate score ratio returned by the integer lattice resolver.
     pub integer_ratio: f64,
+    /// Score of the best integer candidate.
     pub integer_best_score: f64,
+    /// Score of the second candidate, when the resolver evaluated one.
     pub integer_second_best_score: Option<f64>,
+    /// Number of integer candidates evaluated by the resolver.
     pub integer_candidates: usize,
+    /// Frozen order, float values, and covariance matrices from the lattice
+    /// search.
     pub ambiguity_search: AmbiguitySearch,
 }
 
@@ -902,10 +1136,20 @@ pub struct FixedSolution {
     /// Residual temporal-correlation estimate used by
     /// [`Self::temporal_position_covariance`].
     pub temporal_correlation: TemporalCorrelationSummary,
+    /// Final receiver-clock states in meters from the ambiguity-held fixed
+    /// re-solve, with one element required for each input epoch.
     pub epoch_clocks_m: Vec<f64>,
+    /// Selected integer ambiguity values keyed by ambiguity id and retained in
+    /// the integer-search order.
     pub fixed_ambiguities_cycles: BTreeMap<String, i64>,
+    /// Selected integer ambiguities converted to meters as offset plus integer
+    /// cycles times wavelength and held in every fixed phase row.
     pub fixed_ambiguities_m: BTreeMap<String, f64>,
+    /// Post-combination ionosphere states from the fixed re-solve when enabled;
+    /// otherwise this is an empty map.
     pub residual_ionosphere_m: BTreeMap<String, f64>,
+    /// Fixed re-solve residual ZTD when ZTD estimation is enabled; otherwise
+    /// this is `None`.
     pub ztd_residual_m: Option<f64>,
     /// Estimated north horizontal troposphere gradient, in metres.
     pub tropo_gradient_north_m: Option<f64>,
@@ -916,25 +1160,44 @@ pub struct FixedSolution {
     pub tropo_gradient_covariance_m2: Option<[[f64; 2]; 2]>,
     /// Unscaled formal covariance of north/east troposphere gradients.
     pub formal_tropo_gradient_covariance_m2: Option<[[f64; 2]; 2]>,
+    /// Original validated float solution carried alongside the fixed result.
     pub float_solution: FloatSolution,
+    /// Fixed re-solve residual rows in epoch and observation traversal order.
     pub residuals_m: Vec<FloatResidual>,
+    /// Ambiguity ids from the integer-search order, exposed in that same order.
     pub used_sats: Vec<String>,
+    /// Iteration counter from the ambiguity-held fixed re-solve.
     pub iterations: usize,
+    /// True when the fixed re-solve met all active state tolerances.
     pub converged: bool,
+    /// Records whether the fixed re-solve met state tolerances or reached its
+    /// iteration cap.
     pub status: FloatStatus,
+    /// Root-mean-square of the fixed code residuals.
     pub code_rms_m: f64,
+    /// Root-mean-square of the fixed phase residuals.
     pub phase_rms_m: f64,
+    /// Root-mean-square after fixed code and phase residuals are multiplied by
+    /// their row weights.
     pub weighted_rms_m: f64,
+    /// Integer-search metadata produced by the search that supplied the fixed
+    /// ambiguity values.
     pub integer: FixedIntegerMetadata,
 }
 
 /// Static fixed PPP solve errors.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FixedSolveError {
+    /// A float prerequisite, validation, prediction, correction, or normal
+    /// equation operation failed before or during fixed processing.
     Float(FloatSolveError),
+    /// The LAMBDA integer lattice search returned an [`IlsError`].
     Integer(IlsError),
+    /// The ambiguity id has no configured carrier wavelength.
     MissingWavelength(String),
+    /// The ambiguity id has no configured meter offset.
     MissingOffset(String),
+    /// A fixed ambiguity was expected but absent from the fixed result path.
     MissingFixedAmbiguity(String),
 }
 

--- a/crates/sidereon-core/src/reduced_orbit/mod.rs
+++ b/crates/sidereon-core/src/reduced_orbit/mod.rs
@@ -269,22 +269,38 @@ pub struct DriftReport {
 pub enum ReducedOrbitSource<'a> {
     /// Precise SP3 product plus the satellite to sample.
     Sp3 {
+        /// Product queried at each generated epoch; its header time scale
+        /// determines the scale used for sampling, and unavailable positions
+        /// are omitted.
         product: &'a Sp3,
+        /// GNSS ID passed to the product position lookup for every generated
+        /// epoch.
         satellite: GnssSatelliteId,
     },
     /// Initialized SGP4 satellite sampled in UTC.
-    Sgp4 { satellite: &'a Satellite },
+    Sgp4 {
+        /// Satellite propagated at each generated UTC epoch; failed
+        /// propagation or frame conversion omits that epoch.
+        satellite: &'a Satellite,
+    },
 }
 
 /// Sampling window and cadence for source-backed reduced-orbit drivers.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ReducedOrbitSourceSampling {
+    /// Start epoch validated in the source time scale and used as the first
+    /// generated step and the lower bound for piecewise fitting.
     pub t0: CalendarEpoch,
+    /// End epoch validated in the source time scale and used to bound generated
+    /// steps and piecewise fitting coverage.
     pub t1: CalendarEpoch,
+    /// Finite positive cadence in seconds. Generated offsets are rounded to
+    /// whole seconds before conversion back to calendar epochs.
     pub cadence_s: f64,
 }
 
 impl ReducedOrbitSourceSampling {
+    /// Store the sampling endpoints and cadence for a source driver.
     pub const fn new(t0: CalendarEpoch, t1: CalendarEpoch, cadence_s: f64) -> Self {
         Self { t0, t1, cadence_s }
     }
@@ -293,54 +309,92 @@ impl ReducedOrbitSourceSampling {
 /// Options for [`fit_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ReducedOrbitSourceFitOptions {
+    /// Sampling configuration used to produce source samples before fitting.
     pub sampling: ReducedOrbitSourceSampling,
+    /// Model passed to [`fit_with_model`] after source sampling.
     pub model: Model,
 }
 
 /// Options for [`drift_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ReducedOrbitSourceDriftOptions {
+    /// Sampling configuration used to produce truth samples for drift
+    /// evaluation.
     pub sampling: ReducedOrbitSourceSampling,
+    /// Meter threshold passed to [`drift`] or [`piecewise_drift`]; the first
+    /// error strictly greater than it is recorded as the crossing.
     pub threshold_m: f64,
 }
 
 /// Options for [`fit_piecewise_reduced_orbit_source`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PiecewiseOrbitSourceFitOptions {
+    /// Sampling configuration used to produce source samples; its endpoints
+    /// become the requested piecewise coverage bounds.
     pub sampling: ReducedOrbitSourceSampling,
+    /// Model passed to [`fit_piecewise`] for every segment.
     pub model: Model,
+    /// Requested segment length in seconds; it is validated, rounded to an
+    /// integer, and used to tile the piecewise coverage.
     pub segment_s: f64,
 }
 
 /// A source-backed single-model fit and its sampling metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReducedOrbitSourceFit {
+    /// [`ReducedOrbit`] returned by [`fit_with_model`] from the successfully
+    /// sampled source positions.
     pub orbit: ReducedOrbit,
+    /// Number of generated cadence steps, including steps whose source lookup
+    /// returned no position.
     pub requested_samples: usize,
 }
 
 /// A source-backed single-model drift report and its sampling metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReducedOrbitSourceDrift {
+    /// Report produced by [`drift`] or [`piecewise_drift`] over successfully
+    /// sampled source positions.
     pub report: DriftReport,
+    /// Number of generated cadence steps, rather than the number of retained
+    /// truth samples.
     pub requested_samples: usize,
 }
 
 /// A source-backed piecewise fit and its sampling metadata.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PiecewiseOrbitSourceFit {
+    /// [`PiecewiseOrbit`] returned by [`fit_piecewise`] from the successfully
+    /// sampled source positions.
     pub orbit: PiecewiseOrbit,
+    /// Number of generated cadence steps, including steps omitted because the
+    /// source had no position at that epoch.
     pub requested_samples: usize,
 }
 
 /// Error returned by source-backed reduced-orbit drivers.
 #[derive(Debug, Clone)]
 pub enum ReducedOrbitSourceError {
+    /// The source span is non-finite or non-positive, or the truncated cadence
+    /// count is non-finite or negative.
     InvalidWindow,
+    /// The requested source cadence is non-finite or not positive.
     InvalidCadence,
+    /// The requested segment length is non-finite, non-positive, rounds below
+    /// one second, or exceeds the `i64` range.
     InvalidSegment,
-    TooFewSamples { got: usize, required: usize },
+    /// No usable source positions remained for a source-driver drift path.
+    TooFewSamples {
+        /// Number of usable sampled positions; the empty-source paths set this
+        /// to zero.
+        got: usize,
+        /// Minimum usable positions required by the source-driver drift path;
+        /// the empty-source paths set this to one.
+        required: usize,
+    },
+    /// A single-model fit, evaluation, or source-epoch validation failed.
     Reduced(ReducedOrbitError),
+    /// A piecewise fit or piecewise drift evaluation failed.
     Piecewise(PiecewiseOrbitError),
 }
 

--- a/crates/sidereon-core/src/rinex_nav/mod.rs
+++ b/crates/sidereon-core/src/rinex_nav/mod.rs
@@ -849,15 +849,30 @@ impl core::fmt::Display for NavParseError {
 
 impl std::error::Error for NavParseError {}
 
+/// Diagnostic for a supported navigation block that lenient parsing could not decode or validate.
+/// The lenient parsers retain the block's satellite token and the [`NavParseError`] display text
+/// in [`Self::satellite`] and [`Self::message`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkippedNavBlock {
+    /// Satellite token associated with the failed supported block: v3 trims columns 0..3
+    /// of its first line, while v4 copies the SV token from the frame marker.
     pub satellite: String,
+    /// Display text of the [`NavParseError`] returned while parsing or validating the block.
     pub message: String,
 }
 
+/// Result of lenient RINEX navigation parsing.
+/// It keeps successfully parsed supported records and diagnostics for supported blocks that
+/// failed; header failures remain errors and unsupported systems or message rosters follow the
+/// parsers' skip policy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NavParse {
+    /// Successfully parsed supported records, in input order. A malformed supported block is
+    /// omitted here and reported in [`Self::skipped`].
     pub records: Vec<BroadcastRecord>,
+    /// Diagnostics for supported blocks whose parsing or marker validation returned a
+    /// [`NavParseError`]. Unsupported systems and explicitly skipped version-4 rosters do not add
+    /// entries.
     pub skipped: Vec<SkippedNavBlock>,
 }
 

--- a/crates/sidereon-core/src/rtk_filter/mod.rs
+++ b/crates/sidereon-core/src/rtk_filter/mod.rs
@@ -288,7 +288,17 @@ impl<'a> MeasContext<'a> {
 /// two maps separately.
 #[derive(Clone, Copy)]
 pub struct AmbiguityScale<'a> {
+    /// Carrier wavelengths in meters indexed by ambiguity identifier.
+    ///
+    /// Used to convert float ambiguities and covariance to cycles before
+    /// integer search, and to reconstruct fixed metric ambiguities. Missing
+    /// entries return [`FixedSolveError::MissingWavelength`].
     pub wavelengths_m: &'a BTreeMap<String, f64>,
+    /// Code-to-phase offsets in meters indexed by ambiguity identifier.
+    ///
+    /// Subtracted before cycle scaling and added back when reconstructing
+    /// fixed metric ambiguities. Missing entries return
+    /// [`FixedSolveError::MissingOffset`].
     pub offsets_m: &'a BTreeMap<String, f64>,
 }
 

--- a/crates/sidereon-core/src/sbas/mod.rs
+++ b/crates/sidereon-core/src/sbas/mod.rs
@@ -1,8 +1,37 @@
 #![warn(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
+/// Parse EMS and RTKLIB SBAS log lines into [`SbasLogBlock`] records.
+///
+/// EMS calendar components are converted to GPST, while RTKLIB lines provide
+/// GPST week and seconds-of-week directly. Recognized records retain input
+/// order and classify 29-byte bodies or 32-byte framed blocks; unrecognized
+/// lines are skipped, while invalid recognized epochs or block lengths return
+/// errors.
 pub mod format;
+
+/// Decode and encode SBAS body and CRC-framed wire blocks.
+///
+/// The decoder maps phase-A message IDs to typed [`SbasMessage`] records and
+/// retains other six-bit IDs as raw unsupported payloads. [`SbasBlock`] keeps
+/// the selected [`SbasWireForm`] so encoding can reproduce either form.
 pub mod message;
+
+/// Apply stored SBAS corrections through broadcast ephemeris source adapters.
+///
+/// The borrowed and owned adapters reject disabled source GEOs and withdrawn
+/// satellites, combine fresh fast and GPS long-term corrections when
+/// available, and otherwise follow [`SbasSolveMode`]. A selected GEO uses its
+/// stored navigation state with the available fast clock correction.
 pub mod source;
+
+/// Store SBAS corrections and navigation state partitioned by source GEO.
+///
+/// [`SbasCorrectionStore::ingest`] retains masks, fast and long-term
+/// corrections, GEO navigation, ionospheric grids, and withdrawal or disable
+/// state. Freshness policies govern correction lookups; ionospheric delay uses
+/// a 350-kilometer pierce-point shell with four-point or three-point
+/// interpolation, and broadcast PRNs 120 through 158 map to SBAS slots 20
+/// through 58.
 pub mod store;
 
 pub use format::{parse_ems_lines, parse_rtklib_lines, SbasLogBlock};

--- a/crates/sidereon-core/src/terrain.rs
+++ b/crates/sidereon-core/src/terrain.rs
@@ -25,13 +25,24 @@ const MAX_LOOKUP_LONGITUDE_DEG: f64 = 180.0;
 pub enum DtedTileError {
     /// The tile could not be read from disk.
     #[error("{path}: {message}")]
-    Io { path: String, message: String },
+    Io {
+        /// Display string of the path passed to [`DtedTile::from_path`].
+        path: String,
+        /// Text returned by the underlying filesystem read error.
+        message: String,
+    },
     /// The tile does not contain the fixed DTED header area.
     #[error("{path} is too short for DTED headers")]
-    TooShort { path: String },
+    TooShort {
+        /// Display string of the path passed to [`DtedTile::from_path`].
+        path: String,
+    },
     /// The tile does not start with the DTED UHL1 marker.
     #[error("{path} missing UHL1 header")]
-    MissingUhl1 { path: String },
+    MissingUhl1 {
+        /// Display string of the path passed to [`DtedTile::from_path`].
+        path: String,
+    },
     /// A fixed-width field was not valid UTF-8.
     #[error("{0}")]
     InvalidEncoding(String),
@@ -43,39 +54,57 @@ pub enum DtedTileError {
         "{path} has invalid DTED dimensions lon_count={lon_count} lat_count={lat_count}; both must be at least 2"
     )]
     InvalidDimensions {
+        /// Display string of the path passed to [`DtedTile::from_path`].
         path: String,
+        /// Longitude block count parsed from header bytes `47..51`.
         lon_count: usize,
+        /// Latitude posting count parsed from header bytes `51..55`.
         lat_count: usize,
     },
     /// The tile ends before its declared data blocks end.
     #[error("{path} has {actual} bytes but expected at least {expected}")]
     Truncated {
+        /// Display string of the path passed to [`DtedTile::from_path`].
         path: String,
+        /// Total number of bytes returned by `fs::read`.
         actual: usize,
+        /// Minimum length computed from the fixed data offset and declared blocks.
         expected: usize,
     },
     /// A query is outside this tile's one-degree extent.
     #[error("point ({longitude},{latitude}) is outside DTED tile ({origin_longitude},{origin_latitude})")]
     Outside {
+        /// Longitude supplied to [`DtedTile::get_elevation`].
         longitude: f64,
+        /// Latitude supplied to [`DtedTile::get_elevation`].
         latitude: f64,
+        /// Parsed tile origin longitude used by the containment check.
         origin_longitude: f64,
+        /// Parsed tile origin latitude used by the containment check.
         origin_latitude: f64,
     },
     /// A rounded query did not map to a declared posting.
     #[error("posting index out of bounds lon={longitude_index} lat={latitude_index}")]
     PostingIndexOutOfBounds {
+        /// Nearest longitude posting index computed from the query offset.
         longitude_index: usize,
+        /// Nearest latitude posting index computed from the query offset.
         latitude_index: usize,
     },
     /// A DTED data block is missing its sentinel byte.
     #[error("DTED block {longitude_index} missing data sentinel")]
-    MissingDataSentinel { longitude_index: usize },
+    MissingDataSentinel {
+        /// Zero-based longitude data-block index whose first byte was not `0xAA`.
+        longitude_index: usize,
+    },
     /// A DTED data block checksum does not match its contents.
     #[error("DTED checksum failed for block {longitude_index}: expected {checksum}, found {sum}")]
     Checksum {
+        /// Zero-based longitude data-block index whose checksum comparison failed.
         longitude_index: usize,
+        /// Signed big-endian `i32` decoded from the block's final four bytes.
         checksum: i32,
+        /// Signed `i32` sum of the bytes before the final four checksum bytes.
         sum: i32,
     },
     /// A coordinate field is empty.
@@ -83,10 +112,16 @@ pub enum DtedTileError {
     EmptyCoordinate,
     /// A coordinate field has an unsupported hemisphere suffix.
     #[error("invalid DTED hemisphere {hemisphere}")]
-    InvalidHemisphere { hemisphere: char },
+    InvalidHemisphere {
+        /// Final coordinate-field character that was not `N`, `E`, `S`, or `W`.
+        hemisphere: char,
+    },
     /// The rounded coordinate is negative and cannot be a posting index.
     #[error("cannot round negative posting index {index}")]
-    NegativePostingIndex { index: i64 },
+    NegativePostingIndex {
+        /// Signed nearest posting index that could not convert to `usize`.
+        index: i64,
+    },
 }
 
 #[cfg(test)]

--- a/crates/sidereon-core/src/tropo/zwd.rs
+++ b/crates/sidereon-core/src/tropo/zwd.rs
@@ -12,7 +12,11 @@ pub const TROPOSPHERE_ALTITUDE_CLAMP_M: (f64, f64) = (-500.0, 9000.0);
 /// Closed altitude interval used before evaluating the ZWD profile.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AltitudeClamp {
+    /// Lower endpoint, in meters, used when clamping a height for the wet profile.
+    /// The checked ZWD helpers require this value to be finite and no greater than `max_m`.
     pub min_m: f64,
+    /// Upper endpoint, in meters, used when clamping a height for the wet profile.
+    /// The checked ZWD helpers require this value to be finite and no less than `min_m`.
     pub max_m: f64,
 }
 
@@ -28,8 +32,13 @@ impl Default for AltitudeClamp {
 /// Exponential wet-delay profile.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ZwdProfile {
+    /// Closed altitude interval in meters applied before evaluating the wet profile.
     pub altitude_clamp: AltitudeClamp,
+    /// Zenith wet delay at zero altitude, in meters, before exponential scaling.
+    /// The checked helpers require this value to be finite and nonnegative.
     pub sea_level_zenith_wet_delay_m: f64,
+    /// Scale height in meters used as the denominator of the negative wet-delay exponent.
+    /// The checked helpers require this value to be finite and positive.
     pub wet_scale_height_m: f64,
 }
 
@@ -46,11 +55,15 @@ impl Default for ZwdProfile {
 /// Time input needed by the ZWD mapping variant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ZwdEpoch {
+    /// Unix timestamp in nanoseconds retained with the epoch; the XYZ ZWD helper does not read it.
     pub unix_nanos: i64,
+    /// Day number used by the Niell seasonal term, accepted in the inclusive range `1..=366`.
     pub day_of_year: u16,
 }
 
 impl ZwdEpoch {
+    /// Construct an epoch, rejecting a `day_of_year` outside `1..=366`.
+    /// The Unix timestamp and accepted day number are stored unchanged.
     pub fn new(unix_nanos: i64, day_of_year: u16) -> Result<Self> {
         validate_day_of_year(day_of_year)?;
         Ok(Self {
@@ -63,11 +76,15 @@ impl ZwdEpoch {
 /// Inputs controlling the XYZ ZWD slant-delay helper.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ZwdSlantOptions {
+    /// Epoch metadata for the XYZ calculation; its `day_of_year` drives the Niell seasonal term.
     pub epoch: ZwdEpoch,
+    /// Validated altitude and exponential wet-delay settings for the XYZ calculation.
     pub profile: ZwdProfile,
 }
 
 impl ZwdSlantOptions {
+    /// Construct XYZ ZWD options after validating the epoch day and wet-delay profile.
+    /// Returns [`crate::Error::InvalidInput`] when either validation fails.
     pub fn new(epoch: ZwdEpoch, profile: ZwdProfile) -> Result<Self> {
         validate_day_of_year(epoch.day_of_year)?;
         validate_profile(profile)?;
@@ -153,6 +170,13 @@ pub(crate) fn niell_mapping_function_unchecked(
     }
 }
 
+/// Compute the total ZWD-variant slant delay from satellite and receiver ECEF positions.
+///
+/// The two XYZ arrays are in meters. `ecef_to_lla` is called for the receiver and must return
+/// `[longitude_deg, latitude_deg, ellipsoidal_height_m]`; the height is clamped by the profile
+/// before standard-atmosphere Saastamoinen hydrostatic and exponential wet delays are mapped by
+/// the Niell factors. Invalid options, non-finite or degenerate vectors, or an invalid callback
+/// result return [`crate::Error::InvalidInput`].
 pub fn tropo_delay_xyz<F>(
     options: ZwdSlantOptions,
     sat_xyz: &[f64; 3],
@@ -208,6 +232,11 @@ fn saastamoinen_zhd(pressure_hpa: f64, latitude_deg: f64, altitude_m: f64) -> f6
     0.0022768 * pressure_hpa / (1.0 - 0.00266 * libm::cos(2.0 * lat_rad) - 2.8e-7 * altitude_m)
 }
 
+/// Evaluate the exponential zenith wet delay at a height in meters.
+///
+/// The height is clamped to the interval in `profile.altitude_clamp` before applying
+/// `sea_level_zenith_wet_delay_m * exp(-height_m / wet_scale_height_m)`. Invalid profile values
+/// or a non-finite height return [`crate::Error::InvalidInput`].
 pub fn zenith_wet_delay(profile: ZwdProfile, height_m: f64) -> Result<f64> {
     validate_profile(profile)?;
     validate_finite(height_m, "height_m")?;


### PR DESCRIPTION
Finishes the documentation program started in #30. Same method: for each file, read every producer and consumer of each undocumented item, record the code-established facts, then write the doc comment from those facts only. One commit per file.

This round covers the modules #30 left out, including the ones deferred while other lanes owned them: `precise_positioning/types.rs` (171 items), `astro/sgp4/fit.rs`, `precise_positioning/prep.rs`, `astro/almanac/mod.rs`, `astro/math/least_squares.rs`, `astro/math/portable.rs`, `terrain.rs`, `tropo/zwd.rs`, and the module-index files.

Docs state the algorithm and its reference where one exists (Shampine's continuous extension for the DP5(4) dense output, the Hairer/Wanner step controller), the function that establishes each value, units and frames, and the condition under which each error variant is returned.

No code changes: the only non-comment edits are the field reformatting rustfmt applies when a struct field gains a doc comment.

Gates: fmt, clippy `--workspace --all-targets -D warnings`, `cargo nextest run --workspace` (3,050 passed), and `RUSTDOCFLAGS='-D warnings' cargo doc -p sidereon-core --no-deps` clean.