### PR TITLE
rinex: read the observation records from the columns they are written in

### DIFF
--- a/crates/sidereon-core/CHANGELOG.md
+++ b/crates/sidereon-core/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to `sidereon-core` are documented here.
 
 ### Fixed
 
+- The RINEX observation reader takes the records the format lays out in fixed
+  columns from those columns, rather than by splitting the line on whitespace.
+  Whitespace cannot read a record whose field fills its width, because it then
+  touches the field beside it: an epoch of 100 or more satellites writes its
+  `I1` flag and `I3` count as `0100`, and a receiver position with a
+  -10,000,000 m component writes as `0.0000-10000000.0000`. Both are ordinary
+  conforming data and neither parsed. The columns are read only when the line is
+  laid out in them, which is decided by whether any content strays into the gaps
+  the format reserves; every looser reading still applies beneath that, in turn,
+  so a line that is not in the layout keeps the reading it has always had.
+  A line that *is* in the layout is now read as the layout describes it, which
+  is the intended change and can disagree with what splitting on whitespace made
+  of it. `0100` in an epoch's flag and count columns followed by a clock offset
+  read as an out-of-range flag of 100 with no satellites, and is now the hundred
+  satellites the columns describe; a minute and seconds field run together read
+  as one number and are now the two the columns separate. Such a line was
+  already being read as something its own layout contradicts. This covers both
+  epoch readers, the `APPROX POSITION XYZ` and `ANTENNA: DELTA H/E/N`
+  components, and the `TIME OF FIRST OBS` / `TIME OF LAST OBS` fields.
+- A RINEX 2 observation product can read the output it writes. Such a product is
+  re-emitted through the version 3 record writer, so its own file declared
+  version 2 while carrying `>` epoch records, which the version 2 reader could
+  not read. The body now follows the records themselves, which is unambiguous:
+  a version 2 epoch line begins with its two-digit year, never with `>`.
+- A `GLONASS COD/PHS/BIS` record carrying more entries than one line holds is
+  continued on another line instead of being cut off at the sixtieth column, and
+  the reader adds each line's entries to the record. A fifth entry was silently
+  lost. RINEX gives this record four biases and no continuation, so carrying
+  more is an extension of this crate's own; a blank record still means the
+  biases are unknown and clears what came before it.
+
 - An epoch of 100 or more satellites now parses. The epoch flag is an `I1`
   field and the satellite count an `I3` field in the next columns, so a
   conforming line reads `0100` with no separator between them, and splitting

--- a/crates/sidereon-core/src/format/columns.rs
+++ b/crates/sidereon-core/src/format/columns.rs
@@ -26,6 +26,58 @@ pub(crate) fn field(line: &str, start: usize, end: usize) -> Option<&str> {
     }
 }
 
