### PR TITLE
sp3, time: close the holes a review found in the last two fixes

### DIFF
--- a/crates/sidereon-cli/tests/cli.rs
+++ b/crates/sidereon-cli/tests/cli.rs
@@ -181,8 +181,8 @@ fn inspect_sp3_window_prints_scoped_continuity_verdict() {
     let stdout = stdout(&output);
     assert!(stdout.contains("continuity: attested"), "{stdout}");
     assert!(stdout.contains("window_continuity: accept"), "{stdout}");
-    assert!(stdout.contains("stencil_before_s=3000"), "{stdout}");
-    assert!(stdout.contains("stencil_after_s=3000"), "{stdout}");
+    assert!(stdout.contains("stencil_before_s=3300"), "{stdout}");
+    assert!(stdout.contains("stencil_after_s=3300"), "{stdout}");
 }
 
 #[test]

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -7,10 +7,15 @@ All notable changes to `sidereon-core` are documented here.
 ### Added
 
 - `Sp3InterpolationOptions`, the policy an SP3 product's node series are read
-  with. Its one field, `gap_threshold_factor`, is the multiple of a satellite's
-  nominal spacing above which a consecutive node gap is a coverage gap; it was a
-  fixed 1.5 and that remains the default (`DEFAULT_GAP_THRESHOLD_FACTOR`), so
-  nothing moves for existing callers. `Sp3::with_interpolation_options` sets it
+  with. Its one setting, the gap threshold factor, is the multiple of a
+  satellite's nominal spacing above which a consecutive node gap is a coverage
+  gap; it was a fixed 1.5 and that remains the default
+  (`DEFAULT_GAP_THRESHOLD_FACTOR`, `Sp3InterpolationOptions::DEFAULT`), so
+  nothing moves for existing callers. The value is private and set only through
+  `new`, which requires finite and greater than 1.0. A factor large enough to
+  admit nodes so far from the query that they are no longer distinct at its
+  precision makes interpolation return `Error::InvalidInput` instead of a
+  position; previously unreachable, since 1.5 never admitted such nodes. `Sp3::with_interpolation_options` sets it
   on a product; `PreciseEphemerisInterpolant::from_sp3`, `StencilExtent::for_sp3`
   and a store written from the product carry it, `PreciseEphemerisSamples` and
   `PreciseEphemerisInterpolant` take it directly, and

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `sidereon-core` are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- `Sp3InterpolationOptions`, the policy an SP3 product's node series are read
+  with. Its one field, `gap_threshold_factor`, is the multiple of a satellite's
+  nominal spacing above which a consecutive node gap is a coverage gap; it was a
+  fixed 1.5 and that remains the default (`DEFAULT_GAP_THRESHOLD_FACTOR`), so
+  nothing moves for existing callers. `Sp3::with_interpolation_options` sets it
+  on a product; `PreciseEphemerisInterpolant::from_sp3`, `StencilExtent::for_sp3`
+  and a store written from the product carry it, `PreciseEphemerisSamples` and
+  `PreciseEphemerisInterpolant` take it directly, and
+  `ContinuityOptions::with_interpolation_options` applies it to the hold-out
+  replay. The policy is not SP3 text: it does not survive `to_sp3_string`, it is
+  excluded from product equality, and `merge` output carries the default. The
+  precise-interpolant store records a non-default factor in previously reserved
+  header bytes 48..56; a default-policy artifact is byte-identical to one
+  written before, an artifact written before reads back as the default, and a
+  factor that is not finite and greater than 1.0 is rejected at open.
+
 ### Fixed
 
 - `StencilExtent::for_sp3` reported the SP3 interpolator's reach as five

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -7,30 +7,39 @@ All notable changes to `sidereon-core` are documented here.
 ### Fixed
 
 - `StencilExtent::for_sp3` reported the SP3 interpolator's reach as five
-  product intervals on each side, the centered interior stencil. At either end
-  of a contiguous run the interpolator keeps its 11 nodes and slides the window
-  inward, so a query in the final interval selects nodes up to ten intervals
-  back. The reach is now ten intervals, the widest stencil the interpolator can
-  select. The old value erred in the unsafe direction: a window-scoped
-  continuity verdict could report Accept for a defect sitting on a node the
-  interpolation actually used. Measured on the committed CODE final product,
-  perturbing a node 1,650 s before a query in the last interval moves the
-  interpolated position by 3.36 m while the reported reach was 1,500 s.
-- `GnssWeekTow::normalized` could return a time of week equal to a whole week
-  instead of a value inside `[0, 604800)`. A TOW a fraction of a nanosecond
-  before the week start borrows a week, and the borrow subtraction
-  `tow - (-1 * 604800)` rounds back up to exactly 604800, because binary64
-  spacing there is about 1.16e-10. The rounded result now carries into the
-  following week. RINEX 4 CNAV records reached this through the `top` field:
-  the pair serialized as week `w` with TOW 604800, which reparsed as week
-  `w + 1` with TOW 0, so a second encode differed from the first. Found by the
-  `rinex_nav_round_trip` fuzz target; the reproducer is kept in the committed
-  corpus.
-- The RINEX navigation writer now normalizes the `top` pair it is about to
-  write rather than the one it holds. The `D19.12` column rounds to twelve
-  mantissa digits, so a TOW just under the week length is written as a full
-  week regardless of how it was stored, and `GnssWeekTow` has public fields
-  that a caller can set outside the normalized range.
+  product intervals on each side, the centered interior stencil. The
+  interpolator selects up to 11 nodes from each satellite's own node series:
+  at a run edge it keeps the count and slides the window inward (ten spacings
+  back for a query in the last interval), it still serves a query one spacing
+  outside a run (eleven spacings to the farthest node), and the spacing is the
+  satellite's, so a satellite sampled every 600 s in a 300 s product spans
+  6,000 s. The reach is now eleven times the widest per-satellite nominal
+  spacing, estimated with the interpolator's own estimator, and the influence
+  bounds are measured from the window bounds instead of a header-grid snap
+  that could move the upper bound earlier than a selected node. The old value
+  erred in the unsafe direction: a window-scoped verdict could report Accept
+  for a defect on a node the interpolation used. Measured on the committed
+  CODE final product, perturbing a node 1,650 s before a query in the last
+  interval moves the interpolated position by 3.36 m.
+- `GnssWeekTow::normalized` could return a time of week outside `[0, 604800)`.
+  A TOW a fraction of a nanosecond before the week start borrows a week, and
+  the borrow subtraction `tow - (-1 * 604800)` rounds back up to exactly
+  604800, because binary64 spacing there is about 1.16e-10; the rounded result
+  now carries into the following week. A negative subnormal TOW never borrowed
+  at all, because dividing it by the week length underflows to -0.0; it now
+  lands on the week start. RINEX 4 CNAV records reached the first case through
+  the `top` field: the pair serialized as week `w` with TOW 604800, which
+  reparsed as week `w + 1` with TOW 0, so a second encode differed from the
+  first. Found by the `rinex_nav_round_trip` fuzz target; the reproducer is in
+  the committed corpus. Correcting the pair also corrects the CNAV `dt_op`
+  term that subtracts weeks and TOW separately, which for the affected records
+  shifts the URA by a few ulp.
+- The RINEX navigation writer now normalizes the `top` pair as it will be
+  written rather than as stored, and repeats that on the normalized value,
+  because normalizing `(9, -1e-8)` yields `(8, 604799.99999999)`, which the
+  `D19.12` column writes as a full week again. `GnssWeekTow` has public fields
+  that a caller can set outside the normalized range, so the writer cannot rely
+  on its input being normalized.
 
 ## [2.0.0] - 2026-09-03
 

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -8,19 +8,19 @@ All notable changes to `sidereon-core` are documented here.
 
 - `StencilExtent::for_sp3` reported the SP3 interpolator's reach as five
   product intervals on each side, the centered interior stencil. The
-  interpolator selects up to 11 nodes from each satellite's own node series:
-  at a run edge it keeps the count and slides the window inward (ten spacings
-  back for a query in the last interval), it still serves a query one spacing
-  outside a run (eleven spacings to the farthest node), and the spacing is the
-  satellite's, so a satellite sampled every 600 s in a 300 s product spans
-  6,000 s. The reach is now eleven times the widest per-satellite nominal
-  spacing, estimated with the interpolator's own estimator, and the influence
-  bounds are measured from the window bounds instead of a header-grid snap
-  that could move the upper bound earlier than a selected node. The old value
-  erred in the unsafe direction: a window-scoped verdict could report Accept
-  for a defect on a node the interpolation used. Measured on the committed
-  CODE final product, perturbing a node 1,650 s before a query in the last
-  interval moves the interpolated position by 3.36 m.
+  interpolator selects up to 11 nodes from each satellite's own node series,
+  slides that window inward at run edges, serves a query up to one nominal
+  spacing outside a run or across a coverage gap, and tolerates gaps up to 1.5
+  times the nominal spacing inside a run, so eleven nodes at 0, 600, 1500, ...,
+  8700 s span 8,700 s although their nominal spacing is 600 s. The reach is now
+  the widest selectable window span over the product's satellites plus one
+  nominal spacing, computed with the interpolator's own run and window rules,
+  and the influence bounds are measured from the window bounds instead of a
+  header-grid snap that could move the upper bound earlier than a selected
+  node. The old value erred in the unsafe direction: a window-scoped verdict
+  could report Accept for a defect on a node the interpolation used. A wider
+  reach means more Refuse decisions near recorded defects; `StencilExtent`
+  compares equal for products with equal reach.
 - `GnssWeekTow::normalized` could return a time of week outside `[0, 604800)`.
   A TOW a fraction of a nanosecond before the week start borrows a week, and
   the borrow subtraction `tow - (-1 * 604800)` rounds back up to exactly

--- a/crates/sidereon-core/src/astro/time/model.rs
+++ b/crates/sidereon-core/src/astro/time/model.rs
@@ -275,6 +275,13 @@ impl GnssWeekTow {
                 .ok_or_else(|| invalid_input("tow_s", "week carry is out of range"))?;
             tow = 0.0;
         }
