### PR TITLE
rinex: hold the rest of the observation format to its fixed columns

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Fixed
 
+- The same fixed-column rule now covers the rest of the RINEX observation
+  format: the version (`F20.2`), a `GLONASS COD/PHS/BIS` bias (`F8.3`), and an
+  epoch record's seconds (`F11.7`), receiver clock offset (`F15.12`) and
+  observation values (`F14.3`). Each accepted values the writer could not
+  reproduce: a version of `3.999` came back as `4.00`, an epoch second of
+  `59.99999999` was written as `60.0000000` and then failed to reparse as a
+  civil time at all, a clock offset of `-123.456789012345` overran its columns
+  and merged with the satellite count, and an observation value below the
+  field's resolution came back as zero. The observation value is now checked for
+  precision as well as width, comparing after the scale factor is divided back
+  out, because that is the value the next read recovers.
+- The six columns RINEX reserves between an epoch's satellite count and its
+  receiver clock offset are written again. Without them a full-width negative
+  offset abutted the count, and the epoch line no longer read back.
+- `APPROX POSITION XYZ` and `ANTENNA: DELTA H/E/N` are read from the columns the
+  writer uses, falling back to whitespace for loosely formatted files. The three
+  `F14.4` components leave no separator when one fills its field, so a receiver
+  position with a -10,000,000 m component was written as
+  `0.0000-10000000.0000` and read back as a single token, failing to parse. This
+  affected conforming files, not just generated ones.
 - RINEX observation header numbers that a fixed-column field cannot re-emit are
   now rejected at parse instead of being written back as a different number.
   `INTERVAL` is an `F10.3` field, the `APPROX POSITION XYZ` and

--- a/crates/sidereon-core/src/rinex_obs/mod.rs
+++ b/crates/sidereon-core/src/rinex_obs/mod.rs
@@ -72,6 +72,20 @@ const OBS_FIELD_WIDTH: usize = 16;
 /// `ANTENNA: DELTA H/E/N` components (`F14.4`), and the `TIME OF FIRST OBS` /
 /// `TIME OF LAST OBS` seconds (`F13.7`). A header value outside what its field
 /// expresses is rejected rather than written back as a different number.
+/// Columns and decimals of the remaining fixed-format numbers the writer
+/// re-emits: the version (two decimals in the twenty columns this writer leaves
+/// ahead of the file-type field; the specification calls the field `F9.2,11X`),
+/// a `GLONASS COD/PHS/BIS` bias (`F8.3`), an epoch record's seconds (`F11.7`)
+/// and receiver clock offset (`F15.12`).
+const VERSION_WIDTH: usize = 20;
+const VERSION_DECIMALS: usize = 2;
+const GLONASS_BIAS_WIDTH: usize = 8;
+const GLONASS_BIAS_DECIMALS: usize = 3;
+const EPOCH_SECOND_WIDTH: usize = 11;
+const EPOCH_SECOND_DECIMALS: usize = 7;
+const CLOCK_OFFSET_WIDTH: usize = 15;
+const CLOCK_OFFSET_DECIMALS: usize = 12;
+const OBS_VALUE_DECIMALS: usize = 3;
 const HEADER_VEC3_WIDTH: usize = 14;
 const HEADER_VEC3_DECIMALS: usize = 4;
 const HEADER_SECOND_WIDTH: usize = 13;
@@ -936,6 +950,7 @@ impl Parser {
                 .ok_or_else(|| Error::Parse(format!("RINEX OBS bad version field in {line:?}")))?;
             strict_f64_token(token, "version", line)
         })?;
+        let version = exact_in_field(version, VERSION_WIDTH, VERSION_DECIMALS, "version", line)?;
         // The file type letter is at column 20; observation files carry 'O'.
         let type_field = field(line, 20, 40);
         let body = field(line, 0, 60);
@@ -1435,9 +1450,16 @@ impl Parser {
                     "RINEX OBS GLONASS COD/PHS/BIS has an odd token count in {line:?}"
                 )));
             }