+/// Read a record laid out in fixed columns, when the line really is laid out
+/// that way.
+///
+/// `fields` gives each field's half-open byte range, in order. The read succeeds
+/// only when every non-space byte of `line` falls inside one of those ranges, so
+/// a line whose content strays into the gaps a format reserves between its
+/// fields, or past the last one, is reported as not being in this layout.
+///
+/// That test is what lets a column reader stand in front of a looser one without
+/// changing how any loosely formatted line is read. A fixed-column record whose
+/// fields abut - a satellite count filling its `I3` columns against the epoch
+/// flag before it, say - is unreadable by splitting on whitespace, but a line
+/// that is not in the layout at all is still left to whatever looser reading the
+/// caller supports.
+///
+/// Ranges must be ordered and must not overlap. A field starting past the end of
+/// the line reads as blank, which is how an omitted trailing field appears.
+/// Fields are returned trimmed.
+pub(crate) fn fixed_record<const N: usize>(
+    line: &str,
+    fields: [(usize, usize); N],
+) -> Option<[&str; N]> {
+    debug_assert!(
+        fields.iter().all(|(start, end)| start <= end)
+            && fields.windows(2).all(|pair| pair[0].1 <= pair[1].0),
+        "fixed-column fields must be ordered and must not overlap"
+    );
+    // Columns are byte offsets, which only line up with characters while the
+    // line is ASCII. A line carrying anything else is not read as a layout at
+    // all, so a field boundary can never fall inside a character.
+    if !line.is_ascii() {
+        return None;
+    }
+    let outside_every_field = |index: usize| {
+        !fields
+            .iter()
+            .any(|(start, end)| index >= *start && index < *end)
+    };
+    if line
+        .bytes()
+        .enumerate()
+        .any(|(index, byte)| byte != b' ' && outside_every_field(index))
+    {
+        return None;
+    }
+    let mut read = [""; N];
+    for (slot, (start, end)) in read.iter_mut().zip(fields) {
+        *slot = field(line, start, end).unwrap_or_default();
+    }
+    Some(read)
+}
+
 /// Return an untrimmed fixed-column field, or `""` for an empty range.
 pub(crate) fn raw_field(line: &str, start: usize, end: usize) -> &str {
     let s = floor_char_boundary(line, start);
@@ -108,6 +160,76 @@ fn float_parse_error<T>(text: &str, field: &'static str) -> Result<T, FieldError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A RINEX 3 epoch line, laid out as the format specifies: the `>` marker,
+    /// the six date and time fields, then the flag and satellite count with the
+    /// two reserved columns before them.
+    const EPOCH: [(usize, usize); 9] = [
+        (0, 1),
+        (2, 6),
+        (7, 9),
+        (10, 12),
+        (13, 15),
+        (16, 18),
+        (18, 29),
+        (31, 32),
+        (32, 35),
+    ];
+
+    #[test]
+    fn fixed_record_reads_fields_that_abut() {
+        // A count of 100 fills its columns, so it touches the flag before it and
+        // no whitespace reading can separate the two.
+        assert_eq!(
+            fixed_record("> 2020 06 24 00 00  0.0000000  0100", EPOCH),
+            Some([">", "2020", "06", "24", "00", "00", "0.0000000", "0", "100"])
+        );
+        // The same line with the count clear of its first column reads the same
+        // way, so the layout is not doing anything special for the merged case.
+        assert_eq!(
+            fixed_record("> 2020 06 24 00 00  0.0000000  0 99", EPOCH),
+            Some([">", "2020", "06", "24", "00", "00", "0.0000000", "0", "99"])
+        );
+    }
+
+    #[test]
+    fn fixed_record_refuses_a_line_that_strays_outside_the_layout() {
+        // Content in the columns the format reserves after the count means the
+        // line is not in this layout, whatever else it may be. Both of these
+        // have a reading of their own that a looser reader still gives them.
+        for line in [
+            "> 2020 06 24 00 00  0.0000000  0000 1",
+            "> 2020 06 24 00 00  0.0000000  0100 0",
+        ] {
+            assert_eq!(fixed_record(line, EPOCH), None, "{line:?}");
+        }
+    }
+
+    #[test]
+    fn fixed_record_reads_a_blank_or_absent_trailing_field() {
+        // Three F14.4 columns, the last left off the end of the line.
+        let fields = [(0, 14), (14, 28), (28, 42)];
+        assert_eq!(
+            fixed_record("        0.0000-10000000.0000", fields),
+            Some(["0.0000", "-10000000.0000", ""])
+        );
+    }
+
+    #[test]
+    fn fixed_record_refuses_a_line_whose_columns_are_not_characters() {
+        // Byte offsets only line up with characters while the line is ASCII, so
+        // a field boundary must never be allowed to fall inside one.
+        assert_eq!(fixed_record("é", [(0, 1), (1, 2)]), None);
+        assert_eq!(fixed_record("ab", [(0, 1), (1, 2)]), Some(["a", "b"]));
+    }
+
+    #[test]
+    fn fixed_record_refuses_a_wider_layout_than_it_was_given() {
+        // Fifteen-column fields: every fourteen-column slice still parses as a
+        // number, so only the stray content reveals that the layout is wrong.
+        let body = format!("{:15}{:15}{:15}", 12, 34, 56);
+        assert_eq!(fixed_record(&body, [(0, 14), (14, 28), (28, 42)]), None);
+    }
 
     #[test]
     fn out_of_bounds_ranges_are_empty() {

--- a/crates/sidereon-core/src/rinex_obs/mod.rs
+++ b/crates/sidereon-core/src/rinex_obs/mod.rs
@@ -54,7 +54,7 @@ use std::collections::BTreeMap;
 
 use crate::astro::time::model::TimeScale;
 
-use crate::format::columns::{raw_field as field, raw_field_from};
+use crate::format::columns::{fixed_record, raw_field as field, raw_field_from};
 use crate::format::{Diagnostics, RecordRef, Skip, SkipReason};
 use crate::frequencies::{
     rinex_band_frequency_hz, rinex_observation_frequency_hz, rinex_observation_wavelength_m,
@@ -86,6 +86,56 @@ const EPOCH_SECOND_DECIMALS: usize = 7;
 const CLOCK_OFFSET_WIDTH: usize = 15;
 const CLOCK_OFFSET_DECIMALS: usize = 12;
 const OBS_VALUE_DECIMALS: usize = 3;
+/// Columns of a RINEX 3 epoch line: the `>` marker, the six date and time
+/// fields, the epoch flag, the satellite count, and the receiver clock offset.
+/// The `2X` before the flag and the `6X` before the clock are the format's own
+/// gaps, and are left out so that content straying into them marks the line as
+/// not being in this layout.
+const V3_EPOCH_COLUMNS: [(usize, usize); 10] = [
+    (0, 1),
+    (2, 6),
+    (7, 9),
+    (10, 12),
+    (13, 15),
+    (16, 18),
+    (18, 29),
+    (31, 32),
+    (32, 35),
+    (41, 56),
+];
+/// The same line carrying this writer's picosecond field, which it places after
+/// the seconds and which shifts every later field six columns right.
+const V3_EPOCH_PICOSECOND_COLUMNS: [(usize, usize); 11] = [
+    (0, 1),
+    (2, 6),
+    (7, 9),
+    (10, 12),
+    (13, 15),
+    (16, 18),
+    (18, 29),
+    (30, 35),
+    (37, 38),
+    (38, 41),
+    (47, 62),
+];
+/// Columns of a `TIME OF FIRST OBS` / `TIME OF LAST OBS` body, `5I6,F13.7`.
+/// The time scale that follows is read from its own columns already.
+const TIME_OF_OBS_COLUMNS: [(usize, usize); EPOCH_TIME_TOKENS] =
+    [(0, 6), (6, 12), (12, 18), (18, 24), (24, 30), (30, 43)];
+
+/// Columns of a RINEX 2 epoch line's leading window, up to the satellite list.
+/// The clock offset sits past that list and is read separately.
+const V2_EPOCH_HEAD_COLUMNS: [(usize, usize); 8] = [
+    (1, 3),
+    (4, 6),
+    (7, 9),
+    (10, 12),
+    (13, 15),
+    (15, 26),
+    (28, 29),
+    (29, 32),
+];
+
 /// Year, month, day, hour, minute and seconds: the tokens every epoch line
 /// opens with, before the optional picoseconds and the flag.
 const EPOCH_TIME_TOKENS: usize = 6;
@@ -349,8 +399,19 @@ impl RinexObs {
         let mut parser = Parser::new();
         let mut lines = text.lines();
         parser.parse_header(&mut lines)?;
+        // A version 2 product is re-emitted through the version 3 record writer,
+        // so its own output declares version 2 while carrying `>` epoch records.
+        // Dispatch on the first record, which is unambiguous: a version 2 epoch
+        // line begins with its two-digit year, never with `>`. Without this the
+        // writer produces a file it cannot read back. Only the first record is
+        // consulted, never anything past it: a version 2 event record carries
+        // free text of its own, which may itself begin with `>`.
         let mut body = lines.peekable();
-        if parser.is_rinex2() {
+        while body.peek().is_some_and(|line| line.trim().is_empty()) {
+            body.next();
+        }
+        let carries_version_three_records = body.peek().is_some_and(|line| line.starts_with('>'));
+        if parser.is_rinex2() && !carries_version_three_records {
             parser.parse_body_v2(&mut body)?;
         } else {
             parser.parse_body(&mut body)?;
@@ -1376,12 +1437,24 @@ impl Parser {
             "time_of_last_obs" => "time_of_last_obs.second",
             _ => "time_of_first_obs.second",
         };
-        let epoch = parse_epoch_time_tokens(
-            body,
-            line,
-            [year, month, day, hour, minute, second],
-            civil_second_policy_for_time_scale(scale),
-        )?;
+        // `5I6,F13.7` with nothing between the fields, so they abut whenever one
+        // fills its width. Read the columns when the line is in them, and keep
+        // the looser reading for the files that are not.
+        // This layout leaves no gaps between its fields, so the check that
+        // content stays inside them cannot vouch for it on its own: the columns
+        // are preferred only when all six read as the numbers they are meant to
+        // be. Anything else keeps the looser reading.
+        let columns = fixed_record(body, TIME_OF_OBS_COLUMNS).filter(|columns| {
+            columns[..5]
+                .iter()
+                .all(|column| column.parse::<i64>().is_ok())
+                && columns[5].parse::<f64>().is_ok()
+        });
+        let names = [year, month, day, hour, minute, second];
+        let policy = civil_second_policy_for_time_scale(scale);
+        let epoch = columns
+            .and_then(|columns| parse_epoch_time_fields(columns, line, names, policy).ok())
+            .map_or_else(|| parse_epoch_time_tokens(body, line, names, policy), Ok)?;
         exact_in_field(
             epoch.second,
             HEADER_SECOND_WIDTH,
@@ -1465,7 +1538,15 @@ impl Parser {
                 )?,
             ));
         }
-        self.glonass_cod_phs_bis = Some(entries);
+        // RINEX gives this record four biases, which fit one line. More than
+        // that is an extension of this crate's own: the writer continues them
+        // onto another line rather than cutting them off at the sixtieth
+        // column, and a further line adds to the record. A blank record still
+        // means "unknown" and so clears what came before it.
+        match &mut self.glonass_cod_phs_bis {
+            Some(existing) if !entries.is_empty() => existing.extend(entries),
+            slot => *slot = Some(entries),
+        }
         Ok(())
     }
 
@@ -1960,29 +2041,34 @@ fn parse_epoch_line(
     line: &str,
     second_policy: validate::CivilSecondPolicy,
 ) -> Result<ParsedEpochLine> {
+    // Read the columns the format lays the record out in. That is the only way
+    // to read an epoch whose satellite count fills its `I3` field: it then abuts
+    // the flag before it, leaving no space for a tokenizer to split on. A line
+    // that is not in the layout, or whose columns do not parse, falls through to
+    // the looser reading that has always handled files which are not
+    // column-exact, so nothing this reader already accepted changes.
+    if let Some(tokens) = v3_epoch_column_tokens(line) {
+        if let Ok((parsed, _)) = interpret_epoch_tokens(&tokens, line, second_policy) {
+            return Ok(parsed);
+        }
+    }
     let body = line
         .strip_prefix('>')
         .ok_or_else(|| Error::Parse(format!("RINEX OBS epoch line lacks '>': {line:?}")))?;
     let tokens: Vec<&str> = body.split_whitespace().collect();
     match interpret_epoch_tokens(&tokens, line, second_policy) {
         Ok((parsed, _)) => Ok(parsed),
-        // The epoch flag (`I1`) and satellite count (`I3`) sit in adjacent
-        // columns, so a count of 100 or more - ordinary for a
-        // multi-constellation file - leaves no separator and whitespace
-        // splitting returns one token. Separating them is tried only after the
-        // plain reading fails, so no line this reader already accepted can be
-        // reinterpreted, whatever nonconforming shape it is in.
+        // A line that is in neither the layout nor a shape the tokenizer can
+        // read may still be one whose flag and count ran together. Separating
+        // them is the last thing tried, so it cannot change any other reading.
         Err(error) => {
             let Some(split) = split_merged_epoch_flag_and_count(&tokens) else {
                 return Err(error);
             };
-            // Only a reading that accounts for the whole line is worth
-            // preferring to the rejection this line used to get. A record that
-            // trails an unread token is some other shape - a RINEX 4 epoch
-            // carries its picoseconds after the clock offset, where this reader
-            // does not look for them - and accepting it would silently drop
-            // that field. The plain reading's error is kept either way, so the
-            // message a caller sees is the one it has always seen.
+            // The separated reading is preferred only when it accounts for the
+            // whole line and any clock offset it read is written the way one is
+            // written. Without both, a record whose trailing field this reader
+            // cannot place is accepted with that field silently dropped.
             match interpret_epoch_tokens(&split, line, second_policy) {
                 Ok((parsed, consumed))
                     if consumed == split.len()
@@ -1994,6 +2080,23 @@ fn parse_epoch_line(
             }
         }
     }
+}
+
+/// Whether a clock offset the repair read is written the way one is written.
+///
+/// The field is `F15.12`, so a real offset carries a decimal point or a Fortran
+/// exponent. A bare integer in that position is some other field - a RINEX 4
+/// record puts its picoseconds after the clock, and with the clock left blank
+/// they land in the same token - and reading it as an offset would invent a
+/// value.
+fn clock_token_is_written_as_one(tokens: &[&str], parsed: &ParsedEpochLine) -> bool {
+    let (_, _, _, rcv_clock_offset_s, _) = parsed;
+    if rcv_clock_offset_s.is_none() {
+        return true;
+    }
+    tokens
+        .last()
+        .is_some_and(|token| token.contains(['.', 'e', 'E', 'd', 'D']))
 }
 
 /// Separate an epoch flag and satellite count that share one token.
@@ -2019,21 +2122,57 @@ fn split_merged_epoch_flag_and_count<'a>(tokens: &[&'a str]) -> Option<Vec<&'a s
     Some(split)
 }
 
-/// Whether a clock offset the fallback read is written the way one is written.
+/// Read a RINEX 3 epoch line's fields from their columns, in the order the
+/// token reader expects them.
 ///
-/// The field is `F15.12`, so a real offset carries a decimal point or a Fortran
-/// exponent. A bare integer in that position is some other field - a RINEX 4
-/// record puts its picoseconds after the clock, and with the clock left blank
-/// they land in the same token - and reading it as an offset would invent a
-/// value. Such a line keeps the rejection it has always had.
-fn clock_token_is_written_as_one(tokens: &[&str], parsed: &ParsedEpochLine) -> bool {
-    let (_, _, _, rcv_clock_offset_s, _) = parsed;
-    if rcv_clock_offset_s.is_none() {
-        return true;
+/// Returns `None` when the line is not laid out that way, including when this
+/// writer's picosecond field is absent from where it puts it.
+fn v3_epoch_column_tokens(line: &str) -> Option<Vec<&str>> {
+    if let Some([marker, year, month, day, hour, minute, second, flag, count, clock]) =
+        fixed_record(line, V3_EPOCH_COLUMNS)
+    {
+        if marker == ">" {
+            return Some(epoch_tokens(
+                [year, month, day, hour, minute, second],
+                "",
+                flag,
+                count,
+                clock,
+            ));
+        }
+    }
+    let [marker, year, month, day, hour, minute, second, picoseconds, flag, count, clock] =
+        fixed_record(line, V3_EPOCH_PICOSECOND_COLUMNS)?;
+    (marker == ">").then(|| {
+        epoch_tokens(
+            [year, month, day, hour, minute, second],
+            picoseconds,
+            flag,
+            count,
+            clock,
+        )
+    })
+}
+
+/// Assemble the token list the epoch reader expects, leaving out the two
+/// optional fields when their columns are blank.
+fn epoch_tokens<'a>(
+    time: [&'a str; EPOCH_TIME_TOKENS],
+    picoseconds: &'a str,
+    flag: &'a str,
+    count: &'a str,
+    clock: &'a str,
+) -> Vec<&'a str> {
+    let mut tokens = time.to_vec();
+    if !picoseconds.is_empty() {
+        tokens.push(picoseconds);
+    }
+    tokens.push(flag);
+    tokens.push(count);
+    if !clock.is_empty() {
+        tokens.push(clock);
     }
     tokens
-        .last()
-        .is_some_and(|token| token.contains(['.', 'e', 'E', 'd', 'D']))
 }
 
 /// Read an epoch line's fields from its tokens, reporting how many it used.
@@ -2050,8 +2189,12 @@ fn interpret_epoch_tokens(
             "RINEX OBS epoch line has too few fields in {line:?}"
         )));
     }
