### PR TITLE
sp3: report the interpolator's run-edge reach, not the centered one

### DIFF
--- a/crates/sidereon-cli/tests/cli.rs
+++ b/crates/sidereon-cli/tests/cli.rs
@@ -181,8 +181,8 @@ fn inspect_sp3_window_prints_scoped_continuity_verdict() {
     let stdout = stdout(&output);
     assert!(stdout.contains("continuity: attested"), "{stdout}");
     assert!(stdout.contains("window_continuity: accept"), "{stdout}");
-    assert!(stdout.contains("stencil_before_s=1500"), "{stdout}");
-    assert!(stdout.contains("stencil_after_s=1500"), "{stdout}");
+    assert!(stdout.contains("stencil_before_s=3000"), "{stdout}");
+    assert!(stdout.contains("stencil_after_s=3000"), "{stdout}");
 }
 
 #[test]

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Fixed
 
+- `StencilExtent::for_sp3` reported the SP3 interpolator's reach as five
+  product intervals on each side, the centered interior stencil. At either end
+  of a contiguous run the interpolator keeps its 11 nodes and slides the window
+  inward, so a query in the final interval selects nodes up to ten intervals
+  back. The reach is now ten intervals, the widest stencil the interpolator can
+  select. The old value erred in the unsafe direction: a window-scoped
+  continuity verdict could report Accept for a defect sitting on a node the
+  interpolation actually used. Measured on the committed CODE final product,
+  perturbing a node 1,650 s before a query in the last interval moves the
+  interpolated position by 3.36 m while the reported reach was 1,500 s.
 - `GnssWeekTow::normalized` could return a time of week equal to a whole week
   instead of a value inside `[0, 604800)`. A TOW a fraction of a nanosecond
   before the week start borrows a week, and the borrow subtraction

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -146,9 +146,21 @@ pub struct StencilExtent {
 impl StencilExtent {
     /// Derive the interpolation reach for an SP3 product.
     ///
-    /// The degree-10 Lagrange substrate uses 11 nodes centered on the query, so
-    /// its nominal reach is five product intervals on either side. A non-finite
-    /// or non-positive declared interval is rejected.
+    /// The degree-10 Lagrange substrate uses 11 nodes. They are centered on the
+    /// query only in the interior of a contiguous run: near either end the
+    /// interpolator keeps the node count and slides the window inward, so the
+    /// stencil becomes one-sided. A query in the last interval of a run selects
+    /// the final 11 nodes, which reach back up to ten intervals rather than
+    /// five, and a query in the first interval reaches ten intervals forward.
+    ///
+    /// The reach reported here is therefore ten intervals on each side, the
+    /// widest window the interpolator can select anywhere in the product.
+    /// Reporting the centered five would understate it, and it understates it
+    /// in the unsafe direction: a window-scoped verdict such as
+    /// [`ContinuityReport::verdict_for_window`] would accept a window whose
+    /// interpolation selects a node the defect sits on.
+    ///
+    /// A non-finite or non-positive declared interval is rejected.
     pub fn for_sp3(sp3: &Sp3) -> Result<Self> {
         let interval_s = sp3.header.epoch_interval_s;
         if !interval_s.is_finite() || interval_s <= 0.0 {
@@ -166,28 +178,35 @@ impl StencilExtent {
                     "SP3 stencil extent requires at least one representable epoch".to_string(),
                 )
             })?;
-        let half_nodes = (NEVILLE_POINTS / 2) as f64;
-        let half_width_s = half_nodes * interval_s;
+        // The window slides but never shrinks, so the furthest a selected node
+        // can sit from the pivot is the full span of the stencil.
+        let widest_span_s = (NEVILLE_POINTS - 1) as f64 * interval_s;
         Ok(Self {
             grid_origin_j2000_s,
             interval_s,
-            before_s: half_width_s,
-            after_s: half_width_s,
+            before_s: widest_span_s,
+            after_s: widest_span_s,
         })
     }
 
-    /// Nominal reach before an evaluated epoch, seconds.
+    /// Reach before an evaluated epoch, seconds.
+    ///
+    /// The widest stencil the interpolator can select, which is the one it uses
+    /// at the end of a contiguous run, not the centered interior stencil.
     pub fn before_s(self) -> f64 {
         self.before_s
     }
 
-    /// Nominal reach after an evaluated epoch, seconds.
+    /// Reach after an evaluated epoch, seconds.
+    ///
+    /// The widest stencil the interpolator can select, which is the one it uses
+    /// at the start of a contiguous run, not the centered interior stencil.
     pub fn after_s(self) -> f64 {
         self.after_s
     }
 
-    /// Union of nominal grid nodes the interpolator can select for any query in
-    /// `window`.
+    /// Union of grid nodes the interpolator can select for any query in
+    /// `window`, covering the inward slide at a run edge.
     fn influence_bounds(self, window: EpochWindow) -> (f64, f64) {
         let pivot_at_or_before = |query: f64| {
             self.grid_origin_j2000_s

--- a/crates/sidereon-core/tests/sp3_window_continuity.rs
+++ b/crates/sidereon-core/tests/sp3_window_continuity.rs
@@ -120,8 +120,10 @@ fn merged_daily_window_verdict_flips_when_the_stencil_reaches_the_seam() {
 
     let stencil = StencilExtent::for_sp3(&merged).expect("merged-product stencil");
     assert_eq!(merged.header.epoch_interval_s, 300.0);
-    assert_eq!(stencil.before_s(), 1_500.0);
-    assert_eq!(stencil.after_s(), 1_500.0);
+    // Ten intervals, not five: the reach is the one-sided stencil the
+    // interpolator selects at a run edge, which is the widest it ever uses.
+    assert_eq!(stencil.before_s(), 3_000.0);
+    assert_eq!(stencil.after_s(), 3_000.0);
 
     let inside_one_day =
         EpochWindow::new(seam - 18.0 * 3_600.0, seam - 6.0 * 3_600.0).expect("inside-day window");
@@ -175,4 +177,70 @@ fn window_and_stencil_constructors_reject_invalid_axes() {
     let mut product = real_daily_product();
     product.header.epoch_interval_s = 0.0;
     assert!(StencilExtent::for_sp3(&product).is_err());
+}
+
+/// A defect that only the run-edge stencil can reach must still refuse.
+///
+/// The interpolator centers its 11 nodes on the query only in the interior of
+/// a run. For a query in the last interval it keeps the node count and slides
+/// the window inward, so the earliest selected node sits up to ten intervals
+/// back rather than five. A reach derived from the centered stencil reported
+/// 1,500 s here, and a defect 1,800 s before the window fell outside it while
+/// sitting inside the nodes the interpolator actually selects. That is the
+/// unsafe direction: the verdict said Accept for a window the defect moves.
+///
+/// Demonstrated on this product by perturbing a node 1,650 s before a query in
+/// the final interval and watching the interpolated position move by 3.36 m.
+#[test]
+fn a_defect_only_the_edge_stencil_reaches_still_refuses() {
+    let product = real_daily_product();
+    let epochs = product.epochs_j2000_seconds();
+    let interval_s = product.header.epoch_interval_s;
+    assert_eq!(interval_s, 300.0);
+    let n = epochs.len();
+    let sat = product.satellites()[0];
+
+    // Queries anywhere in the product's final interval.
+    let final_interval = EpochWindow::new(epochs[n - 2], epochs[n - 1]).expect("final interval");
+    let stencil = StencilExtent::for_sp3(&product).expect("product stencil");
+
+    // Six intervals before the window start: outside the centered five, inside
+    // the eleven nodes the interpolator selects at the run end (indices
+    // n-11 .. n-1 for any query past epochs[n-2]).
+    let reached_by_edge_stencil = epochs[n - 2] - 6.0 * interval_s;
+    let report = ContinuityReport {
+        defects: vec![ContinuityDefect::DuplicateEpoch {
+            sat,
+            epoch_j2000_s: reached_by_edge_stencil,
+            occurrences: 2,
+        }],
+        ..ContinuityReport::default()
+    };
+    let verdict = report.verdict_for_window(final_interval, stencil);
+    assert_eq!(
+        verdict.decision,
+        WindowContinuityDecision::Refuse,
+        "a node the edge stencil selects must count as influencing"
+    );
+    assert_eq!(verdict.influencing_defects.len(), 1);
+
+    // Eleven intervals before the window start is beyond even the edge
+    // stencil, so the corrected reach does not simply refuse everything.
+    let beyond_any_stencil = epochs[n - 2] - 11.0 * interval_s;
+    let report = ContinuityReport {
+        defects: vec![ContinuityDefect::DuplicateEpoch {
+            sat,
+            epoch_j2000_s: beyond_any_stencil,
+            occurrences: 2,
+        }],
+        ..ContinuityReport::default()
+    };
+    let verdict = report.verdict_for_window(final_interval, stencil);
+    assert_eq!(verdict.decision, WindowContinuityDecision::Accept);
+    assert!(verdict.influencing_defects.is_empty());
+    assert_eq!(
+        verdict.all_defects.len(),
+        1,
+        "the finding is still reported"
+    );
 }


### PR DESCRIPTION
Fixes finding 2 of the standalone SP3 continuity reproduction (`sp3-continuity-review`, against revision 44b9c8e).

## The defect

`StencilExtent::for_sp3` reported the position interpolator's reach as five product intervals on each side: the 11-node stencil centered on the query. That is only true in the interior of a contiguous run. At either end, `interpolate_position_neville` keeps its node count and slides the window inward (`start = run_hi - win`), so a query in the final interval selects the last 11 nodes, which reach back up to ten intervals rather than five.

The reach is now ten intervals, the widest stencil the interpolator can select anywhere in the product.

## Why it matters

`before_s`/`after_s` feed `influence_bounds`, which decides whether a recorded defect can enter a stencil the evaluation window uses. Understating the reach errs in the unsafe direction: the window-scoped verdict reported Accept for a defect sitting on a node the interpolation actually used.

Measured on the committed CODE final product: for a query halfway between the last two epochs, perturbing a single node 1,650 s earlier by 1 m moves the interpolated position by 3.36 m, while the reported reach was 1,500 s.

## Tests

- New: a `DuplicateEpoch` defect six intervals before the product's final interval must produce Refuse (outside the old reach, inside the nodes the run-end stencil selects), and one eleven intervals before must produce Accept, so the wider bound is shown not to refuse indiscriminately. Verified to fail on `main` at the Refuse assertion.
- Two existing pins of the old value move from 1,500 s to 3,000 s: the merged-day seam test and the CLI's printed `stencil_before_s`/`stencil_after_s`.

## Not in this PR

The reproduction's other two findings are requests rather than defects and are left for a decision: attributing a holdout violation to the sources of the nodes the interpolator actually selected rather than only the adjacent record (finding 1), and a per-satellite position/clock coverage API alongside the union epoch grid (finding 3).

## Gates

fmt, clippy `--workspace --all-targets -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc`, `cargo nextest run --workspace` (3,053 passed), mmap suite (2,864 passed).