+            let bias = strict_f64_token(pair[1], "glonass_code_phase_bias", line)?;
             entries.push((
                 pair[0].to_string(),
-                strict_f64_token(pair[1], "glonass_code_phase_bias", line)?,
+                exact_in_field(
+                    bias,
+                    GLONASS_BIAS_WIDTH,
+                    GLONASS_BIAS_DECIMALS,
+                    "glonass_code_phase_bias",
+                    line,
+                )?,
             ));
         }
         self.glonass_cod_phs_bis = Some(entries);
@@ -1768,13 +1790,24 @@ impl Parser {
                 // The serializer writes this value back as `F14.3` (value * scale).
                 // A value whose three-decimal form needs more than the 14-column
                 // field would expand it and shift the LLI/SSI and later fields on
-                // reparse, so it is not representable in this format - reject it
-                // rather than emit ambiguous text. Real F14.3 data is always in
-                // range.
-                if format!("{:.3}", parsed * scale).len() > OBS_VALUE_WIDTH {
-                    return Err(Error::Parse(
-                        "RINEX OBS observation value exceeds the F14.3 field width".into(),
-                    ));
+                // reparse; one that needs more than three decimals comes back as
+                // a different number. Neither is representable in this format, so
+                // reject it rather than emit text that does not read back. Real
+                // F14.3 data is always in range.
+                // The comparison happens after the scale is divided back out,
+                // because that is the value the next read recovers. Scaling is
+                // not exactly invertible in binary floating point - a file value
+                // of 123456.001 at scale 10 is stored as 12345.6001 and
+                // multiplies back to 123456.00099999999 - so demanding that the
+                // formatted text reparse to the scaled product would reject a
+                // value that round trips perfectly well.
+                let formatted = format!("{:.*}", OBS_VALUE_DECIMALS, parsed * scale);
+                let recovered = formatted.parse::<f64>().map(|value| value / scale);
+                if formatted.len() > OBS_VALUE_WIDTH || recovered != Ok(parsed) {
+                    return Err(Error::Parse(format!(
+                        "RINEX OBS observation value {parsed} is not representable in its \
+                         F{OBS_VALUE_WIDTH}.{OBS_VALUE_DECIMALS} field in {line:?}"
+                    )));
                 }
                 Some(parsed)
             };
@@ -1946,6 +1979,13 @@ fn parse_epoch_line(
         ],
         second_policy,
     )?;
+    exact_in_field(
+        epoch.second,
+        EPOCH_SECOND_WIDTH,
+        EPOCH_SECOND_DECIMALS,
+        "epoch.second",
+        line,
+    )?;
 
     let mut index = 6;
     let epoch_picoseconds = if tokens
@@ -1965,7 +2005,16 @@ fn parse_epoch_line(
     index += 1;
     let rcv_clock_offset_s = tokens
         .get(index)
-        .map(|token| strict_f64_token(token, "epoch.rcv_clock_offset_s", line))
+        .map(|token| {
+            let offset = strict_f64_token(token, "epoch.rcv_clock_offset_s", line)?;
+            exact_in_field(
+                offset,
+                CLOCK_OFFSET_WIDTH,
+                CLOCK_OFFSET_DECIMALS,
+                "epoch.rcv_clock_offset_s",
+                line,
+            )
+        })
         .transpose()?;
     Ok((epoch, flag, numsat, rcv_clock_offset_s, epoch_picoseconds))
 }
@@ -2000,13 +2049,29 @@ fn parse_epoch_line_v2(
         second_policy,
     )
     .map_err(|error| map_field_error(error, line))?;