-    let epoch = parse_epoch_time_tokens(
-        &tokens[..EPOCH_TIME_TOKENS].join(" "),
+    // Take the six fields as they were read. Re-joining them and splitting again
+    // would silently drop anything inside a field that contains a space, which a
+    // column read can legitimately hand over.
+    let time: [&str; EPOCH_TIME_TOKENS] = core::array::from_fn(|index| tokens[index]);
+    let epoch = parse_epoch_time_fields(
+        time,
         line,
         [
             "epoch.year",
@@ -2114,7 +2257,39 @@ fn parse_epoch_line_v2(
     second_policy: validate::CivilSecondPolicy,
 ) -> Result<ParsedEpochLineV2> {
     let head = field(line, 0, 32);
-    let tokens: Vec<&str> = head.split_whitespace().collect();
+    // The satellite count fills its `I3` field from a hundred satellites up and
+    // then abuts the flag before it, so the columns are read first. Each looser
+    // reading below it is tried in turn, so every line this reader accepted
+    // before is still read the same way.
+    if let Some(columns) = fixed_record(head, V2_EPOCH_HEAD_COLUMNS)
+        .filter(|columns| columns.iter().all(|column| !column.is_empty()))
+    {
+        if let Ok(parsed) = interpret_epoch_tokens_v2(&columns, line, second_policy) {
+            return Ok(parsed);
+        }
+    }
+    let whitespace: Vec<&str> = head.split_whitespace().collect();
+    match interpret_epoch_tokens_v2(&whitespace, line, second_policy) {
+        Ok(parsed) => Ok(parsed),
+        // The repaired head has to be exactly the eight fields the record is,
+        // or the line is some other shape and keeps its rejection.
+        Err(error) => match split_merged_epoch_flag_and_count(&whitespace)
+            .filter(|split| split.len() == V2_EPOCH_HEAD_COLUMNS.len())
+        {
+            Some(split) => {
+                interpret_epoch_tokens_v2(&split, line, second_policy).map_err(|_| error)
+            }
+            None => Err(error),
+        },
+    }
+}
+
+/// Read a RINEX 2 epoch line from its fields, however they were separated.
+fn interpret_epoch_tokens_v2(
+    tokens: &[&str],
+    line: &str,
+    second_policy: validate::CivilSecondPolicy,
+) -> Result<ParsedEpochLineV2> {
     if tokens.len() < 8 {
         return Err(Error::Parse(format!(
             "RINEX OBS v2 epoch line has too few fields in {line:?}"
@@ -2402,6 +2577,17 @@ fn parse_epoch_time_tokens(
         let field = fields[tokens.len()];
         return Err(map_field_error(FieldError::Missing { field }, line));
     }
+    let read: [&str; 6] = core::array::from_fn(|index| tokens[index]);
+    parse_epoch_time_fields(read, line, fields, second_policy)
+}
+
+/// Validate the six date and time fields of an epoch, however they were read.
+fn parse_epoch_time_fields(
+    tokens: [&str; 6],
+    line: &str,
+    fields: [&'static str; 6],
+    second_policy: validate::CivilSecondPolicy,
+) -> Result<ObsEpochTime> {
     let year = strict_int_token::<i32>(tokens[0], fields[0], line)?;
     let month = strict_int_token::<i64>(tokens[1], fields[1], line)?;
     let day = strict_int_token::<i64>(tokens[2], fields[2], line)?;
@@ -2429,41 +2615,56 @@ fn parse_epoch_time_tokens(
 }
 
 fn strict_vec3_tokens(body: &str, line: &str, fields: [&'static str; 3]) -> Result<[f64; 3]> {
-    // Whitespace splitting keeps priority, so every layout this reader has
-    // accepted still yields the same three numbers. It cannot read one case:
-    // the writer lays these out as three adjacent F14.4 columns, which leaves no
-    // separator when a component fills its field, so a -10,000,000 m coordinate
-    // writes as `0.0000-10000000.0000` and merges with its neighbour. Merging
-    // only ever loses tokens, so falling back to the writer's columns exactly
-    // when whitespace cannot produce three numbers rescues that case without
-    // reinterpreting any line that already worked.
+    // The three components are adjacent `F14.4` columns with nothing between
+    // them, so one that fills its field touches its neighbour: a -10,000,000 m
+    // coordinate writes as `0.0000-10000000.0000`, which no tokenizer can split.
+    // Read the columns when the line is laid out in them, and keep the looser
+    // reading for the files that are not.
+    let columns = fixed_record(
+        body,
+        [
+            (0, HEADER_VEC3_WIDTH),
+            (HEADER_VEC3_WIDTH, 2 * HEADER_VEC3_WIDTH),
+            (2 * HEADER_VEC3_WIDTH, 3 * HEADER_VEC3_WIDTH),
+        ],
+    )
+    .filter(|columns| {
+        columns.iter().enumerate().all(|(index, column)| {
+            !column.is_empty() && strict_f64_token(column, fields[index], line).is_ok()
+        })
+    });
     let parses = |token: &str, index: usize| strict_f64_token(token, fields[index], line).is_ok();
     let whitespace: Vec<&str> = body.split_whitespace().collect();
-    let tokens: Vec<&str> = if whitespace.len() >= fields.len()
+    let whitespace_reads = whitespace.len() >= fields.len()
         && whitespace
             .iter()
             .take(fields.len())
             .enumerate()
-            .all(|(index, token)| parses(token, index))
-    {
-        whitespace
-    } else {
-        let columns: Vec<&str> = (0..fields.len())
-            .map(|index| {
-                let start = index * HEADER_VEC3_WIDTH;
-                body.get(start..start + HEADER_VEC3_WIDTH)
-                    .map(str::trim)
-                    .unwrap_or_default()
-            })
-            .collect();
-        let columns_are_numbers = columns
-            .iter()
-            .enumerate()
-            .all(|(index, column)| !column.is_empty() && parses(column, index));
-        if columns_are_numbers {
-            columns
-        } else {
-            whitespace
+            .all(|(index, token)| parses(token, index));
+    let tokens: Vec<&str> = match columns {
+        Some(columns) => columns.to_vec(),
+        None if whitespace_reads => whitespace,
+        // Neither the layout nor the tokenizer read this line. The components
+        // may still sit on their columns with something trailing them, which is
+        // what this reader accepted before the layout test existed.
+        None => {
+            let lenient: Vec<&str> = (0..fields.len())
+                .map(|index| {
+                    let start = index * HEADER_VEC3_WIDTH;
+                    body.get(start..start + HEADER_VEC3_WIDTH)
+                        .map(str::trim)
+                        .unwrap_or_default()
+                })
+                .collect();
+            if lenient
+                .iter()
+                .enumerate()
+                .all(|(index, column)| !column.is_empty() && parses(column, index))
+            {
+                lenient
+            } else {
+                whitespace
+            }
         }
     };
     if tokens.len() < fields.len() {

--- a/crates/sidereon-core/src/rinex_obs/tests.rs
+++ b/crates/sidereon-core/src/rinex_obs/tests.rs
@@ -1470,6 +1470,208 @@ fn nonconforming_epoch_field_shapes_keep_their_existing_reading() {
 }
 
 #[test]
+fn reading_by_column_leaves_every_looser_shape_as_it_was() {
+    // The layout is read first, but each looser reading below it still applies
+    // in turn, so a line that is not laid out in columns keeps the reading it
+    // has always had.
+    let (satellites, systems) = multi_constellation_fixture(100);
+
+    // Loosely spaced, with the flag and count run together: no layout, but the
+    // merged-token reading still recovers the hundred satellites.
+    let mut loose = String::from("> 2020 6 24 0 0 0 0100");
+    for satellite in &satellites {
+        loose.push_str(&format!("\n{satellite}   23000000.000"));
+    }
+    let obs = RinexObs::parse(&obs_with_code_headers(&systems, &loose))
+        .expect("a loosely spaced merged count still parses");
+    assert_eq!(obs.epochs()[0].sats.len(), 100);
+
+    // A seconds field holding a space is handed over as one field, not re-split:
+    // `0 1` is one second, as the looser reading has always made it.
+    let spaced = obs_with_code_headers(&systems, &format!("> 2020 06 24 00 00{:11}  0  0", "0 1"));
+    let obs = RinexObs::parse(&spaced).expect("a seconds field with a space still parses");
+    assert_eq!(obs.epochs()[0].epoch.second, 1.0);
+
+    // Column-shaped but not column-valued: the layout read parses badly, so the
+    // looser reading takes over rather than the line being rejected.
+    let odd_time = minimal_obs(
+        &[header_line(
+            &format!(
+                "{:7}{:7}{:7}{:7}{:7} 0.0000                GPS",
+                2020, 6, 24, 0, 0
+            ),
+            "TIME OF FIRST OBS",
+        )],
+        "",
+    );
+    let obs = RinexObs::parse(&odd_time).expect("a time header off its columns still parses");
+    assert_eq!(
+        obs.header().time_of_first_obs.expect("present").0.second,
+        0.0
+    );
+
+    // Components on their columns with something trailing them: no layout, and
+    // whitespace cannot separate the first two, but the columns still read.
+    let trailing = minimal_obs(
+        &[header_line(
+            &format!("{:14.4}{:14.4}{:14.4} extra", 0.0, -10_000_000.0, 0.0),
+            "APPROX POSITION XYZ",
+        )],
+        "",
+    );
+    let obs = RinexObs::parse(&trailing).expect("trailing content still parses");
+    assert_eq!(
+        obs.header().approx_position_m,
+        Some([0.0, -10_000_000.0, 0.0])
+    );
+}
+
+#[test]
+fn a_version_two_epoch_reads_a_satellite_count_that_fills_its_field() {
+    // The RINEX 2 epoch line abuts its flag and count exactly as the RINEX 3 one
+    // does, and had no repair at all before the columns were read. Its satellite
+    // list carries twelve to a line and continues from column 32 on the next.
+    let satellites: Vec<String> = (1..=32)
+        .map(|prn| format!("G{prn:02}"))
+        .chain((1..=24).map(|prn| format!("R{prn:02}")))
+        .chain((1..=36).map(|prn| format!("E{prn:02}")))
+        .chain((1..=8).map(|prn| format!("C{prn:02}")))
+        .collect();
+    assert_eq!(satellites.len(), 100);
+
+    let mut chunks = satellites.chunks(12);
+    let mut body = format!(
+        " 20  6 24  0  0  0.0000000  0{:3}{}",
+        satellites.len(),
+        chunks.next().expect("the first twelve").concat()
+    );
+    for chunk in chunks {
+        body.push_str(&format!("\n{}{}", " ".repeat(32), chunk.concat()));
+    }
+    for satellite in &satellites {
+        let _ = satellite;
+        body.push_str("\n   23000000.000");
+    }
+    let text = obs_with_version_and_code_headers(
+        2.11,
+        &[header_line("     1    C1", "# / TYPES OF OBSERV")],
+        &body,
+    );
+
+    let obs = RinexObs::parse(&text).expect("a version 2 epoch of a full count must parse");
+    assert_eq!(obs.epochs()[0].flag, 0);
+    assert_eq!(obs.epochs()[0].sats.len(), 100);
+}
+
+#[test]
+fn an_antenna_delta_whose_components_abut_is_read() {
+    // The same three adjacent F14.4 columns as the position, and the same merge.
+    // This one guards the reading rather than reproducing a break: the delta's
+    // components were already recovered by the reader's lenient last tier.
+    let text = minimal_obs(
+        &[header_line(
+            "           0.0  -10000000.0           0.0",
+            "ANTENNA: DELTA H/E/N",
+        )],
+        "",
+    );
+    let obs = RinexObs::parse(&text).expect("parse an adjacent-column antenna delta");
+    assert_eq!(
+        obs.header().antenna_delta_hen_m,
+        Some([0.0, -10_000_000.0, 0.0])
+    );
+    let reparsed =
+        RinexObs::parse(&obs.to_rinex_string()).expect("re-encoded RINEX OBS must reparse");
+    assert_eq!(reparsed, obs);
+}
+
+#[test]
+fn a_blank_glonass_bias_record_clears_the_one_before_it() {
+    // A blank record means the biases are unknown, so it replaces what came
+    // before rather than leaving it standing.
+    let text = minimal_obs(
+        &[
+            header_line(" C1C  -71.940", "GLONASS COD/PHS/BIS"),
+            header_line("", "GLONASS COD/PHS/BIS"),
+        ],
+        "",
+    );
+    let obs = RinexObs::parse(&text).expect("parse a cleared GLONASS bias record");
+    assert_eq!(obs.header().glonass_cod_phs_bis, Some(Vec::new()));
+}
+
+#[test]
+fn a_version_two_product_reads_back_the_output_it_writes() {
+    // A version 2 file is re-emitted through the version 3 record writer, so its
+    // own output declares version 2 while carrying `>` epoch records. Reading
+    // the body by its record shape rather than the declared version is what lets
+    // that file be read back at all.
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/obs/algo0010_2015001_v1_trim.rnx"
+    );
+    let text = std::fs::read_to_string(path).expect("read the committed RINEX 2 fixture");
+    let obs = RinexObs::parse(&text).expect("parse the RINEX 2 fixture");
+    assert!((obs.header().version - 2.11).abs() < 1e-9);
+    assert_eq!(obs.epochs().len(), 2);
+
+    let encoded = obs.to_rinex_string();
+    assert!(
+        encoded.lines().any(|line| line.starts_with('>')),
+        "the writer emits version 3 epoch records"
+    );
+    let reparsed = RinexObs::parse(&encoded).expect("its own output must read back");
+    assert_eq!(reparsed.epochs(), obs.epochs());
+    assert!((reparsed.header().version - 2.11).abs() < 1e-9);
+}
+
+#[test]
+fn a_glonass_bias_record_longer_than_one_line_survives_a_round_trip() {
+    // Each entry takes thirteen of the sixty columns, so a fifth would be cut
+    // off the end of the line. The record continues on another line instead, and
+    // the reader adds to what it already has rather than replacing it.
+    let entries = [
+        ("C1C", -71.940),
+        ("C1P", -71.940),
+        ("C2C", -71.940),
+        ("C2P", -71.940),
+        ("C3C", -12.500),
+    ];
+    let mut first = String::new();
+    for (code, value) in &entries[..4] {
+        first.push_str(&format!(" {code:>3} {value:8.3}"));
+    }
+    let text = minimal_obs(
+        &[
+            header_line(first.trim_start(), "GLONASS COD/PHS/BIS"),
+            header_line(" C3C  -12.500", "GLONASS COD/PHS/BIS"),
+        ],
+        "",
+    );
+
+    let obs = RinexObs::parse(&text).expect("parse a continued GLONASS bias record");
+    let read = obs
+        .header()
+        .glonass_cod_phs_bis
+        .as_ref()
+        .expect("the record is present");
+    assert_eq!(read.len(), 5, "every entry is kept: {read:?}");
+    assert_eq!(read[4].0, "C3C");
+
+    let encoded = obs.to_rinex_string();
+    assert_eq!(
+        encoded
+            .lines()
+            .filter(|line| line.contains("GLONASS COD/PHS/BIS"))
+            .count(),
+        2,
+        "the record is written across two lines rather than truncated"
+    );
+    let reparsed = RinexObs::parse(&encoded).expect("re-encoded RINEX OBS must reparse");
+    assert_eq!(reparsed, obs);
+}
+
+#[test]
 fn rejects_malformed_glonass_slot_records() {
     for header in [
         header_line("  1 R01 bad", "GLONASS SLOT / FRQ #"),

--- a/crates/sidereon-core/src/rinex_obs/write.rs
+++ b/crates/sidereon-core/src/rinex_obs/write.rs
@@ -24,6 +24,9 @@ use super::{ObsEpoch, ObsEpochTime, ObsValue, RinexObs, OBS_FIELD_WIDTH, OBS_VAL
 
 /// Columns a header record's content occupies before its 20-column label.
 pub(super) const HEADER_CONTENT_WIDTH: usize = 60;
+/// `GLONASS COD/PHS/BIS` entries that fit the sixty-column body: each takes
+/// thirteen columns, `1X,A3,1X,F8.3`.
+pub(super) const GLONASS_BIAS_ENTRIES_PER_LINE: usize = 4;
 /// Width of the `SYS / PHASE SHIFT` correction field (`F8.5`).
 const PHASE_SHIFT_CORRECTION_WIDTH: usize = 8;
 /// RINEX-3 observation codes per `SYS / # / OBS TYPES` line before continuation.
@@ -370,11 +373,20 @@ fn write_glonass_slots(out: &mut String, slots: &std::collections::BTreeMap<u8, 
 }
 
 fn write_glonass_cod_phs_bis(out: &mut String, entries: &[(String, f64)]) {
-    let mut content = String::new();
-    for (code, value) in entries {
-        let _ = write!(content, " {code:>3} {value:8.3}");
+    if entries.is_empty() {
+        push_header_line(out, "", "GLONASS COD/PHS/BIS");
+        return;
     }
-    push_header_line(out, content.trim_start(), "GLONASS COD/PHS/BIS");
+    // Each entry takes thirteen of the sixty columns, so a fifth one would be
+    // cut off the end of the line and lost. The record continues on another line
+    // instead, which is how the reader takes it back.
+    for chunk in entries.chunks(GLONASS_BIAS_ENTRIES_PER_LINE) {
+        let mut content = String::new();
+        for (code, value) in chunk {
+            let _ = write!(content, " {code:>3} {value:8.3}");
+        }
+        push_header_line(out, content.trim_start(), "GLONASS COD/PHS/BIS");
+    }
 }
 
 fn write_leap_seconds(out: &mut String, leap: super::ObsLeapSeconds) {

--- a/fuzz/fuzz_targets/rinex_obs_round_trip.rs
+++ b/fuzz/fuzz_targets/rinex_obs_round_trip.rs
@@ -17,6 +17,13 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let encoded = original.to_rinex_string();
-    let reparsed = RinexObs::parse(&encoded).expect("encoded RINEX OBS must reparse");
+    let mut reparsed = RinexObs::parse(&encoded).expect("encoded RINEX OBS must reparse");
+    // The labels of header records that were read and not retained describe the
+    // source text rather than the product, and the writer does not re-emit them,
+    // so a clean re-parse reports none. Normalise that one diagnostic rather
+    // than skipping the whole product, which would stop checking its records.
+    let mut original = original;
+    original.header.unretained_header_labels.clear();
+    reparsed.header.unretained_header_labels.clear();
     assert_eq!(reparsed, original);
 });


### PR DESCRIPTION
Three PRs have now fixed the same defect one record at a time: the parser split a fixed-column line on whitespace, so a field filling its width touched the field beside it and the line could not be read. This reads those records from their columns, removing the class rather than another instance.

## The mechanism

`fixed_record` reads a line's fields from their columns and reports the line as *not* in that layout when any content strays into the gaps the format reserves between them. That test is what lets a column reader stand in front of the looser one without changing how a loosely formatted file is read: everything the layout does not describe keeps the reading it has always had.

It also subsumes the counterexamples that took four review rounds to get right on #41. `0000 1` and `0100 0` both put content in the reserved columns, so they are not in the layout and keep their old readings — no special case required. The two repairs applied to the epoch line and the vector headers are deleted, and both records are simpler for it.

## Converted

Both epoch readers, the `APPROX POSITION XYZ` and `ANTENNA: DELTA H/E/N` components, and the `TIME OF FIRST OBS` / `TIME OF LAST OBS` fields.

The RINEX 2 epoch line had the same merge as the RINEX 3 one and **no repair at all**, so a version 2 file of a hundred satellites did not parse either. #41 only fixed the version 3 path.

## Two records that could not read back what we write

- A RINEX 2 product is re-emitted through the version 3 record writer, so its own file declared version 2 while carrying `>` epoch records, which the version 2 reader could not read. The body now follows the records themselves; a version 2 epoch line begins with its two-digit year, never with `>`.
- A `GLONASS COD/PHS/BIS` record with more entries than one line holds was cut off at the sixtieth column, silently losing the fifth. It is continued on another line, and the reader adds each line's entries rather than replacing what came before.

## Fuzz target

The round-trip target now also passes over products carrying an unretained header label. Like a skipped record, which it already passes over, that field records what the source text held rather than what the product is, so a clean re-parse reports neither.

## Verification

- Every committed observation fixture was round-tripped against a build of `main`: the six that do not reach product equality do not reach it on `main` either, and the version 2 fixture goes from failing to reparse at all to reading back.
- New tests: the column reader's layout tests; a version 2 product reading back its own output; a GLONASS record of five entries surviving a round trip. The latter two fail on the parent.
- Gates: fmt, clippy, rustdoc, 3,086 workspace tests, 2,897 mmap tests, vocabulary and whitespace scans.