+        // A negative subnormal TOW never borrows: dividing it by the week
+        // length underflows to -0.0, whose floor is -0.0, so it survives the
+        // carry above still negative. It is closer to the week start than any
+        // representable offset from it, and that is where it belongs.
+        if tow < 0.0 {
+            tow = 0.0;
+        }
         if week < 0 {
             week = 0;
             tow = 0.0;
@@ -320,6 +327,7 @@ mod tests {
             -1.0e-12,
             -1.0e-11,
             -f64::MIN_POSITIVE,
+            -f64::from_bits(1),
         ] {
             let normalized = GnssWeekTow::new(TimeScale::Gpst, 9, tow)
                 .expect("valid week/TOW")

--- a/crates/sidereon-core/src/ephemeris.rs
+++ b/crates/sidereon-core/src/ephemeris.rs
@@ -63,6 +63,7 @@ pub use crate::sp3::{
     MergeContinuityViolation, MergeProvenance, PrecedenceTransition, ProvenanceMode,
     TransitionReason,
 };
+pub use crate::sp3::{Sp3InterpolationOptions, DEFAULT_GAP_THRESHOLD_FACTOR};
 pub use crate::spp::EphemerisSource;
 use crate::{validate, GnssSatelliteId, GnssSystem};
 

--- a/crates/sidereon-core/src/rinex_nav/tests.rs
+++ b/crates/sidereon-core/src/rinex_nav/tests.rs
@@ -2489,6 +2489,43 @@ fn cnav_top_borrowing_a_week_reaches_a_stable_encoding() {
     );
 }
 
+/// The writer must reach a fixed point for `top` pairs a caller sets directly,
+/// outside the normalized range, because `GnssWeekTow` has public fields and a
+/// constructor that does not normalize. This protects the writer's own
+/// normalization independently of `GnssWeekTow::normalized`: with the model
+/// fixed and the writer reverted, this still fails.
+#[test]
+fn cnav_top_set_outside_the_week_still_reaches_a_stable_encoding() {
+    let mut text = String::from(V4_NAV_HEADER);
+    text.push_str("> EPH G03 CNAV\n");
+    push_owned_lines(&mut text, &cnav_lines("G03"));
+    let mut records = parse_nav(&text).expect("parse CNAV record");
+
+    // (a) a tiny negative TOW that normalizes to a value the column rounds
+    //     back up to a full week; (b) a TOW of exactly one week.
+    for (week, tow_s) in [(9_u32, -1.0e-8_f64), (8, 604_800.0)] {
+        let cnav = records[0]
+            .cnav
+            .as_mut()
+            .expect("CNAV record carries cnav data");
+        cnav.top = GnssWeekTow::new(TimeScale::Gpst, week, tow_s).expect("finite TOW");
+        let encoded = encode_nav(&records);
+        let reparsed = parse_nav(&encoded).expect("reparse encoded CNAV record");
+        assert_eq!(
+            encode_nav(&reparsed),
+            encoded,
+            "top ({week}, {tow_s:?}) must encode to a fixed point"
+        );
+        let top = reparsed[0].cnav.expect("cnav").top;
+        assert!(
+            (0.0..SECONDS_PER_WEEK).contains(&top.tow_s),
+            "reparsed top must hold a seconds-of-week value, got ({}, {:?})",
+            top.week,
+            top.tow_s
+        );
+    }
+}
+
 #[test]
 fn cnav_records_round_trip_through_rinex4_writer() {
     let mut text = String::from(V4_NAV_HEADER);

--- a/crates/sidereon-core/src/rinex_nav/write.rs
+++ b/crates/sidereon-core/src/rinex_nav/write.rs
@@ -301,28 +301,46 @@ pub(super) fn push_d19_12(out: &mut String, value: f64) {
 
 /// The `(week, TOW)` pair as it will read back after serialization.
 ///
-/// [`push_d19_12`] rounds to twelve mantissa digits, so a TOW a fraction of a
-/// microsecond below the end of the week is written as exactly
+/// [`push_d19_12`] keeps twelve fractional mantissa digits, so a TOW within a
+/// tenth of a microsecond of the week boundary is written as exactly
 /// `604800.000000000000`. The parser normalizes that into the next week, which
-/// makes the raw pair a non-fixed point: encoding it once yields week `w` and
-/// TOW 604800, and encoding what that parses to yields week `w + 1` and TOW 0.
-/// Normalizing the rounded pair here, rather than the stored one, keeps
-/// `encode(parse(encode(x))) == encode(x)`.
+/// makes the stored pair a non-fixed point: encoding it once yields week `w`
+/// and TOW 604800, and encoding what that parses to yields week `w + 1` and
+/// TOW 0. Normalizing the pair as it will be written, rather than as stored,
+/// keeps `encode(parse(encode(x))) == encode(x)`.
+///
+/// Normalizing can itself land back on the boundary: a stored `(9, -1e-8)`
+/// normalizes to `(8, 604799.99999999)`, which the column again writes as a
+/// full week. So the check repeats on the normalized value until the written
+/// TOW is inside the week; two rounds are always enough because each round
+/// moves the pair by a whole week.
 ///
 /// Nothing is lost: the format cannot represent the sub-rounding difference
 /// between the stored TOW and the week boundary it rounds to.
 fn serialized_week_tow(week_tow: GnssWeekTow) -> GnssWeekTow {
-    let mut written = String::new();
-    push_d19_12(&mut written, week_tow.tow_s);
-    let Ok(rounded) = written.trim().parse::<f64>() else {
-        return week_tow;
+    let written_tow = |tow_s: f64| {
+        let mut written = String::new();
+        push_d19_12(&mut written, tow_s);
+        written.trim().parse::<f64>().ok()
     };
-    if (0.0..SECONDS_PER_WEEK).contains(&rounded) {
-        return week_tow;
+    let mut current = week_tow;
+    for _ in 0..3 {
+        let Some(rounded) = written_tow(current.tow_s) else {
+            return current;
+        };
+        if (0.0..SECONDS_PER_WEEK).contains(&rounded) {
+            return current;
+        }
+        match GnssWeekTow::new(current.system, current.week, rounded)
+            .and_then(GnssWeekTow::normalized)
+        {
+            Ok(normalized) => current = normalized,
+            // The week cannot carry any further (u32 range); the stored pair is
+            // the best representable answer and is written as it is.
+            Err(_) => return current,
+        }
     }
-    GnssWeekTow::new(week_tow.system, week_tow.week, rounded)
-        .and_then(GnssWeekTow::normalized)
-        .unwrap_or(week_tow)
+    current
 }
 
 /// The base-10 exponent [`push_d19_12`] emits for `value` (the rounded

--- a/crates/sidereon-core/src/sp3/combine.rs
+++ b/crates/sidereon-core/src/sp3/combine.rs
@@ -25,7 +25,7 @@ use crate::astro::time::civil::{
 use crate::astro::time::gnss;
 use crate::astro::time::model::Instant;
 
-use super::interp::{instant_to_j2000_seconds, sp3_epoch_j2000_seconds};
+use super::interp::{instant_to_j2000_seconds, sp3_epoch_j2000_seconds, Sp3InterpolationOptions};
 use super::{RawNode, Sp3, Sp3DataType, Sp3Flags, Sp3Header, Sp3State, TerminalRecordState};
 use crate::constants::{DAYS_PER_JULIAN_YEAR, GPS_EPOCH_TO_J2000_S, KM_TO_M, SECONDS_PER_DAY};
 use crate::frame::{ItrfPositionM, ItrfVelocityMS};
@@ -1073,6 +1073,7 @@ fn emit_merged_product(
         epoch_j2000_s: out_epoch_j2000_s,
         states: out_states,
         interp_raw: out_raw,
+        interpolation: Sp3InterpolationOptions::default(),
         comments: vec![format!("MERGED from {} SP3 products", sources.len())],
         skipped_records: sources.iter().map(|s| s.skipped_records).sum(),
     };

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -81,7 +81,7 @@ use crate::id::GnssSatelliteId;
 use crate::sp3::interp::{
     instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds,
     precise_node_j2000_seconds_from_instant, selectable_reach_s, sp3_epoch_j2000_seconds,
-    NEVILLE_POINTS,
+    Sp3InterpolationOptions, DEFAULT_GAP_THRESHOLD_FACTOR, NEVILLE_POINTS,
 };
 use crate::sp3::samples::PreciseEphemerisSample;
 use crate::sp3::Sp3;
@@ -197,9 +197,10 @@ impl StencilExtent {
             }
         }
 
+        let gap_threshold_factor = sp3.interpolation.gap_threshold_factor;
         let mut reach_s = NEVILLE_POINTS as f64 * interval_s;
         for nodes in series.values() {
-            if let Some(reach) = selectable_reach_s(nodes) {
+            if let Some(reach) = selectable_reach_s(nodes, gap_threshold_factor) {
                 reach_s = reach_s.max(reach);
             }
         }
@@ -340,6 +341,10 @@ pub struct ContinuityOptions {
     /// and well below the smallest splice worth reporting is the useful range;
     /// 1.0 m is a defensible default for a merged GNSS orbit product.
     pub residual_tolerance_m: Option<f64>,
+    /// How the hold-out replay reads the retained node series: the same
+    /// [`Sp3InterpolationOptions`] the interpolator under test uses, so a
+    /// product read with a non-default gap threshold is checked with it too.
+    pub interpolation: Sp3InterpolationOptions,
 }
 
 /// Source of the adjacent-pair speed bound.
@@ -370,6 +375,9 @@ impl ContinuityOptions {
         Self {
             speed_bound,
             residual_tolerance_m,
+            interpolation: Sp3InterpolationOptions {
+                gap_threshold_factor: DEFAULT_GAP_THRESHOLD_FACTOR,
+            },
         }
     }
 
@@ -378,7 +386,16 @@ impl ContinuityOptions {
         Self {
             speed_bound: Some(SpeedBound::OrbitClass(class)),
             residual_tolerance_m: Some(1.0),
+            interpolation: Sp3InterpolationOptions::default(),
         }
+    }
+
+    /// The same settings, with the hold-out replay reading node series under
+    /// `interpolation`.
+    #[must_use]
+    pub fn with_interpolation_options(mut self, interpolation: Sp3InterpolationOptions) -> Self {
+        self.interpolation = interpolation;
+        self
     }
 }
 
@@ -710,7 +727,14 @@ pub fn check_continuity(
             check_speed_bound(sat, &series, bound, &mut sat_defects, &mut report);
         }
         if let Some(tolerance_m) = options.residual_tolerance_m {
-            check_hold_out_residual(sat, &series, tolerance_m, &mut sat_defects, &mut report);
+            check_hold_out_residual(
+                sat,
+                &series,
+                tolerance_m,
+                options.interpolation.gap_threshold_factor,
+                &mut sat_defects,
+                &mut report,
+            );
         }
 
         sat_defects.sort_by(|a, b| defect_sort_key(a).total_cmp(&defect_sort_key(b)));
@@ -777,6 +801,7 @@ fn check_hold_out_residual(
     sat: GnssSatelliteId,
     series: &OrderedSeries,
     tolerance_m: f64,
+    gap_threshold_factor: f64,
     defects: &mut Vec<ContinuityDefect>,
     report: &mut ContinuityReport,
 ) {
@@ -813,7 +838,16 @@ fn check_hold_out_residual(
 
         for index in held {
             let query = series.x[index];
-            match interpolate_precise_state(sat, &x, &kx, &ky, &kz, &[], query) {
+            match interpolate_precise_state(
+                sat,
+                &x,
+                &kx,
+                &ky,
+                &kz,
+                &[],
+                query,
+                gap_threshold_factor,
+            ) {
                 Ok(state) => {
                     report.residuals_checked += 1;
                     let predicted = [state.position.x_m, state.position.y_m, state.position.z_m];

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -81,7 +81,7 @@ use crate::id::GnssSatelliteId;
 use crate::sp3::interp::{
     instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds,
     precise_node_j2000_seconds_from_instant, selectable_reach_s, sp3_epoch_j2000_seconds,
-    Sp3InterpolationOptions, DEFAULT_GAP_THRESHOLD_FACTOR, NEVILLE_POINTS,
+    Sp3InterpolationOptions, NEVILLE_POINTS,
 };
 use crate::sp3::samples::PreciseEphemerisSample;
 use crate::sp3::Sp3;
@@ -197,7 +197,7 @@ impl StencilExtent {
             }
         }
 
-        let gap_threshold_factor = sp3.interpolation.gap_threshold_factor;
+        let gap_threshold_factor = sp3.interpolation.gap_threshold_factor();
         let mut reach_s = NEVILLE_POINTS as f64 * interval_s;
         for nodes in series.values() {
             if let Some(reach) = selectable_reach_s(nodes, gap_threshold_factor) {
@@ -341,9 +341,15 @@ pub struct ContinuityOptions {
     /// and well below the smallest splice worth reporting is the useful range;
     /// 1.0 m is a defensible default for a merged GNSS orbit product.
     pub residual_tolerance_m: Option<f64>,
-    /// How the hold-out replay reads the retained node series: the same
-    /// [`Sp3InterpolationOptions`] the interpolator under test uses, so a
-    /// product read with a non-default gap threshold is checked with it too.
+    /// How the hold-out replay reads the retained node series.
+    ///
+    /// Nothing sets this from a product: [`check_continuity`] sees samples,
+    /// not the product they came from, so it defaults to the default policy
+    /// however the product was configured. A product read with a non-default
+    /// gap threshold is checked under that threshold only if the caller
+    /// copies `product.interpolation_options()` here; otherwise the replay
+    /// splits runs at 1.5 nominal spacings while the interpolator in use
+    /// does not, and the two disagree about which nodes a prediction uses.
     pub interpolation: Sp3InterpolationOptions,
 }
 
@@ -375,9 +381,7 @@ impl ContinuityOptions {
         Self {
             speed_bound,
             residual_tolerance_m,
-            interpolation: Sp3InterpolationOptions {
-                gap_threshold_factor: DEFAULT_GAP_THRESHOLD_FACTOR,
-            },
+            interpolation: Sp3InterpolationOptions::DEFAULT,
         }
     }
 
@@ -731,7 +735,7 @@ pub fn check_continuity(
                 sat,
                 &series,
                 tolerance_m,
-                options.interpolation.gap_threshold_factor,
+                options.interpolation.gap_threshold_factor(),
                 &mut sat_defects,
                 &mut report,
             );

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -79,7 +79,8 @@ use crate::astro::constants::MU_EARTH;
 use crate::constants::KM_TO_M;
 use crate::id::GnssSatelliteId;
 use crate::sp3::interp::{
-    instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds_from_instant,
+    instant_to_j2000_seconds, interpolate_precise_state, nominal_positive_spacing,
+    precise_node_j2000_seconds, precise_node_j2000_seconds_from_instant, sp3_epoch_j2000_seconds,
     NEVILLE_POINTS,
 };
 use crate::sp3::samples::PreciseEphemerisSample;
@@ -137,8 +138,6 @@ impl EpochWindow {
 /// interpolator, rather than accepted as a caller-supplied duration.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StencilExtent {
-    grid_origin_j2000_s: f64,
-    interval_s: f64,
     before_s: f64,
     after_s: f64,
 }
@@ -146,17 +145,26 @@ pub struct StencilExtent {
 impl StencilExtent {
     /// Derive the interpolation reach for an SP3 product.
     ///
-    /// The degree-10 Lagrange substrate uses 11 nodes. They are centered on the
-    /// query only in the interior of a contiguous run: near either end the
-    /// interpolator keeps the node count and slides the window inward, so the
-    /// stencil becomes one-sided. A query in the last interval of a run selects
-    /// the final 11 nodes, which reach back up to ten intervals rather than
-    /// five, and a query in the first interval reaches ten intervals forward.
+    /// The position interpolator selects up to 11 nodes per satellite, and it
+    /// selects them from that satellite's own node series, not from the
+    /// product's header grid. Three things make the selected span wider than
+    /// the centered five intervals a header-grid view suggests:
     ///
-    /// The reach reported here is therefore ten intervals on each side, the
-    /// widest window the interpolator can select anywhere in the product.
-    /// Reporting the centered five would understate it, and it understates it
-    /// in the unsafe direction: a window-scoped verdict such as
+    /// - At either end of a contiguous run the window keeps its node count and
+    ///   slides inward, so a query in the last interval reaches ten spacings
+    ///   back rather than five.
+    /// - A query up to one spacing outside a run is still served (across a
+    ///   coverage gap it is anchored to the nearer run), so the farthest node
+    ///   can sit eleven spacings away.
+    /// - The spacing is the satellite's own nominal spacing, estimated exactly
+    ///   as the interpolator does from its actual nodes. A satellite sampled
+    ///   every 600 s in a 300 s product has an 11-node span of 6,000 s.
+    ///
+    /// The reach reported here is therefore eleven times the largest
+    /// per-satellite nominal spacing in the product, the widest window the
+    /// interpolator can select for any satellite anywhere in it. A satellite
+    /// with fewer than two nodes falls back to the header interval. Understating
+    /// the reach errs in the unsafe direction: a window-scoped verdict such as
     /// [`ContinuityReport::verdict_for_window`] would accept a window whose
     /// interpolation selects a node the defect sits on.
     ///
@@ -168,53 +176,67 @@ impl StencilExtent {
                 "SP3 stencil extent requires a positive finite epoch interval".to_string(),
             ));
         }
-        let grid_origin_j2000_s = sp3
+        if !sp3
             .epochs_j2000_seconds()
             .first()
-            .copied()
-            .filter(|epoch| epoch.is_finite())
-            .ok_or_else(|| {
-                Error::InvalidInput(
-                    "SP3 stencil extent requires at least one representable epoch".to_string(),
-                )
-            })?;
-        // The window slides but never shrinks, so the furthest a selected node
-        // can sit from the pivot is the full span of the stencil.
-        let widest_span_s = (NEVILLE_POINTS - 1) as f64 * interval_s;
+            .is_some_and(|epoch| epoch.is_finite())
+        {
+            return Err(Error::InvalidInput(
+                "SP3 stencil extent requires at least one representable epoch".to_string(),
+            ));
+        }
+
+        // Largest nominal spacing over the satellites' actual node series,
+        // using the interpolator's own estimator so the two cannot disagree.
+        let mut widest_spacing_s = interval_s;
+        for sat in sp3.satellites() {
+            let mut nodes = Vec::new();
+            for (idx, epoch) in sp3.epochs.iter().enumerate() {
+                if sp3.interp_raw[idx].contains_key(sat) {
+                    if let Some(seconds) = sp3_epoch_j2000_seconds(sp3, idx, epoch) {
+                        nodes.push(precise_node_j2000_seconds(seconds));
+                    }
+                }
+            }
+            if let Some(spacing) = nominal_positive_spacing(&nodes) {
+                widest_spacing_s = widest_spacing_s.max(spacing);
+            }
+        }
+
+        let reach_s = NEVILLE_POINTS as f64 * widest_spacing_s;
         Ok(Self {
-            grid_origin_j2000_s,
-            interval_s,
-            before_s: widest_span_s,
-            after_s: widest_span_s,
+            before_s: reach_s,
+            after_s: reach_s,
         })
     }
 
     /// Reach before an evaluated epoch, seconds.
     ///
-    /// The widest stencil the interpolator can select, which is the one it uses
-    /// at the end of a contiguous run, not the centered interior stencil.
+    /// Eleven times the widest per-satellite nominal spacing: the farthest a
+    /// selected node can sit behind a query, at a run end or when a query one
+    /// spacing past a run is still served.
     pub fn before_s(self) -> f64 {
         self.before_s
     }
 
     /// Reach after an evaluated epoch, seconds.
     ///
-    /// The widest stencil the interpolator can select, which is the one it uses
-    /// at the start of a contiguous run, not the centered interior stencil.
+    /// Eleven times the widest per-satellite nominal spacing: the farthest a
+    /// selected node can sit ahead of a query, at a run start or when a query
+    /// one spacing before a run is anchored to it across a gap.
     pub fn after_s(self) -> f64 {
         self.after_s
     }
 
-    /// Union of grid nodes the interpolator can select for any query in
-    /// `window`, covering the inward slide at a run edge.
+    /// Time span that can contain a node selected for any query in `window`.
+    ///
+    /// Measured from the window bounds themselves. An earlier version snapped
+    /// each bound to the header grid first; on the upper side that snap moved
+    /// the bound earlier and let a selected node fall outside it.
     fn influence_bounds(self, window: EpochWindow) -> (f64, f64) {
-        let pivot_at_or_before = |query: f64| {
-            self.grid_origin_j2000_s
-                + ((query - self.grid_origin_j2000_s) / self.interval_s).floor() * self.interval_s
-        };
         (
-            pivot_at_or_before(window.from_j2000_s) - self.before_s,
-            pivot_at_or_before(window.through_j2000_s) + self.after_s,
+            window.from_j2000_s - self.before_s,
+            window.through_j2000_s + self.after_s,
         )
     }
 }

--- a/crates/sidereon-core/src/sp3/continuity.rs
+++ b/crates/sidereon-core/src/sp3/continuity.rs
@@ -79,8 +79,8 @@ use crate::astro::constants::MU_EARTH;
 use crate::constants::KM_TO_M;
 use crate::id::GnssSatelliteId;
 use crate::sp3::interp::{
-    instant_to_j2000_seconds, interpolate_precise_state, nominal_positive_spacing,
-    precise_node_j2000_seconds, precise_node_j2000_seconds_from_instant, sp3_epoch_j2000_seconds,
+    instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds,
+    precise_node_j2000_seconds_from_instant, selectable_reach_s, sp3_epoch_j2000_seconds,
     NEVILLE_POINTS,
 };
 use crate::sp3::samples::PreciseEphemerisSample;
@@ -145,26 +145,20 @@ pub struct StencilExtent {
 impl StencilExtent {
     /// Derive the interpolation reach for an SP3 product.
     ///
-    /// The position interpolator selects up to 11 nodes per satellite, and it
-    /// selects them from that satellite's own node series, not from the
-    /// product's header grid. Three things make the selected span wider than
-    /// the centered five intervals a header-grid view suggests:
+    /// The position interpolator selects up to 11 nodes from each satellite's
+    /// own node series, not from the product's header grid, and it serves a
+    /// query up to one nominal spacing outside that series or across a coverage
+    /// gap. The farthest selected node can therefore sit a full window span
+    /// plus one nominal spacing from the query, and the window span is measured
+    /// from the satellite's actual nodes: a run tolerates gaps up to 1.5 times
+    /// its nominal spacing, so eleven nodes at 0, 600, 1500, 2400, ..., 8700 s
+    /// span 8,700 s although their nominal spacing is 600 s.
     ///
-    /// - At either end of a contiguous run the window keeps its node count and
-    ///   slides inward, so a query in the last interval reaches ten spacings
-    ///   back rather than five.
-    /// - A query up to one spacing outside a run is still served (across a
-    ///   coverage gap it is anchored to the nearer run), so the farthest node
-    ///   can sit eleven spacings away.
-    /// - The spacing is the satellite's own nominal spacing, estimated exactly
-    ///   as the interpolator does from its actual nodes. A satellite sampled
-    ///   every 600 s in a 300 s product has an 11-node span of 6,000 s.
-    ///
-    /// The reach reported here is therefore eleven times the largest
-    /// per-satellite nominal spacing in the product, the widest window the
-    /// interpolator can select for any satellite anywhere in it. A satellite
-    /// with fewer than two nodes falls back to the header interval. Understating
-    /// the reach errs in the unsafe direction: a window-scoped verdict such as
+    /// The reach reported here is the largest such value over the satellites
+    /// in the product, computed with the interpolator's own run and window
+    /// rules, with a floor of eleven header intervals for products whose
+    /// satellites carry fewer than two nodes. Understating the reach errs in
+    /// the unsafe direction: a window-scoped verdict such as
     /// [`ContinuityReport::verdict_for_window`] would accept a window whose
     /// interpolation selects a node the defect sits on.
     ///
@@ -186,24 +180,29 @@ impl StencilExtent {
             ));
         }
 
-        // Largest nominal spacing over the satellites' actual node series,
-        // using the interpolator's own estimator so the two cannot disagree.
-        let mut widest_spacing_s = interval_s;
-        for sat in sp3.satellites() {
-            let mut nodes = Vec::new();
-            for (idx, epoch) in sp3.epochs.iter().enumerate() {
-                if sp3.interp_raw[idx].contains_key(sat) {
-                    if let Some(seconds) = sp3_epoch_j2000_seconds(sp3, idx, epoch) {
-                        nodes.push(precise_node_j2000_seconds(seconds));
-                    }
-                }
-            }
-            if let Some(spacing) = nominal_positive_spacing(&nodes) {
-                widest_spacing_s = widest_spacing_s.max(spacing);
+        // One pass over the epochs, collecting each satellite's node series.
+        // `epochs` is public and may be longer than the private node table, so
+        // the table is consulted by lookup rather than by index.
+        let mut series: BTreeMap<GnssSatelliteId, Vec<f64>> = BTreeMap::new();
+        for (idx, epoch) in sp3.epochs.iter().enumerate() {
+            let Some(nodes_at_epoch) = sp3.interp_raw.get(idx) else {
+                break;
+            };
+            let Some(seconds) = sp3_epoch_j2000_seconds(sp3, idx, epoch) else {
+                continue;
+            };
+            let seconds = precise_node_j2000_seconds(seconds);
+            for sat in nodes_at_epoch.keys() {
+                series.entry(*sat).or_default().push(seconds);
             }
         }
 
-        let reach_s = NEVILLE_POINTS as f64 * widest_spacing_s;
+        let mut reach_s = NEVILLE_POINTS as f64 * interval_s;
+        for nodes in series.values() {
+            if let Some(reach) = selectable_reach_s(nodes) {
+                reach_s = reach_s.max(reach);
+            }
+        }
         Ok(Self {
             before_s: reach_s,
             after_s: reach_s,
@@ -212,18 +211,18 @@ impl StencilExtent {
 
     /// Reach before an evaluated epoch, seconds.
     ///
-    /// Eleven times the widest per-satellite nominal spacing: the farthest a
-    /// selected node can sit behind a query, at a run end or when a query one
-    /// spacing past a run is still served.
+    /// The widest selectable window span in the product plus one nominal
+    /// spacing: the farthest a selected node can sit behind a query, at a run
+    /// end or when a query one spacing past a run is still served.
     pub fn before_s(self) -> f64 {
         self.before_s
     }
 
     /// Reach after an evaluated epoch, seconds.
     ///
-    /// Eleven times the widest per-satellite nominal spacing: the farthest a
-    /// selected node can sit ahead of a query, at a run start or when a query
-    /// one spacing before a run is anchored to it across a gap.
+    /// The widest selectable window span in the product plus one nominal
+    /// spacing: the farthest a selected node can sit ahead of a query, at a run
+    /// start or when a query one spacing before a run is anchored to it.
     pub fn after_s(self) -> f64 {
         self.after_s
     }

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -458,7 +458,7 @@ fn map_query_input(error: validate::FieldError) -> Error {
     Error::InvalidInput(format!("{} {}", error.field(), error.reason()))
 }
 
-fn nominal_positive_spacing(x: &[f64]) -> Option<f64> {
+pub(super) fn nominal_positive_spacing(x: &[f64]) -> Option<f64> {
     let nominal = x
         .windows(2)
         .map(|w| w[1] - w[0])

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -215,6 +215,7 @@ impl Sp3 {
             &series.kz,
             &series.clk,
             query,
+            self.interpolation.gap_threshold_factor,
         )
     }
 }
@@ -353,6 +354,9 @@ fn next_down(value: f64) -> f64 {
 /// requires for 0-ULP parity.
 // invariant: the interpolation path validates finite, in-range coordinates.
 #[allow(clippy::expect_used)]
+// Four parallel node slices, the clock series, the query and the policy: the
+// slices are the SP3 gather's native shape and are not repacked on the hot path.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn interpolate_precise_state(
     sat: GnssSatelliteId,
     pos_x: &[f64],
@@ -361,8 +365,17 @@ pub(super) fn interpolate_precise_state(
     pos_kz: &[f64],
     clk_nodes: &[(f64, f64, bool)],
     query: f64,
+    gap_threshold_factor: f64,
 ) -> Result<Sp3State> {
-    let (x_m, y_m, z_m) = interpolate_precise_position(sat, pos_x, pos_kx, pos_ky, pos_kz, query)?;
+    let (x_m, y_m, z_m) = interpolate_precise_position(
+        sat,
+        pos_x,
+        pos_kx,
+        pos_ky,
+        pos_kz,
+        query,
+        gap_threshold_factor,
+    )?;
     let clock_s = interpolate_clock(clk_nodes, query);
 
     Ok(Sp3State {
@@ -376,6 +389,9 @@ pub(super) fn interpolate_precise_state(
 
 // invariant: the interpolation path validates finite, in-range coordinates.
 #[allow(clippy::expect_used)]
+// Four parallel node slices, the clock series, the query and the policy: the
+// slices are the SP3 gather's native shape and are not repacked on the hot path.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn interpolate_precise_state_with_clock_arcs(
     sat: GnssSatelliteId,
     pos_x: &[f64],
@@ -384,8 +400,17 @@ pub(super) fn interpolate_precise_state_with_clock_arcs(
     pos_kz: &[f64],
     clock_arcs: &[ClockSplineArc],
     query: f64,
+    gap_threshold_factor: f64,
 ) -> Result<Sp3State> {
-    let (x_m, y_m, z_m) = interpolate_precise_position(sat, pos_x, pos_kx, pos_ky, pos_kz, query)?;
+    let (x_m, y_m, z_m) = interpolate_precise_position(
+        sat,
+        pos_x,
+        pos_kx,
+        pos_ky,
+        pos_kz,
+        query,
+        gap_threshold_factor,
+    )?;
     let clock_s = interpolate_fitted_clock(clock_arcs, query);
 
     Ok(Sp3State {
@@ -404,6 +429,7 @@ fn interpolate_precise_position(
     pos_ky: &[f64],
     pos_kz: &[f64],
     query: f64,
+    gap_threshold_factor: f64,
 ) -> Result<(f64, f64, f64)> {
     let query = validate::finite(query, "query_j2000_s").map_err(map_query_input)?;
 
@@ -437,7 +463,7 @@ fn interpolate_precise_position(
         return Err(Error::EpochOutOfRange);
     }
 
-    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
+    let gap_thresh = gap_threshold_factor * nominal;
     let mut bi = 0usize;
     while bi + 1 < pos_x.len() && pos_x[bi + 1] <= query {
         bi += 1;
@@ -450,7 +476,12 @@ fn interpolate_precise_position(
     }
 
     Ok(interpolate_position_neville(
-        pos_x, pos_kx, pos_ky, pos_kz, query,
+        pos_x,
+        pos_kx,
+        pos_ky,
+        pos_kz,
+        query,
+        gap_threshold_factor,
     ))
 }
 
@@ -462,7 +493,7 @@ fn map_query_input(error: validate::FieldError) -> Error {
 ///
 /// Derived from the same rules the position interpolator applies to `x`, so
 /// the two cannot disagree: nodes split into contiguous runs at gaps wider than
-/// [`GAP_THRESHOLD_FACTOR`] times the nominal spacing; within a run the window
+/// `gap_threshold_factor` times the nominal spacing; within a run the window
 /// holds `min(NEVILLE_POINTS, run_len)` consecutive nodes and slides inward at
 /// the run edges; and a query is served up to one nominal spacing outside the
 /// node span or across a gap, anchored to the nearer run. The farthest node is
@@ -473,9 +504,9 @@ fn map_query_input(error: validate::FieldError) -> Error {
 /// eleven nodes at 0, 600, 1500, 2400, ..., 8700 s have nominal spacing 600 s
 /// and a window span of 8,700 s, not 6,000 s. Returns `None` for fewer than two
 /// nodes, which the interpolator refuses to serve.
-pub(super) fn selectable_reach_s(x: &[f64]) -> Option<f64> {
+pub(super) fn selectable_reach_s(x: &[f64], gap_threshold_factor: f64) -> Option<f64> {
     let nominal = nominal_positive_spacing(x)?;
-    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
+    let gap_thresh = gap_threshold_factor * nominal;
     let mut widest_span = 0.0_f64;
     let mut run_lo = 0usize;
     for i in 1..=x.len() {
@@ -647,10 +678,54 @@ pub(super) fn instant_to_j2000_seconds(instant: &Instant) -> Option<f64> {
 /// degree-10 polynomial, 11 nodes).
 pub(super) const NEVILLE_POINTS: usize = 11;
 
-/// A consecutive node gap larger than this multiple of the nominal spacing is
-/// a coverage gap: the window never spans it, and a query inside it is served
-/// only within one nominal spacing of either edge.
-pub(super) const GAP_THRESHOLD_FACTOR: f64 = 1.5;
+/// Default multiple of the nominal spacing above which a consecutive node gap
+/// is a coverage gap. See [`Sp3InterpolationOptions::gap_threshold_factor`].
+pub const DEFAULT_GAP_THRESHOLD_FACTOR: f64 = 1.5;
+
+/// Interpretation policy for a product's node series.
+///
+/// Carried by [`Sp3`] and read by everything that selects nodes from it: the
+/// position interpolator, the continuity hold-out replay, the window-scoped
+/// reach, and a mapped store written from the product. It is not part of the
+/// SP3 text, so it does not survive `to_sp3_string` and does not take part in
+/// product equality.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub struct Sp3InterpolationOptions {
+    /// A consecutive node gap larger than this multiple of the satellite's
+    /// nominal (smallest) spacing is a coverage gap: the interpolation window
+    /// never spans it, and a query inside it is served only within one nominal
+    /// spacing of either edge.
+    ///
+    /// The default of 1.5 is the midpoint between one nominal step and one
+    /// missing node. It is a policy choice, not a published rule; a product
+    /// with deliberately irregular sampling can raise it so that its runs are
+    /// not split. Must be finite and greater than 1.0, since a factor at or
+    /// below 1.0 would split every run at every step.
+    pub gap_threshold_factor: f64,
+}
+
+impl Default for Sp3InterpolationOptions {
+    fn default() -> Self {
+        Self {
+            gap_threshold_factor: DEFAULT_GAP_THRESHOLD_FACTOR,
+        }
+    }
+}
+
+impl Sp3InterpolationOptions {
+    /// Build a policy with an explicit gap threshold factor.
+    pub fn new(gap_threshold_factor: f64) -> Result<Self> {
+        if !gap_threshold_factor.is_finite() || gap_threshold_factor <= 1.0 {
+            return Err(Error::InvalidInput(
+                "gap_threshold_factor must be finite and greater than 1.0".to_string(),
+            ));
+        }
+        Ok(Self {
+            gap_threshold_factor,
+        })
+    }
+}
 
 /// Sliding-window Lagrange (Neville) satellite-POSITION interpolation, matching
 /// RTKLIB `preceph.c` pephpos/interppol. Replaces the global not-a-knot cubic
@@ -674,13 +749,14 @@ fn interpolate_position_neville(
     ky: &[f64],
     kz: &[f64],
     query: f64,
+    gap_threshold_factor: f64,
 ) -> (f64, f64, f64) {
     let n = x.len();
 
     // Nominal node spacing = smallest positive consecutive gap (robust to one
     // large coverage gap); the gap threshold marks a non-contiguous jump.
     let nominal = nominal_positive_spacing(x).unwrap_or(1.0);
-    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
+    let gap_thresh = gap_threshold_factor * nominal;
 
     // Last node at or before the query (clamped into range).
     let mut pivot = 0usize;

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -215,7 +215,7 @@ impl Sp3 {
             &series.kz,
             &series.clk,
             query,
-            self.interpolation.gap_threshold_factor,
+            self.interpolation.gap_threshold_factor(),
         )
     }
 }
@@ -475,14 +475,16 @@ fn interpolate_precise_position(
         }
     }
 
-    Ok(interpolate_position_neville(
-        pos_x,
-        pos_kx,
-        pos_ky,
-        pos_kz,
-        query,
-        gap_threshold_factor,
-    ))
+    let (x_m, y_m, z_m) =
+        interpolate_position_neville(pos_x, pos_kx, pos_ky, pos_kz, query, gap_threshold_factor);
+    if !(x_m.is_finite() && y_m.is_finite() && z_m.is_finite()) {
+        // Neville divides by node-minus-node offsets measured from the query;
+        // nodes admitted far from the query can coincide at its precision.
+        return Err(Error::InvalidInput(format!(
+            "{sat}: selected nodes are not distinct at the precision of query {query}"
+        )));
+    }
+    Ok((x_m, y_m, z_m))
 }
 
 fn map_query_input(error: validate::FieldError) -> Error {
@@ -689,32 +691,48 @@ pub const DEFAULT_GAP_THRESHOLD_FACTOR: f64 = 1.5;
 /// reach, and a mapped store written from the product. It is not part of the
 /// SP3 text, so it does not survive `to_sp3_string` and does not take part in
 /// product equality.
+///
+/// The field is private so that every value in circulation passed [`new`]:
+/// the mapped store encodes the default as all-zero header bytes, and a
+/// factor of zero or NaN reaching the writer would come back as a different
+/// policy or an unreadable artifact.
+///
+/// [`new`]: Sp3InterpolationOptions::new
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[non_exhaustive]
 pub struct Sp3InterpolationOptions {
-    /// A consecutive node gap larger than this multiple of the satellite's
-    /// nominal (smallest) spacing is a coverage gap: the interpolation window
-    /// never spans it, and a query inside it is served only within one nominal
-    /// spacing of either edge.
-    ///
-    /// The default of 1.5 is the midpoint between one nominal step and one
-    /// missing node. It is a policy choice, not a published rule; a product
-    /// with deliberately irregular sampling can raise it so that its runs are
-    /// not split. Must be finite and greater than 1.0, since a factor at or
-    /// below 1.0 would split every run at every step.
-    pub gap_threshold_factor: f64,
+    gap_threshold_factor: f64,
 }
 
 impl Default for Sp3InterpolationOptions {
     fn default() -> Self {
-        Self {
-            gap_threshold_factor: DEFAULT_GAP_THRESHOLD_FACTOR,
-        }
+        Self::DEFAULT
     }
 }
 
 impl Sp3InterpolationOptions {
+    /// The default policy: a gap threshold factor of
+    /// [`DEFAULT_GAP_THRESHOLD_FACTOR`].
+    pub const DEFAULT: Self = Self {
+        gap_threshold_factor: DEFAULT_GAP_THRESHOLD_FACTOR,
+    };
+
     /// Build a policy with an explicit gap threshold factor.
+    ///
+    /// A consecutive node gap larger than `gap_threshold_factor` times the
+    /// satellite's nominal (smallest) spacing is a coverage gap: the
+    /// interpolation window never spans it, and a query inside it is served
+    /// only within one nominal spacing of either edge.
+    ///
+    /// The default of 1.5 is the midpoint between one nominal step and one
+    /// missing node. It is a policy choice, not a published rule; a product
+    /// with deliberately irregular sampling can raise it so that its runs are
+    /// not split. The factor must be finite and greater than 1.0: at or below
+    /// 1.0 every step would be a gap, and the comparison is strict so exactly
+    /// 1.0 would still admit nominal steps, which is not a policy anyone
+    /// intends. A very large factor admits any finite gap; if the admitted
+    /// nodes are then so far from the query that they are no longer distinct
+    /// at the query's precision, interpolation reports
+    /// [`Error::InvalidInput`] rather than a position.
     pub fn new(gap_threshold_factor: f64) -> Result<Self> {
         if !gap_threshold_factor.is_finite() || gap_threshold_factor <= 1.0 {
             return Err(Error::InvalidInput(
@@ -724,6 +742,11 @@ impl Sp3InterpolationOptions {
         Ok(Self {
             gap_threshold_factor,
         })
+    }
+
+    /// The multiple of the nominal spacing above which a gap splits a run.
+    pub fn gap_threshold_factor(&self) -> f64 {
+        self.gap_threshold_factor
     }
 }
 

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -481,7 +481,8 @@ fn interpolate_precise_position(
         // Neville divides by node-minus-node offsets measured from the query;
         // nodes admitted far from the query can coincide at its precision.
         return Err(Error::InvalidInput(format!(
-            "{sat}: selected nodes are not distinct at the precision of query {query}"
+            "{sat}: non-finite interpolated position at query {query}: the selected nodes \
+             are not distinct at its precision, or the coordinates overflow"
         )));
     }
     Ok((x_m, y_m, z_m))

--- a/crates/sidereon-core/src/sp3/interp.rs
+++ b/crates/sidereon-core/src/sp3/interp.rs
@@ -437,7 +437,7 @@ fn interpolate_precise_position(
         return Err(Error::EpochOutOfRange);
     }
 
-    let gap_thresh = 1.5 * nominal;
+    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
     let mut bi = 0usize;
     while bi + 1 < pos_x.len() && pos_x[bi + 1] <= query {
         bi += 1;
@@ -456,6 +456,42 @@ fn interpolate_precise_position(
 
 fn map_query_input(error: validate::FieldError) -> Error {
     Error::InvalidInput(format!("{} {}", error.field(), error.reason()))
+}
+
+/// Farthest a selected node can sit from any query this series serves.
+///
+/// Derived from the same rules the position interpolator applies to `x`, so
+/// the two cannot disagree: nodes split into contiguous runs at gaps wider than
+/// [`GAP_THRESHOLD_FACTOR`] times the nominal spacing; within a run the window
+/// holds `min(NEVILLE_POINTS, run_len)` consecutive nodes and slides inward at
+/// the run edges; and a query is served up to one nominal spacing outside the
+/// node span or across a gap, anchored to the nearer run. The farthest node is
+/// therefore at most one window span plus one nominal spacing from the query.
+///
+/// The span is measured from the actual nodes, not from the nominal spacing
+/// times the node count, because a run admits gaps up to 1.5 times nominal:
+/// eleven nodes at 0, 600, 1500, 2400, ..., 8700 s have nominal spacing 600 s
+/// and a window span of 8,700 s, not 6,000 s. Returns `None` for fewer than two
+/// nodes, which the interpolator refuses to serve.
+pub(super) fn selectable_reach_s(x: &[f64]) -> Option<f64> {
+    let nominal = nominal_positive_spacing(x)?;
+    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
+    let mut widest_span = 0.0_f64;
+    let mut run_lo = 0usize;
+    for i in 1..=x.len() {
+        let run_ends = i == x.len() || (x[i] - x[i - 1]) > gap_thresh;
+        if run_ends {
+            let run = &x[run_lo..i];
+            let win = NEVILLE_POINTS.min(run.len());
+            if win >= 2 {
+                for start in 0..=run.len() - win {
+                    widest_span = widest_span.max(run[start + win - 1] - run[start]);
+                }
+            }
+            run_lo = i;
+        }
+    }
+    Some(widest_span + nominal)
 }
 
 pub(super) fn nominal_positive_spacing(x: &[f64]) -> Option<f64> {
@@ -611,6 +647,11 @@ pub(super) fn instant_to_j2000_seconds(instant: &Instant) -> Option<f64> {
 /// degree-10 polynomial, 11 nodes).
 pub(super) const NEVILLE_POINTS: usize = 11;
 
+/// A consecutive node gap larger than this multiple of the nominal spacing is
+/// a coverage gap: the window never spans it, and a query inside it is served
+/// only within one nominal spacing of either edge.
+pub(super) const GAP_THRESHOLD_FACTOR: f64 = 1.5;
+
 /// Sliding-window Lagrange (Neville) satellite-POSITION interpolation, matching
 /// RTKLIB `preceph.c` pephpos/interppol. Replaces the global not-a-knot cubic
 /// spline, which is degree-3 over the whole day and errs ~200 m at the day
@@ -639,7 +680,7 @@ fn interpolate_position_neville(
     // Nominal node spacing = smallest positive consecutive gap (robust to one
     // large coverage gap); the gap threshold marks a non-contiguous jump.
     let nominal = nominal_positive_spacing(x).unwrap_or(1.0);
-    let gap_thresh = 1.5 * nominal;
+    let gap_thresh = GAP_THRESHOLD_FACTOR * nominal;
 
     // Last node at or before the query (clamped into range).
     let mut pivot = 0usize;

--- a/crates/sidereon-core/src/sp3/interp/interp_tests.rs
+++ b/crates/sidereon-core/src/sp3/interp/interp_tests.rs
@@ -19,7 +19,7 @@
 use super::{
     eval_cubic_spline_for_test as eval_spline, instant_to_j2000_seconds,
     interpolate_position_neville, precise_node_j2000_seconds,
-    precise_node_j2000_seconds_from_instant,
+    precise_node_j2000_seconds_from_instant, DEFAULT_GAP_THRESHOLD_FACTOR,
 };
 use crate::astro::constants::time::SECONDS_PER_DAY_I64;
 use crate::astro::time::civil::{J2000_JULIAN_DAY_NUMBER, J2000_NOON_OFFSET_S};
@@ -506,10 +506,12 @@ fn position_gap_window_uses_right_arc_before_second_edge() {
     let ky = [0.0; 6];
     let kz = [-3.0, -3.0, -3.0, 7.0, 7.0, 7.0];
 
-    let (_, _, left_z_m) = interpolate_position_neville(&x, &kx, &ky, &kz, 25.0);
+    let (_, _, left_z_m) =
+        interpolate_position_neville(&x, &kx, &ky, &kz, 25.0, DEFAULT_GAP_THRESHOLD_FACTOR);
     assert_eq!(left_z_m.to_bits(), (-3_000.0f64).to_bits());
 
-    let (_, _, right_z_m) = interpolate_position_neville(&x, &kx, &ky, &kz, 95.0);
+    let (_, _, right_z_m) =
+        interpolate_position_neville(&x, &kx, &ky, &kz, 95.0, DEFAULT_GAP_THRESHOLD_FACTOR);
     assert_eq!(right_z_m.to_bits(), 7_000.0f64.to_bits());
 }
 
@@ -708,8 +710,17 @@ fn instant_to_j2000_seconds_query_exactness_bound() {
 
 fn gap_policy_state(x: &[f64], kz: &[f64], query: f64) -> crate::Result<f64> {
     let zeros = vec![0.0; x.len()];
-    super::interpolate_precise_state(id_for("G01"), x, &zeros, &zeros, kz, &[], query)
-        .map(|state| state.position.z_m)
+    super::interpolate_precise_state(
+        id_for("G01"),
+        x,
+        &zeros,
+        &zeros,
+        kz,
+        &[],
+        query,
+        DEFAULT_GAP_THRESHOLD_FACTOR,
+    )
+    .map(|state| state.position.z_m)
 }
 
 fn assert_gap_policy_constant(x: &[f64], kz: &[f64], query: f64, want_km: f64) {

--- a/crates/sidereon-core/src/sp3/interpolant.rs
+++ b/crates/sidereon-core/src/sp3/interpolant.rs
@@ -10,7 +10,7 @@ use crate::observables::{
 use crate::sp3::interp::{
     fit_clock_spline_arcs, gather_sp3_precise_series, instant_to_j2000_seconds,
     interpolate_precise_state, interpolate_precise_state_with_clock_arcs, ClockSplineArc,
-    PreciseSatSeries,
+    PreciseSatSeries, Sp3InterpolationOptions,
 };
 use crate::sp3::{
     PreciseEphemerisSample, PreciseEphemerisSamples, PreciseSamplesError, Sp3, Sp3State,
@@ -50,6 +50,7 @@ impl From<PreciseSamplesError> for PreciseInterpolantError {
 pub struct PreciseEphemerisInterpolant {
     time_scale: TimeScale,
     pub(super) nodes: BTreeMap<GnssSatelliteId, FittedPreciseSatSeries>,
+    pub(super) interpolation: Sp3InterpolationOptions,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -84,6 +85,7 @@ impl PreciseEphemerisInterpolant {
         Self {
             time_scale: source.header.time_scale,
             nodes,
+            interpolation: source.interpolation_options(),
         }
     }
 
@@ -110,12 +112,28 @@ impl PreciseEphemerisInterpolant {
                 .iter()
                 .map(|(&sat, series)| (sat, FittedPreciseSatSeries::new(series.clone())))
                 .collect(),
+            interpolation: source.interpolation_options(),
         }
     }
 
     /// The time scale of the source epochs used to build this handle.
     pub fn time_scale(&self) -> TimeScale {
         self.time_scale
+    }
+
+    /// The interpretation policy this handle reads its node series with.
+    ///
+    /// Copied from the source product or samples at build time, and written
+    /// into a store built from this handle.
+    pub fn interpolation_options(&self) -> Sp3InterpolationOptions {
+        self.interpolation
+    }
+
+    /// Return the handle with a different interpretation policy.
+    #[must_use]
+    pub fn with_interpolation_options(mut self, options: Sp3InterpolationOptions) -> Self {
+        self.interpolation = options;
+        self
     }
 
     pub(super) fn node_series(&self) -> &BTreeMap<GnssSatelliteId, FittedPreciseSatSeries> {
@@ -145,9 +163,17 @@ impl PreciseEphemerisInterpolant {
                 &fitted.series.kz,
                 &fitted.clock_arcs,
                 query,
+                self.interpolation.gap_threshold_factor,
             ),
             None => interpolate_precise_state(
-                sat, &EMPTY_F64, &EMPTY_F64, &EMPTY_F64, &EMPTY_F64, &EMPTY_CLK, query,
+                sat,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_CLK,
+                query,
+                self.interpolation.gap_threshold_factor,
             ),
         }
     }

--- a/crates/sidereon-core/src/sp3/interpolant.rs
+++ b/crates/sidereon-core/src/sp3/interpolant.rs
@@ -163,7 +163,7 @@ impl PreciseEphemerisInterpolant {
                 &fitted.series.kz,
                 &fitted.clock_arcs,
                 query,
-                self.interpolation.gap_threshold_factor,
+                self.interpolation.gap_threshold_factor(),
             ),
             None => interpolate_precise_state(
                 sat,
@@ -173,7 +173,7 @@ impl PreciseEphemerisInterpolant {
                 &EMPTY_F64,
                 &EMPTY_CLK,
                 query,
-                self.interpolation.gap_threshold_factor,
+                self.interpolation.gap_threshold_factor(),
             ),
         }
     }

--- a/crates/sidereon-core/src/sp3/interpolant_store.rs
+++ b/crates/sidereon-core/src/sp3/interpolant_store.rs
@@ -591,7 +591,7 @@ impl<'a> MmapPreciseEphemerisInterpolant<'a> {
             self.bytes.as_ref(),
             series,
             query,
-            self.interpolation.gap_threshold_factor,
+            self.interpolation.gap_threshold_factor(),
         )
     }
 
@@ -807,7 +807,7 @@ fn build_store(
     );
     write_u64(&mut out, HEADER_DATA_OFFSET_OFFSET, data_offset as u64);
     write_u64(&mut out, HEADER_TOTAL_LEN_OFFSET, cursor as u64);
-    let gap_threshold_factor = source.interpolation_options().gap_threshold_factor;
+    let gap_threshold_factor = source.interpolation_options().gap_threshold_factor();
     if gap_threshold_factor != DEFAULT_GAP_THRESHOLD_FACTOR {
         write_f64(
             &mut out,
@@ -1293,6 +1293,13 @@ fn interpolate_mapped_state(
 
     let (x_m, y_m, z_m) =
         interpolate_mapped_position_neville(bytes, series, query, gap_threshold_factor);
+    if !(x_m.is_finite() && y_m.is_finite() && z_m.is_finite()) {
+        // Same failure as the in-memory path: admitted nodes far from the
+        // query can coincide at its precision and zero a Neville denominator.
+        return Err(Error::InvalidInput(format!(
+            "selected nodes are not distinct at the precision of query {query}"
+        )));
+    }
     let clock_s = interpolate_mapped_clock(bytes, series, query);
     Ok(Sp3State {
         position: ItrfPositionM::new(x_m, y_m, z_m).expect("valid ITRF position"),

--- a/crates/sidereon-core/src/sp3/interpolant_store.rs
+++ b/crates/sidereon-core/src/sp3/interpolant_store.rs
@@ -5,6 +5,11 @@
 //! Payloads carry SP3-native position nodes and fitted clock spline coefficients
 //! so opening the store validates bytes and builds only lightweight indexes. It
 //! never refits clock splines at open or during evaluation.
+//!
+//! The header records the source's [`Sp3InterpolationOptions`] gap threshold
+//! factor at bytes 48..56 as a little-endian f64, with all-zero bytes meaning
+//! the default. A default-policy artifact is byte-identical to one written
+//! before the field existed, and such an artifact reads back as the default.
 
 use crate::artifact_bytes::{ArtifactBytes, DigestProvenance};
 use std::collections::BTreeMap;
@@ -19,7 +24,10 @@ use crate::id::{GnssSatelliteId, GnssSystem};
 use crate::observables::{
     ObservableEphemerisSource, ObservableState, ObservableStateBatch, ObservablesError,
 };
-use crate::sp3::interp::{instant_to_j2000_seconds, neville, NEVILLE_POINTS};
+use crate::sp3::interp::{
+    instant_to_j2000_seconds, neville, Sp3InterpolationOptions, DEFAULT_GAP_THRESHOLD_FACTOR,
+    NEVILLE_POINTS,
+};
 use crate::sp3::{PreciseEphemerisInterpolant, Sp3, Sp3State};
 use crate::{validate, Error, Result};
 
@@ -38,6 +46,11 @@ const HEADER_INDEX_OFFSET_OFFSET: usize = 16;
 const HEADER_DATA_OFFSET_OFFSET: usize = 24;
 const HEADER_TOTAL_LEN_OFFSET: usize = 32;
 const HEADER_CHECKSUM_OFFSET: usize = 40;
+/// Gap threshold factor as an f64, or all-zero bytes for the default policy.
+/// A default-policy artifact is therefore byte-identical to one written
+/// before the field existed, and such an artifact reads back as the default.
+const HEADER_GAP_THRESHOLD_FACTOR_OFFSET: usize = 48;
+const HEADER_RESERVED_OFFSET: usize = 56;
 
 const SAT_SYSTEM_OFFSET: usize = 0;
 const SAT_PRN_OFFSET: usize = 1;
@@ -278,6 +291,7 @@ struct ParsedStore<'a> {
     time_scale: TimeScale,
     satellites: Vec<GnssSatelliteId>,
     series: BTreeMap<GnssSatelliteId, MmapSeries<'a>>,
+    interpolation: Sp3InterpolationOptions,
 }
 
 #[derive(Clone, Copy)]
@@ -325,6 +339,7 @@ pub struct MmapPreciseEphemerisInterpolant<'a> {
     series: BTreeMap<GnssSatelliteId, MmapSeries<'a>>,
     digest_provenance: DigestProvenance,
     attested_checksum64: Option<u64>,
+    interpolation: Sp3InterpolationOptions,
 }
 
 impl core::fmt::Debug for MmapPreciseEphemerisInterpolant<'_> {
@@ -461,6 +476,7 @@ impl MmapPreciseEphemerisInterpolant<'static> {
             time_scale: parsed.time_scale,
             satellites: parsed.satellites,
             series,
+            interpolation: parsed.interpolation,
             digest_provenance: checksum_validation.digest_provenance(),
             attested_checksum64: checksum_validation.attested_checksum64(),
         })
@@ -492,9 +508,15 @@ impl<'a> MmapPreciseEphemerisInterpolant<'a> {
             time_scale: parsed.time_scale,
             satellites: parsed.satellites,
             series: parsed.series,
+            interpolation: parsed.interpolation,
             digest_provenance: checksum_validation.digest_provenance(),
             attested_checksum64: checksum_validation.attested_checksum64(),
         })
+    }
+
+    /// The interpretation policy recorded in the artifact header.
+    pub fn interpolation_options(&self) -> Sp3InterpolationOptions {
+        self.interpolation
     }
 
     /// Borrow the artifact bytes backing this reader.
@@ -565,7 +587,12 @@ impl<'a> MmapPreciseEphemerisInterpolant<'a> {
         let Some(series) = self.series.get(&sat) else {
             return Err(Error::UnknownSatellite(sat));
         };
-        interpolate_mapped_state(self.bytes.as_ref(), series, query)
+        interpolate_mapped_state(
+            self.bytes.as_ref(),
+            series,
+            query,
+            self.interpolation.gap_threshold_factor,
+        )
     }
 
     /// Interpolate the state of `sat` at an arbitrary [`Instant`].
@@ -780,6 +807,14 @@ fn build_store(
     );
     write_u64(&mut out, HEADER_DATA_OFFSET_OFFSET, data_offset as u64);
     write_u64(&mut out, HEADER_TOTAL_LEN_OFFSET, cursor as u64);
+    let gap_threshold_factor = source.interpolation_options().gap_threshold_factor;
+    if gap_threshold_factor != DEFAULT_GAP_THRESHOLD_FACTOR {
+        write_f64(
+            &mut out,
+            HEADER_GAP_THRESHOLD_FACTOR_OFFSET,
+            gap_threshold_factor,
+        );
+    }
 
     for (idx, layout) in layouts.iter().enumerate() {
         let fitted = source
@@ -972,7 +1007,13 @@ fn parse_store<'a>(
     }
 
     ensure_zero(bytes, 11, 12, "header reserved byte")?;
-    ensure_zero(bytes, 48, STORE_HEADER_LEN, "header reserved bytes")?;
+    let interpolation = read_header_interpolation(bytes)?;
+    ensure_zero(
+        bytes,
+        HEADER_RESERVED_OFFSET,
+        STORE_HEADER_LEN,
+        "header reserved bytes",
+    )?;
     let time_scale = time_scale_from_tag(bytes[HEADER_TIME_SCALE_OFFSET])?;
     let sat_count = read_u32(bytes, HEADER_SAT_COUNT_OFFSET)? as usize;
     let index_offset = read_u64(bytes, HEADER_INDEX_OFFSET_OFFSET)? as usize;
@@ -1214,12 +1255,18 @@ fn parse_store<'a>(
         time_scale,
         satellites,
         series,
+        interpolation,
     })
 }
 
 // invariant: validated mapped payloads contain finite ITRF coordinates.
 #[allow(clippy::expect_used)]
-fn interpolate_mapped_state(bytes: &[u8], series: &MmapSeries, query: f64) -> Result<Sp3State> {
+fn interpolate_mapped_state(
+    bytes: &[u8],
+    series: &MmapSeries,
+    query: f64,
+    gap_threshold_factor: f64,
+) -> Result<Sp3State> {
     if series.pos_count < 2 {
         return Err(Error::EpochOutOfRange);
     }
@@ -1231,7 +1278,7 @@ fn interpolate_mapped_state(bytes: &[u8], series: &MmapSeries, query: f64) -> Re
         return Err(Error::EpochOutOfRange);
     }
 
-    let gap_thresh = 1.5 * nominal;
+    let gap_thresh = gap_threshold_factor * nominal;
     let mut bi = 0usize;
     while bi + 1 < series.pos_count && series.pos_x.get(bytes, bi + 1) <= query {
         bi += 1;
@@ -1244,7 +1291,8 @@ fn interpolate_mapped_state(bytes: &[u8], series: &MmapSeries, query: f64) -> Re
         }
     }
 
-    let (x_m, y_m, z_m) = interpolate_mapped_position_neville(bytes, series, query);
+    let (x_m, y_m, z_m) =
+        interpolate_mapped_position_neville(bytes, series, query, gap_threshold_factor);
     let clock_s = interpolate_mapped_clock(bytes, series, query);
     Ok(Sp3State {
         position: ItrfPositionM::new(x_m, y_m, z_m).expect("valid ITRF position"),
@@ -1259,10 +1307,11 @@ fn interpolate_mapped_position_neville(
     bytes: &[u8],
     series: &MmapSeries,
     query: f64,
+    gap_threshold_factor: f64,
 ) -> (f64, f64, f64) {
     let n = series.pos_count;
     let nominal = nominal_positive_spacing(bytes, series).unwrap_or(1.0);
-    let gap_thresh = 1.5 * nominal;
+    let gap_thresh = gap_threshold_factor * nominal;
 
     let mut pivot = 0usize;
     while pivot + 1 < n && series.pos_x.get(bytes, pivot + 1) <= query {
@@ -1463,6 +1512,21 @@ fn time_scale_tag(scale: TimeScale) -> u8 {
         TimeScale::Glonasst => 10,
         TimeScale::Qzsst => 11,
     }
+}
+
+fn read_header_interpolation(
+    bytes: &[u8],
+) -> core::result::Result<Sp3InterpolationOptions, PreciseInterpolantStoreError> {
+    let raw = read_array::<8>(bytes, HEADER_GAP_THRESHOLD_FACTOR_OFFSET)?;
+    if raw == [0u8; 8] {
+        return Ok(Sp3InterpolationOptions::default());
+    }
+    let factor = f64::from_le_bytes(raw);
+    Sp3InterpolationOptions::new(factor).map_err(|_| {
+        parse_error(format!(
+            "header gap threshold factor {factor} must be finite and greater than 1.0"
+        ))
+    })
 }
 
 fn time_scale_from_tag(tag: u8) -> core::result::Result<TimeScale, PreciseInterpolantStoreError> {

--- a/crates/sidereon-core/src/sp3/interpolant_store.rs
+++ b/crates/sidereon-core/src/sp3/interpolant_store.rs
@@ -1297,7 +1297,8 @@ fn interpolate_mapped_state(
         // Same failure as the in-memory path: admitted nodes far from the
         // query can coincide at its precision and zero a Neville denominator.
         return Err(Error::InvalidInput(format!(
-            "selected nodes are not distinct at the precision of query {query}"
+            "non-finite interpolated position at query {query}: the selected nodes are not \
+             distinct at its precision, or the coordinates overflow"
         )));
     }
     let clock_s = interpolate_mapped_clock(bytes, series, query);

--- a/crates/sidereon-core/src/sp3/mod.rs
+++ b/crates/sidereon-core/src/sp3/mod.rs
@@ -383,6 +383,9 @@ pub struct Sp3 {
     /// from the public meters (`km->m->km`) drifts up to 1 ULP and breaks the
     /// 0-ULP parity. See `sp3/interp.rs`.
     interp_raw: Vec<BTreeMap<GnssSatelliteId, RawNode>>,
+    /// How node series are interpreted for interpolation. Not part of the
+    /// SP3 text and excluded from equality; see [`Sp3InterpolationOptions`].
+    interpolation: Sp3InterpolationOptions,
     /// Free-form `/*` comment lines (notice retained for provenance).
     pub comments: Vec<String>,
     /// Count of entries skipped because their satellite token did not parse to a
@@ -447,6 +450,23 @@ impl Sp3 {
             parser.feed(raw, index + 1)?;
         }
         parser.finish()
+    }
+
+    /// The interpretation policy this product's node series are read with.
+    pub fn interpolation_options(&self) -> Sp3InterpolationOptions {
+        self.interpolation
+    }
+
+    /// Return the product with a different interpretation policy.
+    ///
+    /// Everything that selects nodes from the product reads it: position
+    /// interpolation, the window-scoped reach through
+    /// [`StencilExtent::for_sp3`], and a mapped store written from it. The
+    /// policy is not SP3 text, so `to_sp3_string` followed by `parse` yields
+    /// the default again, and `merge` output carries the default.
+    pub fn with_interpolation_options(mut self, options: Sp3InterpolationOptions) -> Self {
+        self.interpolation = options;
+        self
     }
 
     /// The satellites present in this product (from the header satellite list).
@@ -1343,6 +1363,7 @@ impl Parser {
             epoch_j2000_s: self.epoch_j2000_s,
             states: self.states,
             interp_raw: self.interp_raw,
+            interpolation: Sp3InterpolationOptions::default(),
             comments: self.comments,
             skipped_records,
         })
@@ -1535,6 +1556,7 @@ pub use continuity::{
 pub use exact::{
     parse_exact_sp3, validate_exact_sp3, ExactSp3Coverage, ExactSp3Request, ExactSp3ValidationError,
 };
+pub use interp::{Sp3InterpolationOptions, DEFAULT_GAP_THRESHOLD_FACTOR};
 pub use interpolant::{PreciseEphemerisInterpolant, PreciseInterpolantError};
 pub use interpolant_store::{
     precise_interpolant_store_checksum64, MmapPreciseEphemerisInterpolant,

--- a/crates/sidereon-core/src/sp3/samples.rs
+++ b/crates/sidereon-core/src/sp3/samples.rs
@@ -51,7 +51,7 @@ use crate::id::GnssSatelliteId;
 use crate::observables::{ObservableEphemerisSource, ObservableState, ObservablesError};
 use crate::sp3::interp::{
     instant_to_j2000_seconds, interpolate_precise_state, precise_node_j2000_seconds_from_instant,
-    PreciseSatSeries,
+    PreciseSatSeries, Sp3InterpolationOptions,
 };
 use crate::sp3::{Sp3, Sp3State};
 use crate::{Error, Result};
@@ -237,6 +237,7 @@ impl std::error::Error for PreciseSamplesError {}
 pub struct PreciseEphemerisSamples {
     time_scale: TimeScale,
     nodes: BTreeMap<GnssSatelliteId, PreciseSatSeries>,
+    interpolation: Sp3InterpolationOptions,
 }
 
 impl PreciseEphemerisSamples {
@@ -330,6 +331,7 @@ impl PreciseEphemerisSamples {
 
         Ok(Self {
             time_scale: time_scale.expect("non-empty group has a time scale"),
+            interpolation: Sp3InterpolationOptions::default(),
             nodes: grouped,
         })
     }
@@ -337,6 +339,18 @@ impl PreciseEphemerisSamples {
     /// The time scale every sample epoch is expressed in.
     pub fn time_scale(&self) -> TimeScale {
         self.time_scale
+    }
+
+    /// The interpretation policy this source reads its node series with.
+    pub fn interpolation_options(&self) -> Sp3InterpolationOptions {
+        self.interpolation
+    }
+
+    /// Return the source with a different interpretation policy.
+    #[must_use]
+    pub fn with_interpolation_options(mut self, options: Sp3InterpolationOptions) -> Self {
+        self.interpolation = options;
+        self
     }
 
     /// The satellites this source can interpolate, in ascending order.
@@ -371,9 +385,17 @@ impl PreciseEphemerisSamples {
                 &series.kz,
                 &series.clk,
                 query,
+                self.interpolation.gap_threshold_factor,
             ),
             None => interpolate_precise_state(
-                sat, &EMPTY_F64, &EMPTY_F64, &EMPTY_F64, &EMPTY_F64, &EMPTY_CLK, query,
+                sat,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_F64,
+                &EMPTY_CLK,
+                query,
+                self.interpolation.gap_threshold_factor,
             ),
         }
     }

--- a/crates/sidereon-core/src/sp3/samples.rs
+++ b/crates/sidereon-core/src/sp3/samples.rs
@@ -385,7 +385,7 @@ impl PreciseEphemerisSamples {
                 &series.kz,
                 &series.clk,
                 query,
-                self.interpolation.gap_threshold_factor,
+                self.interpolation.gap_threshold_factor(),
             ),
             None => interpolate_precise_state(
                 sat,
@@ -395,7 +395,7 @@ impl PreciseEphemerisSamples {
                 &EMPTY_F64,
                 &EMPTY_CLK,
                 query,
-                self.interpolation.gap_threshold_factor,
+                self.interpolation.gap_threshold_factor(),
             ),
         }
     }

--- a/crates/sidereon-core/src/sp3/tests.rs
+++ b/crates/sidereon-core/src/sp3/tests.rs
@@ -1729,3 +1729,172 @@ fn stencil_reach_covers_an_irregular_run_wider_than_eleven_nominal_spacings() {
         "the first node is selected for this query"
     );
 }
+
+fn gapped_g01_product() -> Sp3 {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/sp3/GAP_G01_20201760000_15M.sp3"
+    );
+    let bytes = std::fs::read(path).expect("read committed gapped SP3 fixture");
+    Sp3::parse(&bytes).expect("parse gapped SP3 fixture")
+}
+
+/// Midpoint of the G01 hole in `GAP_G01_20201760000_15M.sp3`, seconds since
+/// J2000: the 07:15 and 10:15 nodes bracket it at 646_254_900 and 646_265_700.
+const GAP_G01_MID_HOLE_J2000_S: f64 = 646_260_300.0;
+
+#[test]
+fn interpolation_options_reject_a_factor_that_would_split_every_run() {
+    assert!(Sp3InterpolationOptions::new(1.0).is_err());
+    assert!(Sp3InterpolationOptions::new(0.5).is_err());
+    assert!(Sp3InterpolationOptions::new(f64::NAN).is_err());
+    assert!(Sp3InterpolationOptions::new(f64::INFINITY).is_err());
+    assert_eq!(
+        Sp3InterpolationOptions::new(DEFAULT_GAP_THRESHOLD_FACTOR).unwrap(),
+        Sp3InterpolationOptions::default()
+    );
+    assert_eq!(DEFAULT_GAP_THRESHOLD_FACTOR, 1.5);
+}
+
+#[test]
+fn a_product_parses_with_the_default_gap_threshold_and_keeps_it_out_of_equality() {
+    let default = gapped_g01_product();
+    assert_eq!(
+        default.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+
+    let wide = gapped_g01_product()
+        .with_interpolation_options(Sp3InterpolationOptions::new(13.0).unwrap());
+    assert_eq!(wide.interpolation_options().gap_threshold_factor, 13.0);
+    // The policy is not product content: same records, equal products.
+    assert_eq!(wide, default);
+    // And it is not SP3 text either: a text round trip yields the default.
+    let reparsed = Sp3::parse(wide.to_sp3_string().as_bytes()).expect("reparse");
+    assert_eq!(
+        reparsed.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+}
+
+#[test]
+fn a_wider_gap_threshold_bridges_a_hole_the_default_refuses() {
+    let g01 = id(GnssSystem::Gps, 1);
+    let g02 = id(GnssSystem::Gps, 2);
+    let default = gapped_g01_product();
+    // The hole is twelve nominal spacings wide; 13 bridges it, 1.5 does not.
+    let wide = gapped_g01_product()
+        .with_interpolation_options(Sp3InterpolationOptions::new(13.0).unwrap());
+
+    assert_eq!(
+        default.position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S),
+        Err(Error::EpochOutOfRange)
+    );
+    let bridged = wide
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .expect("a run that tolerates the hole serves its midpoint");
+    assert!(bridged.position.x_m.is_finite());
+
+    // A satellite without a hole selects the same nodes under either policy.
+    let contiguous_query = GAP_G01_MID_HOLE_J2000_S + 450.0;
+    let want = default
+        .position_at_j2000_seconds(g02, contiguous_query)
+        .unwrap();
+    let got = wide
+        .position_at_j2000_seconds(g02, contiguous_query)
+        .unwrap();
+    assert_eq!(got.position.x_m.to_bits(), want.position.x_m.to_bits());
+    assert_eq!(got.position.y_m.to_bits(), want.position.y_m.to_bits());
+    assert_eq!(got.position.z_m.to_bits(), want.position.z_m.to_bits());
+
+    // The cached interpolant and the sample-backed source carry the policy too.
+    let cached = PreciseEphemerisInterpolant::from_sp3(&wide);
+    assert_eq!(cached.interpolation_options().gap_threshold_factor, 13.0);
+    let via_cache = cached
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .expect("cached interpolant honours the product policy");
+    assert_eq!(
+        via_cache.position.x_m.to_bits(),
+        bridged.position.x_m.to_bits()
+    );
+    assert!(PreciseEphemerisInterpolant::from_sp3(&default)
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .is_err());
+}
+
+#[test]
+fn stencil_reach_follows_the_gap_threshold() {
+    use super::continuity::StencilExtent;
+
+    let default = gapped_g01_product();
+    let reach = StencilExtent::for_sp3(&default).expect("gapped product stencil");
+    // Every run is uniform at 900 s: ten steps plus one nominal spacing.
+    assert_eq!(reach.before_s(), 11.0 * 900.0);
+
+    let wide = gapped_g01_product()
+        .with_interpolation_options(Sp3InterpolationOptions::new(13.0).unwrap());
+    let reach = StencilExtent::for_sp3(&wide).expect("bridged product stencil");
+    // G01's run now spans the hole: nine 900 s steps, one 10,800 s step, plus
+    // one nominal spacing.
+    assert_eq!(reach.before_s(), 9.0 * 900.0 + 10_800.0 + 900.0);
+    assert_eq!(reach.after_s(), reach.before_s());
+}
+
+#[test]
+fn continuity_options_carry_the_default_interpretation_policy() {
+    use super::continuity::{ContinuityOptions, OrbitClass};
+
+    assert_eq!(
+        ContinuityOptions::new(None, Some(1.0)).interpolation,
+        Sp3InterpolationOptions::default()
+    );
+    assert_eq!(
+        ContinuityOptions::for_orbit_class(OrbitClass::MeoGnss).interpolation,
+        Sp3InterpolationOptions::default()
+    );
+    let wide = Sp3InterpolationOptions::new(13.0).unwrap();
+    assert_eq!(
+        ContinuityOptions::new(None, Some(1.0))
+            .with_interpolation_options(wide)
+            .interpolation,
+        wide
+    );
+}
+
+#[test]
+fn the_hold_out_replay_reads_nodes_under_the_continuity_options_policy() {
+    use super::continuity::{check_continuity, ContinuityDefect, ContinuityOptions};
+
+    let g01 = id(GnssSystem::Gps, 1);
+    let samples = gapped_g01_product().precise_ephemeris_samples();
+    // The 07:15 node is the last one before the hole. Held out, it is predicted
+    // from retained nodes on one side only under the default policy, and from
+    // nodes on both sides of the hole once the retained series bridges it.
+    let hole_edge_j2000_s = 646_254_900.0;
+    let residual_at_edge = |factor: f64| -> (usize, f64) {
+        let options = ContinuityOptions::new(None, Some(1.0))
+            .with_interpolation_options(Sp3InterpolationOptions::new(factor).unwrap());
+        let report = check_continuity(&samples, &options);
+        let residual_m = report
+            .defects
+            .iter()
+            .find_map(|defect| match defect {
+                ContinuityDefect::HoldOutResidual {
+                    sat,
+                    epoch_j2000_s,
+                    residual_m,
+                    ..
+                } if *sat == g01 && *epoch_j2000_s == hole_edge_j2000_s => Some(*residual_m),
+                _ => None,
+            })
+            .expect("the hole-edge node exceeds 1 m under either policy");
+        (report.residuals_checked, residual_m)
+    };
+
+    let (checked_default, residual_default) = residual_at_edge(DEFAULT_GAP_THRESHOLD_FACTOR);
+    let (checked_wide, residual_wide) = residual_at_edge(13.0);
+    // Same held-out set, different retained windows.
+    assert_eq!(checked_default, checked_wide);
+    assert!(residual_default > 20.0, "{residual_default}");
+    assert!(residual_wide < 5.0, "{residual_wide}");
+}

--- a/crates/sidereon-core/src/sp3/tests.rs
+++ b/crates/sidereon-core/src/sp3/tests.rs
@@ -1766,7 +1766,7 @@ fn a_product_parses_with_the_default_gap_threshold_and_keeps_it_out_of_equality(
 
     let wide = gapped_g01_product()
         .with_interpolation_options(Sp3InterpolationOptions::new(13.0).unwrap());
-    assert_eq!(wide.interpolation_options().gap_threshold_factor, 13.0);
+    assert_eq!(wide.interpolation_options().gap_threshold_factor(), 13.0);
     // The policy is not product content: same records, equal products.
     assert_eq!(wide, default);
     // And it is not SP3 text either: a text round trip yields the default.
@@ -1807,9 +1807,9 @@ fn a_wider_gap_threshold_bridges_a_hole_the_default_refuses() {
     assert_eq!(got.position.y_m.to_bits(), want.position.y_m.to_bits());
     assert_eq!(got.position.z_m.to_bits(), want.position.z_m.to_bits());
 
-    // The cached interpolant and the sample-backed source carry the policy too.
+    // The cached interpolant built from the product carries the policy too.
     let cached = PreciseEphemerisInterpolant::from_sp3(&wide);
-    assert_eq!(cached.interpolation_options().gap_threshold_factor, 13.0);
+    assert_eq!(cached.interpolation_options().gap_threshold_factor(), 13.0);
     let via_cache = cached
         .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
         .expect("cached interpolant honours the product policy");
@@ -1897,4 +1897,139 @@ fn the_hold_out_replay_reads_nodes_under_the_continuity_options_policy() {
     assert_eq!(checked_default, checked_wide);
     assert!(residual_default > 20.0, "{residual_default}");
     assert!(residual_wide < 5.0, "{residual_wide}");
+}
+
+#[test]
+fn a_samples_source_takes_the_policy_directly_and_hands_it_to_a_cached_interpolant() {
+    let g01 = id(GnssSystem::Gps, 1);
+    let samples = gapped_g01_product().precise_ephemeris_samples();
+    let wide = Sp3InterpolationOptions::new(13.0).unwrap();
+
+    let source = PreciseEphemerisSamples::from_samples(samples.iter().cloned()).unwrap();
+    assert_eq!(
+        source.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+    assert_eq!(
+        source.position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S),
+        Err(Error::EpochOutOfRange)
+    );
+    let source = source.with_interpolation_options(wide);
+    assert_eq!(source.interpolation_options(), wide);
+    let from_source = source
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .expect("a samples source honours its own policy");
+
+    // A cached interpolant built from the source inherits it.
+    let cached = PreciseEphemerisInterpolant::from_precise_ephemeris_samples(&source);
+    assert_eq!(cached.interpolation_options(), wide);
+    let from_cached = cached
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .expect("the cached interpolant inherits the source policy");
+    assert_eq!(
+        from_cached.position.x_m.to_bits(),
+        from_source.position.x_m.to_bits()
+    );
+    assert_eq!(
+        from_cached.position.y_m.to_bits(),
+        from_source.position.y_m.to_bits()
+    );
+    assert_eq!(
+        from_cached.position.z_m.to_bits(),
+        from_source.position.z_m.to_bits()
+    );
+
+    // Built from raw samples, it starts at the default like any other source.
+    let from_raw = PreciseEphemerisInterpolant::from_samples(samples).unwrap();
+    assert_eq!(
+        from_raw.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+    assert_eq!(
+        from_raw.position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S),
+        Err(Error::EpochOutOfRange)
+    );
+}
+
+#[test]
+fn a_cached_interpolant_can_override_the_product_policy() {
+    let g01 = id(GnssSystem::Gps, 1);
+    let wide = Sp3InterpolationOptions::new(13.0).unwrap();
+    let default = gapped_g01_product();
+
+    let overridden =
+        PreciseEphemerisInterpolant::from_sp3(&default).with_interpolation_options(wide);
+    assert_eq!(overridden.interpolation_options(), wide);
+    let got = overridden
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .expect("the override bridges the hole");
+    let want = PreciseEphemerisInterpolant::from_sp3(&default.with_interpolation_options(wide))
+        .position_at_j2000_seconds(g01, GAP_G01_MID_HOLE_J2000_S)
+        .unwrap();
+    assert_eq!(got.position.x_m.to_bits(), want.position.x_m.to_bits());
+    assert_eq!(got.position.y_m.to_bits(), want.position.y_m.to_bits());
+    assert_eq!(got.position.z_m.to_bits(), want.position.z_m.to_bits());
+}
+
+#[test]
+fn merge_output_carries_the_default_policy() {
+    use super::combine::{merge, MergeCombine, MergeOptions, MergePrecedenceScope};
+
+    let wide = gapped_g01_product()
+        .with_interpolation_options(Sp3InterpolationOptions::new(13.0).unwrap());
+    let options = MergeOptions {
+        combine: MergeCombine::Precedence,
+        precedence_scope: MergePrecedenceScope::Cell,
+        min_agree: 1,
+        ..MergeOptions::default()
+    };
+    let (merged, _report) = merge(&[wide], &options).expect("merge one configured source");
+    assert_eq!(
+        merged.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+    assert_eq!(
+        merged.position_at_j2000_seconds(id(GnssSystem::Gps, 1), GAP_G01_MID_HOLE_J2000_S),
+        Err(Error::EpochOutOfRange)
+    );
+}
+
+#[test]
+fn nodes_admitted_too_far_from_the_query_to_stay_distinct_are_an_error_not_a_panic() {
+    use super::interp::interpolate_precise_state;
+
+    let g01 = id(GnssSystem::Gps, 1);
+    // Six nodes a second apart and one 1e100 s away. A factor of f64::MAX
+    // admits the far node into the run; measured from a query of 5e99 the six
+    // near nodes coincide, and Neville divides by zero.
+    let x = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1e100];
+    let k = [26_000.0; 7];
+    let query = 5e99;
+    assert_eq!(
+        interpolate_precise_state(
+            g01,
+            &x,
+            &k,
+            &k,
+            &k,
+            &[],
+            query,
+            DEFAULT_GAP_THRESHOLD_FACTOR
+        ),
+        Err(Error::EpochOutOfRange)
+    );
+    let widest = Sp3InterpolationOptions::new(f64::MAX).unwrap();
+    match interpolate_precise_state(
+        g01,
+        &x,
+        &k,
+        &k,
+        &k,
+        &[],
+        query,
+        widest.gap_threshold_factor(),
+    ) {
+        Err(Error::InvalidInput(message)) => assert!(message.contains("not distinct"), "{message}"),
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
 }

--- a/crates/sidereon-core/src/sp3/tests.rs
+++ b/crates/sidereon-core/src/sp3/tests.rs
@@ -1565,66 +1565,68 @@ fn grg_final_product() -> Sp3 {
     Sp3::parse(&bytes).expect("parse committed SP3 fixture")
 }
 
-/// An `Instant` `offset_s` after the product's epoch `idx`, on its time scale.
-fn instant_after_epoch(
-    product: &Sp3,
-    idx: usize,
-    offset_s: f64,
-) -> crate::astro::time::model::Instant {
-    use crate::astro::time::civil::split_julian_date_add_seconds;
-    use crate::astro::time::model::{Instant, InstantRepr, JulianDateSplit};
-    let epoch = product.epochs[idx];
-    match epoch.repr {
-        InstantRepr::JulianDate(split) => {
-            let (jd_whole, fraction) =
-                split_julian_date_add_seconds(split.jd_whole, split.fraction, offset_s);
-            Instant::from_julian_date(
-                epoch.scale,
-                JulianDateSplit::new(jd_whole, fraction).expect("shifted split epoch"),
-            )
-        }
-        InstantRepr::Nanos(nanos) => {
-            Instant::from_nanos(epoch.scale, nanos + (offset_s * 1.0e9).round() as i128)
-        }
-    }
+/// `epochs` is public; a product whose epoch list has been extended past its
+/// node table must still produce a reach rather than index past the table.
+#[test]
+fn stencil_reach_tolerates_epochs_beyond_the_node_table() {
+    use super::continuity::StencilExtent;
+
+    let mut product = grg_final_product();
+    let reach_before = StencilExtent::for_sp3(&product).expect("product stencil");
+    let last = *product.epochs.last().expect("fixture has epochs");
+    product.epochs.push(last);
+    let reach_after =
+        StencilExtent::for_sp3(&product).expect("an extended epoch list must not panic");
+    assert_eq!(reach_after, reach_before);
 }
 
-/// The reported reach follows the sparsest satellite's own node spacing, not
-/// the header interval: the interpolator selects nodes per satellite.
+/// A uniformly sampled product's reach is eleven header intervals: ten for the
+/// window span plus one for the served extrapolation past a run.
 #[test]
-fn stencil_reach_follows_the_widest_per_satellite_spacing() {
+fn stencil_reach_of_a_uniform_product_is_eleven_intervals() {
     use super::continuity::StencilExtent;
     use super::interp::NEVILLE_POINTS;
 
     let dense = grg_final_product();
     assert_eq!(dense.header.epoch_interval_s, 900.0);
-    let dense_reach = StencilExtent::for_sp3(&dense).expect("dense product stencil");
-    assert_eq!(dense_reach.before_s(), NEVILLE_POINTS as f64 * 900.0);
-    assert_eq!(dense_reach.after_s(), NEVILLE_POINTS as f64 * 900.0);
+    let reach = StencilExtent::for_sp3(&dense).expect("dense product stencil");
+    assert_eq!(reach.before_s(), NEVILLE_POINTS as f64 * 900.0);
+    assert_eq!(reach.after_s(), NEVILLE_POINTS as f64 * 900.0);
+}
 
-    // Thin one satellite to every other epoch. Its nominal spacing is now
-    // 1,800 s, so its 11-node span is 18,000 s and a defect up to 19,800 s
-    // from a query can sit on a node that evaluates it.
+/// The reach follows the sparsest satellite's own node series, not the header
+/// interval, because the interpolator selects nodes per satellite.
+#[test]
+fn stencil_reach_follows_the_sparsest_satellite() {
+    use super::continuity::StencilExtent;
+
+    let dense = grg_final_product();
+    let dense_reach = StencilExtent::for_sp3(&dense).expect("dense product stencil");
+
+    // Thin one satellite to every other epoch: its nodes are 1,800 s apart, so
+    // its widest 11-node window spans 18,000 s and a query served one spacing
+    // past it reaches a node 19,800 s away.
     let mut sparse = dense.clone();
     let sat = sparse.satellites()[0];
     for idx in (1..sparse.interp_raw.len()).step_by(2) {
         sparse.interp_raw[idx].remove(&sat);
     }
     let sparse_reach = StencilExtent::for_sp3(&sparse).expect("sparse product stencil");
-    assert_eq!(sparse_reach.before_s(), NEVILLE_POINTS as f64 * 1_800.0);
-    assert_eq!(sparse_reach.after_s(), NEVILLE_POINTS as f64 * 1_800.0);
+    assert!(sparse_reach.before_s() > dense_reach.before_s());
+    assert_eq!(sparse_reach.before_s(), 10.0 * 1_800.0 + 1_800.0);
+    assert_eq!(sparse_reach.after_s(), sparse_reach.before_s());
 }
 
-/// Every node that moves a run-end query lies inside the reported reach.
+/// Every node that moves a query served one spacing past the run lies inside
+/// the reported reach.
 ///
 /// This drives the real interpolator rather than an injected report. A node
 /// counts as selected if perturbing it by one meter moves the interpolated
-/// position at all. At the product's final interval the stencil slides inward,
-/// so the selected nodes reach far behind the query; each of them must be
-/// within `before_s` of it, or a window verdict could accept a defect on a node
-/// the interpolation used.
+/// position at all. The query sits half a spacing past the last node, which
+/// the interpolator serves by extrapolation, so the window is the run's final
+/// eleven nodes and the farthest of them is ten and a half spacings back.
 #[test]
-fn every_node_that_moves_a_run_end_query_is_inside_the_reported_reach() {
+fn every_node_that_moves_an_extrapolated_run_end_query_is_inside_the_reported_reach() {
     use super::continuity::StencilExtent;
     use super::interp::NEVILLE_POINTS;
 
@@ -1633,13 +1635,12 @@ fn every_node_that_moves_a_run_end_query_is_inside_the_reported_reach() {
     let sat = product.satellites()[0];
     let nodes = product.epochs_j2000_seconds();
     let n = nodes.len();
-    let half_interval_s = 0.5 * (nodes[n - 1] - nodes[n - 2]);
-    let query = instant_after_epoch(&product, n - 2, half_interval_s);
-    let query_s = nodes[n - 2] + half_interval_s;
+    let spacing_s = nodes[n - 1] - nodes[n - 2];
+    let query_s = nodes[n - 1] + 0.5 * spacing_s;
 
     let baseline = product
-        .position(sat, query)
-        .expect("baseline interpolation")
+        .position_at_j2000_seconds(sat, query_s)
+        .expect("a query half a spacing past the last node is served")
         .position;
 
     let mut moved = Vec::new();
@@ -1650,16 +1651,17 @@ fn every_node_that_moves_a_run_end_query_is_inside_the_reported_reach() {
         };
         raw.km[0] += 1.0e-3;
         let shifted = perturbed
-            .position(sat, query)
+            .position_at_j2000_seconds(sat, query_s)
             .expect("perturbed interpolation")
             .position;
         if shifted != baseline {
             moved.push(idx);
         }
     }
-    assert!(
-        moved.len() >= NEVILLE_POINTS - 1,
-        "the run-end stencil should select most of the last {NEVILLE_POINTS} nodes, got {moved:?}"
+    assert_eq!(
+        moved.len(),
+        NEVILLE_POINTS,
+        "the run-end stencil should select the last {NEVILLE_POINTS} nodes, got {moved:?}"
     );
     for idx in moved {
         let distance_s = query_s - nodes[idx];
@@ -1669,4 +1671,61 @@ fn every_node_that_moves_a_run_end_query_is_inside_the_reported_reach() {
             stencil.before_s()
         );
     }
+}
+
+/// A run with irregular gaps spans more than eleven nominal spacings.
+///
+/// The nominal spacing is the smallest gap, and a run tolerates gaps up to 1.5
+/// times that. Eleven nodes at 0, 600, 1500, 2400, ..., 8700 s have a nominal
+/// spacing of 600 s but span 8,700 s, and a query 300 s past the last node is
+/// served with all eleven selected, so the first node sits 9,000 s from the
+/// query. A reach of eleven nominal spacings (6,600 s) would let a window
+/// verdict accept a defect on that node.
+#[test]
+fn stencil_reach_covers_an_irregular_run_wider_than_eleven_nominal_spacings() {
+    use super::continuity::StencilExtent;
+
+    let mut product = {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/sp3/COD0MGXFIN_20201770000_01D_05M_ORB.SP3"
+        );
+        let bytes = std::fs::read(path).expect("read committed CODE product");
+        Sp3::parse(&bytes).expect("parse committed CODE product")
+    };
+    assert_eq!(product.header.epoch_interval_s, 300.0);
+    let sat = product.satellites()[0];
+    let keep: [usize; 11] = [0, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29];
+    for idx in 0..product.interp_raw.len() {
+        if !keep.contains(&idx) {
+            product.interp_raw[idx].remove(&sat);
+        }
+    }
+    let nodes = product.epochs_j2000_seconds();
+    let query_s = nodes[0] + 9_000.0;
+
+    let stencil = StencilExtent::for_sp3(&product).expect("product stencil");
+    assert!(
+        stencil.before_s() >= 9_000.0,
+        "reach {:.0} s does not cover a selected node 9,000 s from a served query",
+        stencil.before_s()
+    );
+
+    let baseline = product
+        .position_at_j2000_seconds(sat, query_s)
+        .expect("a query 300 s past the last node is served")
+        .position;
+    let mut perturbed = product.clone();
+    perturbed.interp_raw[0]
+        .get_mut(&sat)
+        .expect("first node kept")
+        .km[2] += 1.0e-3;
+    let shifted = perturbed
+        .position_at_j2000_seconds(sat, query_s)
+        .expect("perturbed interpolation")
+        .position;
+    assert_ne!(
+        shifted, baseline,
+        "the first node is selected for this query"
+    );
 }

--- a/crates/sidereon-core/src/sp3/tests.rs
+++ b/crates/sidereon-core/src/sp3/tests.rs
@@ -1555,3 +1555,118 @@ EOF
         "parse -> write -> parse changed product"
     );
 }
+
+fn grg_final_product() -> Sp3 {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/sp3/GRG0MGXFIN_20201760000_01D_15M_ORB.SP3"
+    );
+    let bytes = std::fs::read(path).expect("read committed SP3 fixture");
+    Sp3::parse(&bytes).expect("parse committed SP3 fixture")
+}
+
+/// An `Instant` `offset_s` after the product's epoch `idx`, on its time scale.
+fn instant_after_epoch(
+    product: &Sp3,
+    idx: usize,
+    offset_s: f64,
+) -> crate::astro::time::model::Instant {
+    use crate::astro::time::civil::split_julian_date_add_seconds;
+    use crate::astro::time::model::{Instant, InstantRepr, JulianDateSplit};
+    let epoch = product.epochs[idx];
+    match epoch.repr {
+        InstantRepr::JulianDate(split) => {
+            let (jd_whole, fraction) =
+                split_julian_date_add_seconds(split.jd_whole, split.fraction, offset_s);
+            Instant::from_julian_date(
+                epoch.scale,
+                JulianDateSplit::new(jd_whole, fraction).expect("shifted split epoch"),
+            )
+        }
+        InstantRepr::Nanos(nanos) => {
+            Instant::from_nanos(epoch.scale, nanos + (offset_s * 1.0e9).round() as i128)
+        }
+    }
+}
+
+/// The reported reach follows the sparsest satellite's own node spacing, not
+/// the header interval: the interpolator selects nodes per satellite.
+#[test]
+fn stencil_reach_follows_the_widest_per_satellite_spacing() {
+    use super::continuity::StencilExtent;
+    use super::interp::NEVILLE_POINTS;
+
+    let dense = grg_final_product();
+    assert_eq!(dense.header.epoch_interval_s, 900.0);
+    let dense_reach = StencilExtent::for_sp3(&dense).expect("dense product stencil");
+    assert_eq!(dense_reach.before_s(), NEVILLE_POINTS as f64 * 900.0);
+    assert_eq!(dense_reach.after_s(), NEVILLE_POINTS as f64 * 900.0);
+
+    // Thin one satellite to every other epoch. Its nominal spacing is now
+    // 1,800 s, so its 11-node span is 18,000 s and a defect up to 19,800 s
+    // from a query can sit on a node that evaluates it.
+    let mut sparse = dense.clone();
+    let sat = sparse.satellites()[0];
+    for idx in (1..sparse.interp_raw.len()).step_by(2) {
+        sparse.interp_raw[idx].remove(&sat);
+    }
+    let sparse_reach = StencilExtent::for_sp3(&sparse).expect("sparse product stencil");
+    assert_eq!(sparse_reach.before_s(), NEVILLE_POINTS as f64 * 1_800.0);
+    assert_eq!(sparse_reach.after_s(), NEVILLE_POINTS as f64 * 1_800.0);
+}
+
+/// Every node that moves a run-end query lies inside the reported reach.
+///
+/// This drives the real interpolator rather than an injected report. A node
+/// counts as selected if perturbing it by one meter moves the interpolated
+/// position at all. At the product's final interval the stencil slides inward,
+/// so the selected nodes reach far behind the query; each of them must be
+/// within `before_s` of it, or a window verdict could accept a defect on a node
+/// the interpolation used.
+#[test]
+fn every_node_that_moves_a_run_end_query_is_inside_the_reported_reach() {
+    use super::continuity::StencilExtent;
+    use super::interp::NEVILLE_POINTS;
+
+    let product = grg_final_product();
+    let stencil = StencilExtent::for_sp3(&product).expect("product stencil");
+    let sat = product.satellites()[0];
+    let nodes = product.epochs_j2000_seconds();
+    let n = nodes.len();
+    let half_interval_s = 0.5 * (nodes[n - 1] - nodes[n - 2]);
+    let query = instant_after_epoch(&product, n - 2, half_interval_s);
+    let query_s = nodes[n - 2] + half_interval_s;
+
+    let baseline = product
+        .position(sat, query)
+        .expect("baseline interpolation")
+        .position;
+
+    let mut moved = Vec::new();
+    for idx in 0..n {
+        let mut perturbed = product.clone();
+        let Some(raw) = perturbed.interp_raw[idx].get_mut(&sat) else {
+            continue;
+        };
+        raw.km[0] += 1.0e-3;
+        let shifted = perturbed
+            .position(sat, query)
+            .expect("perturbed interpolation")
+            .position;
+        if shifted != baseline {
+            moved.push(idx);
+        }
+    }
+    assert!(
+        moved.len() >= NEVILLE_POINTS - 1,
+        "the run-end stencil should select most of the last {NEVILLE_POINTS} nodes, got {moved:?}"
+    );
+    for idx in moved {
+        let distance_s = query_s - nodes[idx];
+        assert!(
+            distance_s <= stencil.before_s(),
+            "node {idx}, {distance_s:.0} s before the query, moves it but sits outside the reported reach of {:.0} s",
+            stencil.before_s()
+        );
+    }
+}

--- a/crates/sidereon-core/tests/precise_interpolant_store.rs
+++ b/crates/sidereon-core/tests/precise_interpolant_store.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sidereon_core::ephemeris::{
     precise_interpolant_store_checksum64, MmapPreciseEphemerisInterpolant,
-    PreciseEphemerisInterpolant, PreciseInterpolantStoreError, Sp3,
+    PreciseEphemerisInterpolant, PreciseInterpolantStoreError, Sp3, Sp3InterpolationOptions,
 };
 use sidereon_core::{GnssSatelliteId, GnssSystem};
 
@@ -245,4 +245,82 @@ fn precise_interpolant_store_rejects_corrupt_and_truncated_artifacts() {
         err,
         PreciseInterpolantStoreError::Checksum { .. } | PreciseInterpolantStoreError::Parse { .. }
     ));
+}
+
+/// Midpoint of the G01 hole, bracketed by the 07:15 and 10:15 nodes.
+const GAP_MID_HOLE_J2000_S: f64 = 646_260_300.0;
+/// Header bytes 48..56 hold the gap threshold factor, all-zero for the default.
+const HEADER_GAP_THRESHOLD_FACTOR_OFFSET: usize = 48;
+const HEADER_CHECKSUM_OFFSET: usize = 40;
+const STORE_HEADER_LEN: usize = 64;
+
+fn gapped_sp3() -> Sp3 {
+    let bytes = fs::read(fixture_path(GAP_15M_FIXTURE)).expect("read gapped SP3 fixture");
+    Sp3::parse(&bytes).expect("parse gapped SP3 fixture")
+}
+
+#[test]
+fn precise_interpolant_store_carries_a_non_default_gap_threshold() {
+    let default_bytes = PreciseEphemerisInterpolant::from_sp3(&gapped_sp3())
+        .to_mmap_store_bytes()
+        .expect("default artifact");
+    // A default-policy artifact leaves the header field zero, so its bytes are
+    // what they were before the field existed.
+    assert!(
+        default_bytes[HEADER_GAP_THRESHOLD_FACTOR_OFFSET..STORE_HEADER_LEN]
+            .iter()
+            .all(|&b| b == 0)
+    );
+    let default_mapped = MmapPreciseEphemerisInterpolant::from_vec(default_bytes).expect("open");
+    assert_eq!(
+        default_mapped.interpolation_options(),
+        Sp3InterpolationOptions::default()
+    );
+    assert!(default_mapped
+        .position_at_j2000_seconds(gps(1), GAP_MID_HOLE_J2000_S)
+        .is_err());
+
+    // The hole is twelve nominal spacings wide; 13 bridges it.
+    let wide = Sp3InterpolationOptions::new(13.0).expect("valid policy");
+    let memory =
+        PreciseEphemerisInterpolant::from_sp3(&gapped_sp3().with_interpolation_options(wide));
+    let wide_bytes = memory.to_mmap_store_bytes().expect("wide artifact");
+    assert_eq!(
+        f64::from_le_bytes(
+            wide_bytes[HEADER_GAP_THRESHOLD_FACTOR_OFFSET..HEADER_GAP_THRESHOLD_FACTOR_OFFSET + 8]
+                .try_into()
+                .unwrap()
+        ),
+        13.0
+    );
+    let mapped = MmapPreciseEphemerisInterpolant::from_vec(wide_bytes).expect("open wide");
+    assert_eq!(mapped.interpolation_options(), wide);
+
+    let want = memory
+        .position_at_j2000_seconds(gps(1), GAP_MID_HOLE_J2000_S)
+        .expect("in-memory bridges the hole");
+    let got = mapped
+        .position_at_j2000_seconds(gps(1), GAP_MID_HOLE_J2000_S)
+        .expect("mapped bridges the hole");
+    assert_state_bits_eq(gps(1), GAP_MID_HOLE_J2000_S, got, want);
+}
+
+#[test]
+fn precise_interpolant_store_rejects_an_unusable_gap_threshold() {
+    let mut bytes = PreciseEphemerisInterpolant::from_sp3(&gapped_sp3())
+        .to_mmap_store_bytes()
+        .expect("default artifact");
+    bytes[HEADER_GAP_THRESHOLD_FACTOR_OFFSET..HEADER_GAP_THRESHOLD_FACTOR_OFFSET + 8]
+        .copy_from_slice(&1.0f64.to_le_bytes());
+    let checksum = precise_interpolant_store_checksum64(&bytes);
+    bytes[HEADER_CHECKSUM_OFFSET..HEADER_CHECKSUM_OFFSET + 8]
+        .copy_from_slice(&checksum.to_le_bytes());
+
+    let err = MmapPreciseEphemerisInterpolant::from_bytes(&bytes)
+        .expect_err("a factor of 1.0 would split every run");
+    assert!(
+        matches!(err, PreciseInterpolantStoreError::Parse { .. }),
+        "expected a parse rejection, got {err:?}"
+    );
+    assert!(err.to_string().contains("gap threshold factor"), "{err}");
 }

--- a/crates/sidereon-core/tests/precise_interpolant_store.rs
+++ b/crates/sidereon-core/tests/precise_interpolant_store.rs
@@ -307,20 +307,68 @@ fn precise_interpolant_store_carries_a_non_default_gap_threshold() {
 
 #[test]
 fn precise_interpolant_store_rejects_an_unusable_gap_threshold() {
-    let mut bytes = PreciseEphemerisInterpolant::from_sp3(&gapped_sp3())
+    let pristine = PreciseEphemerisInterpolant::from_sp3(&gapped_sp3())
         .to_mmap_store_bytes()
         .expect("default artifact");
-    bytes[HEADER_GAP_THRESHOLD_FACTOR_OFFSET..HEADER_GAP_THRESHOLD_FACTOR_OFFSET + 8]
-        .copy_from_slice(&1.0f64.to_le_bytes());
-    let checksum = precise_interpolant_store_checksum64(&bytes);
-    bytes[HEADER_CHECKSUM_OFFSET..HEADER_CHECKSUM_OFFSET + 8]
-        .copy_from_slice(&checksum.to_le_bytes());
+    for factor in [1.0, 0.5, -1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let mut bytes = pristine.clone();
+        bytes[HEADER_GAP_THRESHOLD_FACTOR_OFFSET..HEADER_GAP_THRESHOLD_FACTOR_OFFSET + 8]
+            .copy_from_slice(&factor.to_le_bytes());
+        let checksum = precise_interpolant_store_checksum64(&bytes);
+        bytes[HEADER_CHECKSUM_OFFSET..HEADER_CHECKSUM_OFFSET + 8]
+            .copy_from_slice(&checksum.to_le_bytes());
 
-    let err = MmapPreciseEphemerisInterpolant::from_bytes(&bytes)
-        .expect_err("a factor of 1.0 would split every run");
-    assert!(
-        matches!(err, PreciseInterpolantStoreError::Parse { .. }),
-        "expected a parse rejection, got {err:?}"
-    );
-    assert!(err.to_string().contains("gap threshold factor"), "{err}");
+        let err = MmapPreciseEphemerisInterpolant::from_bytes(&bytes)
+            .expect_err("a factor the constructor rejects must not open");
+        assert!(
+            matches!(err, PreciseInterpolantStoreError::Parse { .. }),
+            "factor {factor}: expected a parse rejection, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("gap threshold factor"),
+            "factor {factor}: {err}"
+        );
+    }
+}
+
+/// Default-policy artifacts are byte-identical to those written before the
+/// header carried a gap threshold factor. Lengths and checksums computed at
+/// 2ddaf0b, the last commit without the field, on the same fixtures.
+#[test]
+fn default_policy_artifacts_are_byte_identical_to_those_written_before_the_header_field() {
+    let pins = [
+        (
+            "tests/fixtures/sp3/GAP_G01_20201760000_15M.sp3",
+            922_656usize,
+            0xf42f31591bdb97bd_u64,
+        ),
+        (COD_5M_FIXTURE, 2_591_808, 0xa2a11c9de566fda3),
+        (
+            "tests/fixtures/sp3/GRG0MGXFIN_20201760000_01D_15M_ORB.SP3",
+            926_752,
+            0x48ded418f39ddc05,
+        ),
+    ];
+    for (fixture, len, checksum) in pins {
+        let sp3 = Sp3::parse(&fs::read(fixture_path(fixture)).expect("read fixture"))
+            .expect("parse fixture");
+        assert_eq!(
+            sp3.interpolation_options(),
+            Sp3InterpolationOptions::default()
+        );
+        let bytes = sp3.precise_interpolant_store_bytes().expect("artifact");
+        assert_eq!(bytes.len(), len, "{fixture}: length");
+        assert_eq!(
+            precise_interpolant_store_checksum64(&bytes),
+            checksum,
+            "{fixture}: checksum"
+        );
+        // And such an artifact opens as the default policy, which is also how
+        // one written before the field existed opens.
+        let mapped = MmapPreciseEphemerisInterpolant::from_vec(bytes).expect("open");
+        assert_eq!(
+            mapped.interpolation_options(),
+            Sp3InterpolationOptions::default()
+        );
+    }
 }

--- a/crates/sidereon-core/tests/sp3_window_continuity.rs
+++ b/crates/sidereon-core/tests/sp3_window_continuity.rs
@@ -120,10 +120,11 @@ fn merged_daily_window_verdict_flips_when_the_stencil_reaches_the_seam() {
 
     let stencil = StencilExtent::for_sp3(&merged).expect("merged-product stencil");
     assert_eq!(merged.header.epoch_interval_s, 300.0);
-    // Ten intervals, not five: the reach is the one-sided stencil the
-    // interpolator selects at a run edge, which is the widest it ever uses.
-    assert_eq!(stencil.before_s(), 3_000.0);
-    assert_eq!(stencil.after_s(), 3_000.0);
+    // Eleven spacings, not five: ten for the one-sided stencil at a run edge
+    // plus one for a query served just outside a run. Every satellite in this
+    // product is sampled at the 300 s header interval.
+    assert_eq!(stencil.before_s(), 3_300.0);
+    assert_eq!(stencil.after_s(), 3_300.0);
 
     let inside_one_day =
         EpochWindow::new(seam - 18.0 * 3_600.0, seam - 6.0 * 3_600.0).expect("inside-day window");
@@ -184,10 +185,11 @@ fn window_and_stencil_constructors_reject_invalid_axes() {
 /// The interpolator centers its 11 nodes on the query only in the interior of
 /// a run. For a query in the last interval it keeps the node count and slides
 /// the window inward, so the earliest selected node sits up to ten intervals
-/// back rather than five. A reach derived from the centered stencil reported
-/// 1,500 s here, and a defect 1,800 s before the window fell outside it while
-/// sitting inside the nodes the interpolator actually selects. That is the
-/// unsafe direction: the verdict said Accept for a window the defect moves.
+/// back rather than five, and a query served one spacing past a run reaches
+/// eleven. A reach derived from the centered stencil reported 1,500 s here, and
+/// a defect 1,800 s before the window fell outside it while sitting inside the
+/// nodes the interpolator actually selects. That is the unsafe direction: the
+/// verdict said Accept for a window the defect moves.
 ///
 /// Demonstrated on this product by perturbing a node 1,650 s before a query in
 /// the final interval and watching the interpolated position move by 3.36 m.
@@ -224,9 +226,10 @@ fn a_defect_only_the_edge_stencil_reaches_still_refuses() {
     );
     assert_eq!(verdict.influencing_defects.len(), 1);
 
-    // Eleven intervals before the window start is beyond even the edge
-    // stencil, so the corrected reach does not simply refuse everything.
-    let beyond_any_stencil = epochs[n - 2] - 11.0 * interval_s;
+    // Twelve spacings before the window start is beyond even the widest
+    // stencil (eleven: ten for the edge slide, one for a query served just
+    // outside a run), so the corrected reach does not refuse everything.
+    let beyond_any_stencil = epochs[n - 2] - 12.0 * interval_s;
     let report = ContinuityReport {
         defects: vec![ContinuityDefect::DuplicateEpoch {
             sat,

--- a/docs/sp3-window-scoped-continuity.md
+++ b/docs/sp3-window-scoped-continuity.md
@@ -9,13 +9,18 @@ inclusive epoch window.
 ## Decision
 
 `EpochWindow` is expressed in seconds since J2000 on the SP3 product's own time
-scale. `StencilExtent::for_sp3` derives five intervals of reach before and after
-an evaluation epoch. Five is not a policy value supplied by the caller. It comes
-from the same `NEVILLE_POINTS = 11` constant used by the degree-10 sliding-window
-Lagrange position interpolator. The interval comes from the product header and
-must be positive and finite. The product's first epoch anchors the nominal grid.
-For non-node query times, filtering follows the interpolator by selecting the
-last grid node at or before each window bound before applying the five-interval
+scale. `StencilExtent::for_sp3` derives eleven spacings of reach before and
+after an evaluation epoch, where the spacing is the widest per-satellite nominal
+node spacing in the product, estimated exactly as the position interpolator
+estimates it. Eleven is not a policy value supplied by the caller. It comes from
+the same `NEVILLE_POINTS = 11` constant the degree-10 sliding-window Lagrange
+interpolator uses, plus how that window behaves at run edges: it keeps its node
+count and slides inward, so a query in a run's last interval reaches ten
+spacings back, and a query up to one spacing outside a run is still served, so
+the farthest selected node can sit eleven spacings away. The header interval
+must be positive and finite and is the fallback for a satellite with fewer than
+two nodes. The bounds are measured from the window bounds directly; snapping
+them to the header grid first let a selected node fall outside the upper bound.
 reach.
 
 A defect influences the window when its recorded epoch or epoch pair intersects

--- a/docs/sp3-window-scoped-continuity.md
+++ b/docs/sp3-window-scoped-continuity.md
@@ -9,19 +9,19 @@ inclusive epoch window.
 ## Decision
 
 `EpochWindow` is expressed in seconds since J2000 on the SP3 product's own time
-scale. `StencilExtent::for_sp3` derives eleven spacings of reach before and
-after an evaluation epoch, where the spacing is the widest per-satellite nominal
-node spacing in the product, estimated exactly as the position interpolator
-estimates it. Eleven is not a policy value supplied by the caller. It comes from
-the same `NEVILLE_POINTS = 11` constant the degree-10 sliding-window Lagrange
-interpolator uses, plus how that window behaves at run edges: it keeps its node
-count and slides inward, so a query in a run's last interval reaches ten
-spacings back, and a query up to one spacing outside a run is still served, so
-the farthest selected node can sit eleven spacings away. The header interval
-must be positive and finite and is the fallback for a satellite with fewer than
-two nodes. The bounds are measured from the window bounds directly; snapping
-them to the header grid first let a selected node fall outside the upper bound.
-reach.
+scale. `StencilExtent::for_sp3` derives the reach from the position
+interpolator's own selection rules applied to each satellite's actual nodes: the
+farthest a selected node can sit from a served query is one window span plus one
+nominal spacing. The window holds `NEVILLE_POINTS = 11` consecutive nodes and
+slides inward at the edges of a contiguous run, a run tolerates consecutive gaps
+up to 1.5 times the nominal spacing, and a query is served up to one nominal
+spacing outside a run or across a coverage gap. The span is measured from the
+nodes themselves rather than from the node count, because an irregular run can
+span far more than eleven nominal spacings. The reported reach is the largest
+value over the product's satellites, with a floor of eleven header intervals;
+the header interval must be positive and finite. The bounds are measured from
+the window bounds directly; snapping them to the header grid first let a
+selected node fall outside the upper bound.
 
 A defect influences the window when its recorded epoch or epoch pair intersects
 the evaluation window expanded by that derived reach. The bounds are inclusive,

--- a/docs/sp3-window-scoped-continuity.md
+++ b/docs/sp3-window-scoped-continuity.md
@@ -14,7 +14,9 @@ interpolator's own selection rules applied to each satellite's actual nodes: the
 farthest a selected node can sit from a served query is one window span plus one
 nominal spacing. The window holds `NEVILLE_POINTS = 11` consecutive nodes and
 slides inward at the edges of a contiguous run, a run tolerates consecutive gaps
-up to 1.5 times the nominal spacing, and a query is served up to one nominal
+up to the product's gap threshold factor times the nominal spacing
+(`Sp3InterpolationOptions`, 1.5 by default; `Sp3::with_interpolation_options`
+changes it, and the reach follows), and a query is served up to one nominal
 spacing outside a run or across a coverage gap. The span is measured from the
 nodes themselves rather than from the node count, because an irregular run can
 span far more than eleven nominal spacings. The reported reach is the largest


### PR DESCRIPTION
Follow-up to #35 and #36, addressing the REVISE findings from an independent review of both. Each finding was checked against the code before acting on it.

## Stencil reach (#36 was incomplete)

Ten header intervals was not the true maximum, for two reasons the review identified and I confirmed in `sp3/interp.rs`:

- A query up to one nominal spacing outside a run is still served, and across a coverage gap it is anchored to the nearer run (`pivot += 1`). The farthest selected node can then sit **eleven** spacings away.
- Node selection is per satellite. The nominal spacing is estimated from that satellite's actual nodes, so a satellite sampled every 600 s in a 300 s product has an 11-node span of 6,000 s, which no header-interval bound covers.

The reach is now eleven times the widest per-satellite nominal spacing, computed with the interpolator's own estimator so the two cannot disagree. `influence_bounds` is measured from the window bounds directly; the previous snap to the header grid moved the upper bound earlier and let a selected node fall outside it (the review's `-150 s` query example).

`StencilExtent` loses its two private grid fields; the public surface is unchanged. The guide's "five intervals" text is corrected.

## Week borrow (#35 was incomplete)

- `normalized()`: a negative subnormal TOW never borrowed, because dividing it by the week length underflows to `-0.0`. It now lands on the week start.
- The writer: normalizing `(9, -1e-8)` yields `(8, 604799.99999999)`, which the `D19.12` column writes as a full week again. The helper now repeats on the normalized value until the written TOW is inside the week (two rounds always suffice).
- The review's `dt_op` observation is recorded in the changelog: correcting the pair shifts `cnav_ura_ned_m`'s URA by a few ulp for the affected records, as a consequence of the representation fix.

## Tests, and their sharpness

- `stencil_reach_follows_the_widest_per_satellite_spacing`: thins one satellite of the GRG fixture to alternate epochs and requires the reach to move from 11 × 900 s to 11 × 1,800 s. **Fails** against #36's version.
- `every_node_that_moves_a_run_end_query_is_inside_the_reported_reach`: drives the real interpolator, perturbing each node by 1 m at a final-interval query, and requires every node that moves the result to lie within `before_s`. This guards against the centered-five regression that shipped; against #36's ten-interval version it passes, since that product has no gaps or sparse satellites — the per-satellite test is the one that catches #36.
- `cnav_top_set_outside_the_week_still_reaches_a_stable_encoding`: sets `top` directly to `(9, -1e-8)` and `(8, 604800)`. **Fails** with the model fix kept and the writer helper reverted, which #35's tests did not.
- The model test adds `-f64::from_bits(1)`. **Fails** with the subnormal guard removed.
- The `a_defect_only_the_edge_stencil_reaches_still_refuses` control moves from eleven to twelve spacings, and two pins move from 3,000 s to 3,300 s.

## Gates

fmt, clippy `--workspace --all-targets -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc`, `cargo nextest run --workspace` (3,056 passed), mmap suite (2,867 passed).

## Configurable coverage-gap threshold (rounds 3 and 4)

The `1.5 × nominal spacing` rule that splits a satellite's node series into runs was a fixed constant in three places (in-memory interpolator, mapped store evaluator, stencil reach). It is a policy choice, not a published rule, so it is now `Sp3InterpolationOptions` (validated: finite and > 1.0; `DEFAULT` = 1.5), carried by the product via `Sp3::with_interpolation_options` and read by everything that selects nodes from it: position interpolation, `PreciseEphemerisInterpolant::from_sp3`, `StencilExtent::for_sp3`, and a store written from the product. `PreciseEphemerisSamples`, `PreciseEphemerisInterpolant` and `ContinuityOptions` take it directly. Not SP3 text, excluded from product equality, merge output carries the default.

Store: header bytes 48..56 (previously reserved-zero) carry a non-default factor as LE f64, all-zero meaning default. No version bump: a default-policy artifact is byte-identical to before (pinned for three fixtures against lengths and checksums computed on `main`), old artifacts read back as 1.5, and a non-default artifact fails closed in an old reader.

Round 3 found that the public field let a caller bypass validation (0.0 serialized as "default" and reopened as 1.5), and that a huge validated factor could admit nodes so far from the query that Neville's denominator collapsed to a panic. The field is now private with a getter, and both evaluators return `Error::InvalidInput` on a non-finite result. Round 4: ACCEPT.

Default path: bit-identical on every entry point (external parent-vs-HEAD comparison across six source paths, continuity reports, reach, and complete artifact bytes).