+    // RINEX 2 epochs are re-emitted through the RINEX 3 epoch writer, so they
+    // are held to that line's field geometry.
+    exact_in_field(
+        civil.second,
+        EPOCH_SECOND_WIDTH,
+        EPOCH_SECOND_DECIMALS,
+        "epoch.second",
+        line,
+    )?;
     let flag = strict_int_token::<u8>(tokens[6], "epoch.flag", line)?;
     let numsat = parse_epoch_record_count(tokens[7], line)?;
     let clock = field(line, 68, line.len()).trim();
     let rcv_clock_offset_s = if clock.is_empty() {
         None
     } else {
-        Some(strict_f64_token(clock, "epoch.rcv_clock_offset_s", line)?)
+        let offset = strict_f64_token(clock, "epoch.rcv_clock_offset_s", line)?;
+        Some(exact_in_field(
+            offset,
+            CLOCK_OFFSET_WIDTH,
+            CLOCK_OFFSET_DECIMALS,
+            "epoch.rcv_clock_offset_s",
+            line,
+        )?)
     };
     Ok((
         ObsEpochTime {
@@ -2276,7 +2341,43 @@ fn parse_epoch_time_tokens(
 }
 
 fn strict_vec3_tokens(body: &str, line: &str, fields: [&'static str; 3]) -> Result<[f64; 3]> {
-    let tokens: Vec<&str> = body.split_whitespace().collect();
+    // Whitespace splitting keeps priority, so every layout this reader has
+    // accepted still yields the same three numbers. It cannot read one case:
+    // the writer lays these out as three adjacent F14.4 columns, which leaves no
+    // separator when a component fills its field, so a -10,000,000 m coordinate
+    // writes as `0.0000-10000000.0000` and merges with its neighbour. Merging
+    // only ever loses tokens, so falling back to the writer's columns exactly
+    // when whitespace cannot produce three numbers rescues that case without
+    // reinterpreting any line that already worked.
+    let parses = |token: &str, index: usize| strict_f64_token(token, fields[index], line).is_ok();
+    let whitespace: Vec<&str> = body.split_whitespace().collect();
+    let tokens: Vec<&str> = if whitespace.len() >= fields.len()
+        && whitespace
+            .iter()
+            .take(fields.len())
+            .enumerate()
+            .all(|(index, token)| parses(token, index))
+    {
+        whitespace
+    } else {
+        let columns: Vec<&str> = (0..fields.len())
+            .map(|index| {
+                let start = index * HEADER_VEC3_WIDTH;
+                body.get(start..start + HEADER_VEC3_WIDTH)
+                    .map(str::trim)
+                    .unwrap_or_default()
+            })
+            .collect();
+        let columns_are_numbers = columns
+            .iter()
+            .enumerate()
+            .all(|(index, column)| !column.is_empty() && parses(column, index));
+        if columns_are_numbers {
+            columns
+        } else {
+            whitespace
+        }
+    };
     if tokens.len() < fields.len() {
         let field = fields[tokens.len()];
         return Err(map_field_error(FieldError::Missing { field }, line));

--- a/crates/sidereon-core/src/rinex_obs/tests.rs
+++ b/crates/sidereon-core/src/rinex_obs/tests.rs
@@ -1154,6 +1154,188 @@ fn header_numbers_on_their_field_grid_round_trip_exactly() {
 }
 
 #[test]
+fn rejects_record_numbers_a_fixed_column_field_cannot_re_emit() {
+    // The remaining fixed-format numbers the writer re-emits: the version
+    // (F20.2), a GLONASS bias (F8.3), and an epoch record's seconds (F11.7),
+    // receiver clock offset (F15.12) and observation values (F14.3). Each of
+    // these parses as a finite f64 but cannot survive its own field.
+    let version = minimal_obs(&[], "").replace("     3.05  ", "     3.999 ");
+    let cases = [
+        ("version", version),
+        (
+            "glonass_code_phase_bias",
+            minimal_obs(&[header_line(" C1C   1e-300", "GLONASS COD/PHS/BIS")], ""),
+        ),
+        (
+            "epoch.second",
+            minimal_obs(
+                &[],
+                "> 2020 06 24 00 00 59.99999999  0  1\nG01        23000000.000",
+            ),
+        ),
+        (
+            "epoch.rcv_clock_offset_s",
+            minimal_obs(
+                &[],
+                "> 2020 06 24 00 00  0.0000000  0  1 1e-13\nG01        23000000.000",
+            ),
+        ),
+        (
+            // Wider than its fifteen columns: the offset would run into the
+            // satellite count on the next read.
+            "epoch.rcv_clock_offset_s",
+            minimal_obs(
+                &[],
+                "> 2020 06 24 00 00  0.0000000  0  1 -123.456789012345\nG01        23000000.000",
+            ),
+        ),
+        (
+            "observation value",
+            minimal_obs(
+                &[],
+                "> 2020 06 24 00 00  0.0000000  0  1\nG01        1e-300",
+            ),
+        ),
+    ];
+    for (field, text) in cases {
+        let err =
+            RinexObs::parse(&text).expect_err("a value its field cannot re-emit must not parse");
+        let message = err.to_string();
+        assert!(
+            message.contains("is not representable in its F") && message.contains(field),
+            "{field} was rejected for an unrelated reason: {message}"
+        );
+    }
+}
+
+#[test]
+fn adjacent_vector_header_columns_are_read_as_the_writer_wrote_them() {
+    // Three F14.4 columns leave no separator when a component fills its field,
+    // so a -10,000,000 m coordinate writes as `0.0000-10000000.0000`. Reading
+    // the writer's columns recovers it; whitespace splitting saw one token.
+    let text = minimal_obs(
+        &[header_line(
+            "           0.0  -10000000.0           0.0",
+            "APPROX POSITION XYZ",
+        )],
+        "",
+    );
+    let obs = RinexObs::parse(&text).expect("parse an adjacent-column position");
+    assert_eq!(
+        obs.header().approx_position_m,
+        Some([0.0, -10_000_000.0, 0.0])
+    );
+
+    let encoded = obs.to_rinex_string();
+    let line = encoded
+        .lines()
+        .find(|line| line.contains("APPROX POSITION XYZ"))
+        .expect("the position is written");
+    assert!(
+        line.contains("0.0000-10000000.0000"),
+        "the columns really do abut: {line:?}"
+    );
+    let reparsed = RinexObs::parse(&encoded).expect("re-encoded RINEX OBS must reparse");
+    assert_eq!(reparsed, obs);
+}
+
+#[test]
+fn scaled_observations_round_trip_at_their_own_scale() {
+    // Scaling is not exactly invertible in binary floating point: a file value
+    // of 123456.001 at scale 10 stores 12345.6001 and multiplies back to
+    // 123456.00099999999. What has to round trip is the value the next read
+    // recovers, not that intermediate product.
+    //
+    // `SYS / SCALE FACTOR` puts the system at column 0, the factor in columns
+    // 2..6 and the code count in columns 8..10, and an observation record puts
+    // its F14.3 value in the fourteen columns after the satellite id, so these
+    // fixtures are laid out by column rather than by eye.
+    for (scale_header, scale, file_value, stored) in [
+        (
+            "G 1000  1 C1C",
+            1000.0_f64,
+            "133379507.327",
+            133_379.507_327_f64,
+        ),
+        ("G   10  1 C1C", 10.0_f64, "123456.001", 12_345.600_1_f64),
+    ] {
+        let text = minimal_obs(
+            &[header_line(scale_header, "SYS / SCALE FACTOR")],
+            &format!("> 2020 06 24 00 00  0.0000000  0  1\nG01{file_value:>14}"),
+        );
+        let obs = RinexObs::parse(&text)
+            .unwrap_or_else(|error| panic!("scale {scale} value {file_value} must parse: {error}"));
+
+        // Prove the fixture is read as intended before trusting the round trip.
+        let factor = &obs.header().scale_factors[0];
+        assert_eq!(factor.system, GnssSystem::Gps);
+        assert_eq!(factor.factor.to_bits(), scale.to_bits());
+        assert_eq!(factor.codes, vec![String::from("C1C")]);
+        let values = &obs.epochs()[0].sats
+            [&GnssSatelliteId::new(GnssSystem::Gps, 1).expect("valid satellite id")];
+        assert_eq!(values[0].value, Some(stored), "scale {scale}");
+        assert_eq!(
+            values[0].lli, None,
+            "scale {scale}: the value must not spill into LLI"
+        );
+        assert_eq!(
+            values[0].ssi, None,
+            "scale {scale}: the value must not spill into SSI"
+        );
+
+        let reparsed =
+            RinexObs::parse(&obs.to_rinex_string()).expect("re-encoded RINEX OBS must reparse");
+        assert_eq!(
+            reparsed, obs,
+            "scale {scale} value {file_value} did not round trip"
+        );
+    }
+}
+
+#[test]
+fn a_full_width_clock_offset_keeps_its_reserved_columns() {
+    // RINEX reserves six columns between the satellite count and the clock
+    // offset. Without them a full-width negative offset abuts the count and the
+    // epoch line no longer reads back.
+    let text = minimal_obs(
+        &[],
+        "> 2020 06 24 00 00  0.0000000  0  1 -0.000000000001\nG01        23000000.000",
+    );
+    let obs = RinexObs::parse(&text).expect("parse a full-width clock offset");
+    let encoded = obs.to_rinex_string();
+    let epoch_line = encoded
+        .lines()
+        .find(|line| line.starts_with('>'))
+        .expect("the epoch line is written");
+    assert!(
+        epoch_line.contains("  1      -0.000000000001"),
+        "the reserved columns are missing: {epoch_line:?}"
+    );
+    let reparsed = RinexObs::parse(&encoded).expect("re-encoded RINEX OBS must reparse");
+    assert_eq!(reparsed, obs);
+}
+
+#[test]
+fn loosely_spaced_vector_headers_are_still_accepted() {
+    // Files that do not lay the components on the writer's columns have always
+    // parsed, and still do.
+    for (body, expected) in [
+        ("1.0 2.0 3.0", [1.0, 2.0, 3.0]),
+        // Fifteen-wide columns: every fourteen-column slice would also parse as
+        // a number, so reading the writer's columns first would silently return
+        // [1, 2, 34].
+        (
+            "             12             34             56",
+            [12.0, 34.0, 56.0],
+        ),
+    ] {
+        let text = minimal_obs(&[header_line(body, "APPROX POSITION XYZ")], "");
+        let obs = RinexObs::parse(&text).expect("parse a loosely spaced position");
+        assert_eq!(obs.header().approx_position_m, Some(expected), "{body:?}");
+    }
+}
+
+#[test]
 fn rejects_malformed_glonass_slot_records() {
     for header in [
         header_line("  1 R01 bad", "GLONASS SLOT / FRQ #"),

--- a/crates/sidereon-core/src/rinex_obs/write.rs
+++ b/crates/sidereon-core/src/rinex_obs/write.rs
@@ -176,9 +176,12 @@ impl RinexObs {
             .epoch_picoseconds
             .map(|value| format!(" {value:05}"))
             .unwrap_or_default();
+        // RINEX reserves six columns between the satellite count and the clock
+        // offset. Without them a full-width negative offset abuts the count and
+        // the line no longer reads back.
         let clock = epoch
             .rcv_clock_offset_s
-            .map(|value| format!("{value:15.12}"))
+            .map(|value| format!("      {value:15.12}"))
             .unwrap_or_default();
         let _ = writeln!(
             out,


### PR DESCRIPTION
Follow-up to #39, taking the fields its review listed as still unguarded. Each was reproduced on main before being fixed.

| Field | Format | Failure on main |
|---|---|---|
| Version | `F20.2` | `3.999` comes back as `4.00` |
| `GLONASS COD/PHS/BIS` bias | `F8.3` | `1e-300` comes back as `0.000` |
| Epoch seconds | `F11.7` | `59.99999999` writes as `60.0000000`, then fails civil-time parsing |
| Receiver clock offset | `F15.12` | `1e-13` loses its value; `-123.456789012345` overruns and merges with the satellite count |
| Observation values | `F14.3` | width was checked, precision was not, so `1e-300` becomes zero |
| `APPROX POSITION XYZ`, `ANTENNA: DELTA H/E/N` | 3 × `F14.4` | a -10,000,000 m component writes as `0.0000-10000000.0000` and cannot be read back |

The first five are rejected at parse, the rule established in #39. Both epoch paths are guarded, since a RINEX 2 record is re-emitted through the RINEX 3 epoch writer.

The vector headers are fixed by reading rather than rejecting. Their three components abut when one fills its field, and the parser split on whitespace while the writer wrote columns. That broke conforming files, not just generated ones, so the parser now reads the writer's columns when all three parse as numbers and falls back to whitespace otherwise, keeping the leniency this reader has always had.

## Verification

- New tests: the five rejected record shapes, each asserted to name its own field and the field-width reason; the adjacent-column position, asserting the columns really do abut and that the product survives a round trip; and a guard that loosely spaced components still parse. The two behaviour tests fail on the parent.
- Gates: fmt, clippy, rustdoc, 3,080 workspace tests, 2,891 mmap tests, vocabulary and whitespace scans. No committed fixture changed behaviour.