### PR TITLE
release: 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "approx",
  "cc",

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -19,8 +19,8 @@ tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libm = "=0.2.16"
-sidereon = { path = "../sidereon", version = "1.4.1" }
-sidereon-core = { path = "../sidereon-core", version = "1.4.1" }
+sidereon = { path = "../sidereon", version = "2.0.0" }
+sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `sidereon-core` are documented here.
 
-## [Unreleased]
+## [2.0.0] - 2026-09-03
 
 ### Changed
 
@@ -37,13 +37,15 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Added
 
-- Reference documentation for 2,106 public items across 74 modules, written
-  from the code that produces and consumes each item: units, frames, bit
-  widths and scale factors for raw protocol fields, the header record or
-  function each value comes from, when an `Option` is `None`, and the
-  condition under which each error variant is returned. 522 items in 41
-  modules remain undocumented; `#![warn(missing_docs)]` stays off until they
-  are covered.
+- `#![warn(missing_docs)]` is enabled and clean: every public item in the crate
+  carries reference documentation stating units, frames, the function that
+  produces the value, and the condition under which each error variant is
+  returned.
+- Reference documentation for every public item in the crate, written from the
+  code that produces and consumes each one: units, frames, bit widths and scale
+  factors for raw protocol fields, the header record or function each value
+  comes from, when an `Option` is `None`, and the condition under which each
+  error variant is returned.
 - A supply-chain gate (`cargo deny`: advisories, licenses, bans, sources)
   runs in CI, together with an MSRV check at Rust 1.89. One advisory is an
   explicit, documented exception: RUSTSEC-2024-0436 (`paste`, an unmaintained

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "1.4.1"
+version = "2.0.0"
 authors = []
 edition = "2021"
 rust-version = "1.89"

--- a/crates/sidereon-core/src/lib.rs
+++ b/crates/sidereon-core/src/lib.rs
@@ -54,6 +54,7 @@
 //! (`DMatrix`/`DVector`) per the spec.
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(missing_docs)]
 
 extern crate self as sidereon_core;
 
@@ -112,6 +113,7 @@ mod rinex_obs; // RINEX 3 observation parsing + single-frequency pseudoranges
 mod rinex_qc; // RINEX observation/navigation lint and mechanical repair
 pub mod rtcm; // RTCM 3 differential-GNSS stream decode/encode (MSM, station, ephemeris)
 pub mod rtk; // RTK double-difference construction
+/// SBAS message decoding, corrections, and protection levels.
 pub mod sbas;
 /// Provides the sans-I/O [`sbas_protection_levels`] API for calculating SBAS
 /// protection levels from caller-supplied [`ProtectionGeometry`] and

--- a/crates/sidereon-core/src/rtk.rs
+++ b/crates/sidereon-core/src/rtk.rs
@@ -579,6 +579,9 @@ pub enum DoubleDifferenceError {
     ReferenceSatelliteSingleSystem(String),
     /// A per-system reference map omitted a constellation letter.
     ReferenceSatelliteMissingSystem(String),
+    /// No reference-selection path in this crate returns this variant. It is
+    /// retained because bindings match the enum exhaustively; a later release
+    /// may remove it.
     InvalidReferenceOption,
 }
 

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -12,5 +12,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "1.4.1" }
+sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "1.4.1"
+version = "2.0.0"
 authors = []
 edition = "2021"
 rust-version = "1.89"
@@ -17,7 +17,7 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "1.4.1" }
+sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
 crc32fast = "1"
 flate2 = "1"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "approx",
  "cc",


### PR DESCRIPTION
Version bump for the 2.0.0 release. `sidereon-core` and the `sidereon` facade go to 2.0.0 together, which the release workflow verifies against the tag.

## Why this is a major

- Public input structs (options, config, request) are `#[non_exhaustive]`, so external code constructs them through `Default`/`new` plus field assignment. The point is that every future option is a minor release instead of another major.
- `terrain`, `ionex::tec_grid` and `astro::propagator::dense_output` return typed error enums rather than `String`, with the message text unchanged.

## Also in this release

- `#![warn(missing_docs)]` is enabled and clean. The last two items are documented here: the `sbas` module, and a `DoubleDifferenceError` variant that no code path returns and which is documented as such rather than given an invented purpose (it stays because a binding matches it).
- Every public item in the crate carries reference documentation written from the code that produces and consumes it.
- The DTED bilinear precision fix, the OMM/SP3 stage refactors behind frozen output hashes, the parser panic audit, exact `nalgebra`/`simba`/`libm` pins, the `parallel` feature, the supply-chain gate, and the same-job hotpath performance gate.

## Gates

fmt, clippy `--workspace --all-targets -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc` with `missing_docs` on, `cargo nextest run --workspace` (3,050 passed), and `cargo check --all-targets` in the separate `fuzz` workspace.

Merging this and tagging `v2.0.0` publishes `sidereon-core` and `sidereon`. The five interface repos follow.