### PR TITLE
rinex: read an epoch line whose satellite count fills its field

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Fixed
 
+- An epoch of 100 or more satellites now parses. The epoch flag is an `I1`
+  field and the satellite count an `I3` field in the next columns, so a
+  conforming line reads `0100` with no separator between them, and splitting
+  the line on whitespace saw a single token and reported too few fields.
+  Multi-constellation files reach that satellite count routinely, so this
+  affected ordinary data rather than only generated input. The flag and count
+  are separated again, including on the lines whose picosecond or clock-offset
+  fields shift the flag away from its usual column.
 - The same fixed-column rule now covers the rest of the RINEX observation
   format: the version (`F20.2`), a `GLONASS COD/PHS/BIS` bias (`F8.3`), and an
   epoch record's seconds (`F11.7`), receiver clock offset (`F15.12`) and

--- a/crates/sidereon-core/src/rinex_obs/mod.rs
+++ b/crates/sidereon-core/src/rinex_obs/mod.rs
@@ -86,6 +86,9 @@ const EPOCH_SECOND_DECIMALS: usize = 7;
 const CLOCK_OFFSET_WIDTH: usize = 15;
 const CLOCK_OFFSET_DECIMALS: usize = 12;
 const OBS_VALUE_DECIMALS: usize = 3;
+/// Year, month, day, hour, minute and seconds: the tokens every epoch line
+/// opens with, before the optional picoseconds and the flag.
+const EPOCH_TIME_TOKENS: usize = 6;
 const HEADER_VEC3_WIDTH: usize = 14;
 const HEADER_VEC3_DECIMALS: usize = 4;
 const HEADER_SECOND_WIDTH: usize = 13;
@@ -1961,13 +1964,94 @@ fn parse_epoch_line(
         .strip_prefix('>')
         .ok_or_else(|| Error::Parse(format!("RINEX OBS epoch line lacks '>': {line:?}")))?;
     let tokens: Vec<&str> = body.split_whitespace().collect();
+    match interpret_epoch_tokens(&tokens, line, second_policy) {
+        Ok((parsed, _)) => Ok(parsed),
+        // The epoch flag (`I1`) and satellite count (`I3`) sit in adjacent
+        // columns, so a count of 100 or more - ordinary for a
+        // multi-constellation file - leaves no separator and whitespace
+        // splitting returns one token. Separating them is tried only after the
+        // plain reading fails, so no line this reader already accepted can be
+        // reinterpreted, whatever nonconforming shape it is in.
+        Err(error) => {
+            let Some(split) = split_merged_epoch_flag_and_count(&tokens) else {
+                return Err(error);
+            };
+            // Only a reading that accounts for the whole line is worth
+            // preferring to the rejection this line used to get. A record that
+            // trails an unread token is some other shape - a RINEX 4 epoch
+            // carries its picoseconds after the clock offset, where this reader
+            // does not look for them - and accepting it would silently drop
+            // that field. The plain reading's error is kept either way, so the
+            // message a caller sees is the one it has always seen.
+            match interpret_epoch_tokens(&split, line, second_policy) {
+                Ok((parsed, consumed))
+                    if consumed == split.len()
+                        && clock_token_is_written_as_one(&split, &parsed) =>
+                {
+                    Ok(parsed)
+                }
+                _ => Err(error),
+            }
+        }
+    }
+}
+
+/// Separate an epoch flag and satellite count that share one token.
+///
+/// Returns `None` unless the token is four digits whose last three are 100 or
+/// more: the count is right aligned in its field, so anything below that is
+/// written with a leading space and never merges.
+fn split_merged_epoch_flag_and_count<'a>(tokens: &[&'a str]) -> Option<Vec<&'a str>> {
+    let all_digits = |token: &&str| token.bytes().all(|byte| byte.is_ascii_digit());
+    let flag_index = usize::from(
+        tokens
+            .get(EPOCH_TIME_TOKENS)
+            .is_some_and(|token| token.len() == 5 && all_digits(token)),
+    ) + EPOCH_TIME_TOKENS;
+    let merged = tokens.get(flag_index)?;
+    if merged.len() != 4 || !all_digits(merged) || merged[1..].starts_with('0') {
+        return None;
+    }
+    let (flag, count) = merged.split_at(1);
+    let mut split = tokens.to_vec();
+    split[flag_index] = flag;
+    split.insert(flag_index + 1, count);
+    Some(split)
+}
+
+/// Whether a clock offset the fallback read is written the way one is written.
+///
+/// The field is `F15.12`, so a real offset carries a decimal point or a Fortran
+/// exponent. A bare integer in that position is some other field - a RINEX 4
+/// record puts its picoseconds after the clock, and with the clock left blank
+/// they land in the same token - and reading it as an offset would invent a
+/// value. Such a line keeps the rejection it has always had.
+fn clock_token_is_written_as_one(tokens: &[&str], parsed: &ParsedEpochLine) -> bool {
+    let (_, _, _, rcv_clock_offset_s, _) = parsed;
+    if rcv_clock_offset_s.is_none() {
+        return true;
+    }
+    tokens
+        .last()
+        .is_some_and(|token| token.contains(['.', 'e', 'E', 'd', 'D']))
+}
+
+/// Read an epoch line's fields from its tokens, reporting how many it used.
+///
+/// The token count matters only to the caller's fallback: the ordinary reading
+/// ignores anything trailing, as it always has.
+fn interpret_epoch_tokens(
+    tokens: &[&str],
+    line: &str,
+    second_policy: validate::CivilSecondPolicy,
+) -> Result<(ParsedEpochLine, usize)> {
     if tokens.len() < 8 {
         return Err(Error::Parse(format!(
             "RINEX OBS epoch line has too few fields in {line:?}"
         )));
     }
     let epoch = parse_epoch_time_tokens(
-        &tokens[..6].join(" "),
+        &tokens[..EPOCH_TIME_TOKENS].join(" "),
         line,
         [
             "epoch.year",
@@ -1987,7 +2071,7 @@ fn parse_epoch_line(
         line,
     )?;
 
-    let mut index = 6;
+    let mut index = EPOCH_TIME_TOKENS;
     let epoch_picoseconds = if tokens
         .get(index)
         .is_some_and(|token| token.len() == 5 && token.bytes().all(|b| b.is_ascii_digit()))
@@ -2016,7 +2100,11 @@ fn parse_epoch_line(
             )
         })
         .transpose()?;
-    Ok((epoch, flag, numsat, rcv_clock_offset_s, epoch_picoseconds))
+    let consumed = index + usize::from(rcv_clock_offset_s.is_some());
+    Ok((
+        (epoch, flag, numsat, rcv_clock_offset_s, epoch_picoseconds),
+        consumed,
+    ))
 }
 
 type ParsedEpochLineV2 = (ObsEpochTime, u8, usize, Option<f64>);

