### PR TITLE
release: 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "sidereon-core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "approx",
  "cc",

--- a/crates/sidereon-cli/Cargo.toml
+++ b/crates/sidereon-cli/Cargo.toml
@@ -19,8 +19,8 @@ tokio = { version = "1", features = ["rt", "io-std", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libm = "=0.2.16"
-sidereon = { path = "../sidereon", version = "2.0.0" }
-sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
+sidereon = { path = "../sidereon", version = "2.1.0" }
+sidereon-core = { path = "../sidereon-core", version = "2.1.0" }
 
 [dev-dependencies]
 portable-pty = "0.9.0"

--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `sidereon-core` are documented here.
 
-## [Unreleased]
+## [2.1.0] - 2026-09-05
 
 ### Added
 

--- a/crates/sidereon-core/Cargo.toml
+++ b/crates/sidereon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon-core"
-version = "2.0.0"
+version = "2.1.0"
 authors = []
 edition = "2021"
 rust-version = "1.89"

--- a/crates/sidereon-scoreboard/Cargo.toml
+++ b/crates/sidereon-scoreboard/Cargo.toml
@@ -12,5 +12,5 @@ flate2 = "1"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
+sidereon-core = { path = "../sidereon-core", version = "2.1.0" }
 thiserror = "1.0"

--- a/crates/sidereon/Cargo.toml
+++ b/crates/sidereon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidereon"
-version = "2.0.0"
+version = "2.1.0"
 authors = []
 edition = "2021"
 rust-version = "1.89"
@@ -17,7 +17,7 @@ categories = ["science", "simulation"]
 # The complete engine. The ergonomic surface here adds no modeling logic of its
 # own; every function delegates to a sidereon-core reference entry point. The
 # default features (gnss + serde) carry the SP3/SPP/RTK/PPP API this wraps.
-sidereon-core = { path = "../sidereon-core", version = "2.0.0" }
+sidereon-core = { path = "../sidereon-core", version = "2.1.0" }
 crc32fast = "1"
 flate2 = "1"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidereon-core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "approx",
  "cc",


### PR DESCRIPTION
Lockstep train 2.1.0. sidereon-core and sidereon to 2.1.0; cli and scoreboard pins follow; both lockfiles updated; CHANGELOG header dated.

Contents since 2.0.0 (all on main): CNAV week-borrow normalization (#35), SP3 stencil reach (#36) and its review follow-ups plus the configurable coverage-gap threshold `Sp3InterpolationOptions` (#37). Additive API, no breaking change, hence minor.

After merge: tag v2.1.0, the Release workflow publishes trust-region-least-squares (unchanged) -> sidereon-core -> sidereon; then the six interfaces and the demo follow at 2.1.0.