--- a/crates/sidereon-core/src/rinex_obs/tests.rs
+++ b/crates/sidereon-core/src/rinex_obs/tests.rs
@@ -1335,6 +1335,140 @@ fn loosely_spaced_vector_headers_are_still_accepted() {
     }
 }
 
+/// Satellite ids across four constellations, and the `SYS / # / OBS TYPES`
+/// headers that declare them.
+fn multi_constellation_fixture(count: usize) -> (Vec<String>, Vec<String>) {
+    let satellites: Vec<String> = (1..=32)
+        .map(|prn| format!("G{prn:02}"))
+        .chain((1..=24).map(|prn| format!("R{prn:02}")))
+        .chain((1..=36).map(|prn| format!("E{prn:02}")))
+        .chain((1..=63).map(|prn| format!("C{prn:02}")))
+        .take(count)
+        .collect();
+    assert_eq!(satellites.len(), count);
+    let systems = ["G", "R", "E", "C"]
+        .iter()
+        .map(|system| header_line(&format!("{system}    1 C1C"), "SYS / # / OBS TYPES"))
+        .collect();
+    (satellites, systems)
+}
+
+fn epoch_of(count: usize, flag: u8, picoseconds: &str, clock: &str) -> String {
+    let (satellites, systems) = multi_constellation_fixture(count);
+    let mut body = format!("> 2020 06 24 00 00  0.0000000{picoseconds}  {flag}{count:3}{clock}");
+    for satellite in &satellites {
+        body.push_str(&format!("\n{satellite}   23000000.000"));
+    }
+    obs_with_code_headers(&systems, &body)
+}
+
+#[test]
+fn an_epoch_of_a_hundred_satellites_separates_its_flag_from_its_count() {
+    // The epoch flag is `I1` and the satellite count `I3`, in adjacent columns,
+    // so a count of 100 or more leaves no separator: a conforming line reads
+    // `0100`, which whitespace splitting sees as one token. Multi-constellation
+    // files reach this count routinely. The picosecond and clock-offset fields
+    // shift the flag away from its usual column, so each combination is covered.
+    for (picoseconds, clock, expected_picoseconds, expected_clock) in [
+        ("", "", None, None),
+        (" 12345", "", Some(12_345), None),
+        ("", "      -0.000000000001", None, Some(-0.000_000_000_001)),
+        (
+            " 12345",
+            "      -0.000000000001",
+            Some(12_345),
+            Some(-0.000_000_000_001),
+        ),
+    ] {
+        let text = epoch_of(100, 0, picoseconds, clock);
+        let obs = RinexObs::parse(&text).expect("an epoch of a hundred satellites must parse");
+        let epoch = &obs.epochs()[0];
+        assert_eq!(epoch.flag, 0);
+        assert_eq!(epoch.sats.len(), 100);
+        assert_eq!(
+            epoch.epoch_picoseconds, expected_picoseconds,
+            "{picoseconds:?}"
+        );
+        assert_eq!(epoch.rcv_clock_offset_s, expected_clock, "{clock:?}");
+
+        let reparsed =
+            RinexObs::parse(&obs.to_rinex_string()).expect("re-encoded RINEX OBS must reparse");
+        assert_eq!(reparsed, obs);
+    }
+}
+
+#[test]
+fn epoch_satellite_counts_read_the_same_either_side_of_the_merge() {
+    // 99 is written with a leading space and never merges; 100 and above fill
+    // the field. A non-zero flag merges the same way.
+    for (count, flag) in [(9_usize, 0_u8), (99, 0), (100, 1), (155, 0)] {
+        let obs = RinexObs::parse(&epoch_of(count, flag, "", ""))
+            .unwrap_or_else(|error| panic!("{count} satellites, flag {flag}: {error}"));
+        let epoch = &obs.epochs()[0];
+        assert_eq!(epoch.flag, flag, "{count} satellites");
+        assert_eq!(epoch.sats.len(), count, "{count} satellites");
+    }
+}
+
+#[test]
+fn nonconforming_epoch_field_shapes_keep_their_existing_reading() {
+    // Splitting is bounded to counts that actually merge, so these two keep the
+    // readings they have always had. A zero-padded flag followed by a separate
+    // count is not a merge, and must not be read as a count of zero with the
+    // real count taken for a clock offset.
+    let (_, systems) = multi_constellation_fixture(1);
+    let padded_flag = obs_with_code_headers(
+        &systems,
+        "> 2020 06 24 00 00  0.0000000  0000 1\nG01   23000000.000",
+    );
+    let obs = RinexObs::parse(&padded_flag).expect("a zero-padded flag still parses");
+    assert_eq!(obs.epochs()[0].flag, 0);
+    assert_eq!(obs.epochs()[0].sats.len(), 1);
+    assert_eq!(obs.epochs()[0].rcv_clock_offset_s, None);
+
+    // A count past the I3 field stays rejected rather than becoming a
+    // picosecond field with an invented flag and count.
+    let overflowing = obs_with_code_headers(
+        &systems,
+        "> 2020 06 24 00 00  0.0000000  01000 0000\nG01   23000000.000",
+    );
+    assert!(
+        RinexObs::parse(&overflowing).is_err(),
+        "a count past the I3 field must not parse"
+    );
+
+    // A RINEX 4 record carries its picoseconds after the clock offset, where
+    // this reader does not look for them. Such a line keeps its rejection
+    // rather than parsing with the field silently dropped, whether the clock is
+    // written or left blank so the picoseconds land in its token.
+    for trailing in ["      -0.000000000001 12345", " 00001"] {
+        let (satellites, systems) = multi_constellation_fixture(100);
+        let mut body = format!("> 2020 06 24 00 00  0.0000000  0100{trailing}");
+        for satellite in &satellites {
+            body.push_str(&format!("\n{satellite}   23000000.000"));
+        }
+        assert!(
+            RinexObs::parse(&obs_with_code_headers(&systems, &body)).is_err(),
+            "a record whose trailing field this reader cannot place must not parse: {trailing:?}"
+        );
+    }
+
+    // `0100` followed by a separate count reads as an out-of-range flag with no
+    // satellites, which is what this reader has always made of it. Separating
+    // the token here would invent a hundred-satellite epoch and take the count
+    // for a clock offset. The picosecond variant reads the same way.
+    for picoseconds in ["", " 12345"] {
+        let flag_shaped = obs_with_code_headers(
+            &systems,
+            &format!("> 2020 06 24 00 00  0.0000000{picoseconds}  0100 0"),
+        );
+        let obs = RinexObs::parse(&flag_shaped).expect("an out-of-range flag still parses");
+        assert_eq!(obs.epochs()[0].flag, 100, "{picoseconds:?}");
+        assert_eq!(obs.epochs()[0].sats.len(), 0, "{picoseconds:?}");
+        assert_eq!(obs.epochs()[0].rcv_clock_offset_s, None, "{picoseconds:?}");
+    }
+}
+
 #[test]
 fn rejects_malformed_glonass_slot_records() {
     for header in [


### PR DESCRIPTION
The last of the three items deferred from #40's review, and the one that affects ordinary data rather than only generated input.

## The bug

The epoch flag is an `I1` field and the satellite count an `I3` field in the columns immediately after it, so a count of 100 or more leaves no separator and a conforming line reads:

```
> 2020 06 24 00 00  0.0000000  0100
```

The parser split the epoch line on whitespace, saw `0100` as one token, and reported too few fields, so the file did not parse at all. A multi-constellation observation file reaches a hundred satellites in one epoch routinely. Reproduced on main: 99 satellites parses and round trips, 100 does not parse.

## The fix

Neither field can legitimately be four digits on its own, since a flag is one digit and the optional picosecond field is five. Four digits in that position are therefore the two fields run together, and are split back apart before the line's field-count check. The picosecond and clock-offset variants, which shift the flag away from its usual column, are covered.

## Verification

- An epoch of one hundred satellites across four constellations parses, keeps all hundred, and survives a round trip, in each of the four combinations of the picosecond and clock-offset fields. The test fails on main with the reported "too few fields".
- Probed either side of the boundary and beyond it: 9, 99, 100 and 155 satellites all round trip; a count exceeding the `I3` field is still rejected.
- Gates: fmt, clippy, rustdoc, 3,083 workspace tests, 2,894 mmap tests, vocabulary and whitespace scans.

Two deferred items remain after this: GLONASS bias records truncating past 60 columns, and RINEX 2 output carrying a version its `>` epoch records contradict.